### PR TITLE
feat: add Neo4j health metrics for monitoring

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,31 +1,37 @@
-import 'dotenv/config'
-import http from 'http'
-import express from 'express'
-import { ApolloServer } from '@apollo/server'
-import { expressMiddleware } from '@apollo/server/express4'
-import { makeExecutableSchema } from '@graphql-tools/schema'
-import { useServer } from 'graphql-ws/lib/use/ws'
-import { WebSocketServer } from 'ws'
-import cors from 'cors'
-import helmet from 'helmet'
-import pino from 'pino'
-import { pinoHttp } from 'pino-http'
-import { typeDefs } from './graphql/schema.js'
-import resolvers from './graphql/resolvers/index.js'
-import { getContext } from './lib/auth.js'
-import { getNeo4jDriver } from './db/neo4j.js';
+import "dotenv/config";
+import http from "http";
+import express from "express";
+import { ApolloServer } from "@apollo/server";
+import { expressMiddleware } from "@apollo/server/express4";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { useServer } from "graphql-ws/lib/use/ws";
+import { WebSocketServer } from "ws";
+import cors from "cors";
+import helmet from "helmet";
+import pino from "pino";
+import { pinoHttp } from "pino-http";
+import { typeDefs } from "./graphql/schema.js";
+import resolvers from "./graphql/resolvers/index.js";
+import { getContext } from "./lib/auth.js";
+import { getNeo4jDriver } from "./db/neo4j.js";
+import "./monitoring/neo4jMetrics.js";
 
-const app = express()
-const logger = pino()
-app.use(helmet())
-app.use(cors({ origin: process.env.CORS_ORIGIN?.split(',') ?? ['http://localhost:3000'], credentials: true }))
-app.use(pinoHttp({ logger, redact: ['req.headers.authorization'] }))
+const app = express();
+const logger = pino();
+app.use(helmet());
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN?.split(",") ?? ["http://localhost:3000"],
+    credentials: true,
+  }),
+);
+app.use(pinoHttp({ logger, redact: ["req.headers.authorization"] }));
 
-app.get('/search/evidence', async (req, res) => {
+app.get("/search/evidence", async (req, res) => {
   const { q, skip = 0, limit = 10 } = req.query;
 
   if (!q) {
-    return res.status(400).send({ error: 'Query parameter \'q\' is required' });
+    return res.status(400).send({ error: "Query parameter 'q' is required" });
   }
 
   const driver = getNeo4jDriver();
@@ -45,16 +51,20 @@ app.get('/search/evidence', async (req, res) => {
     `;
 
     const [searchResult, countResult] = await Promise.all([
-      session.run(searchQuery, { query: q, skip: Number(skip), limit: Number(limit) }),
-      session.run(countQuery, { query: q })
+      session.run(searchQuery, {
+        query: q,
+        skip: Number(skip),
+        limit: Number(limit),
+      }),
+      session.run(countQuery, { query: q }),
     ]);
 
-    const evidence = searchResult.records.map(record => ({
-      node: record.get('node').properties,
-      score: record.get('score')
+    const evidence = searchResult.records.map((record) => ({
+      node: record.get("node").properties,
+      score: record.get("score"),
     }));
 
-    const total = countResult.records[0].get('total').toNumber();
+    const total = countResult.records[0].get("total").toNumber();
 
     res.send({
       data: evidence,
@@ -63,49 +73,56 @@ app.get('/search/evidence', async (req, res) => {
         skip: Number(skip),
         limit: Number(limit),
         pages: Math.ceil(total / Number(limit)),
-        currentPage: Math.floor(Number(skip) / Number(limit)) + 1
-      }
+        currentPage: Math.floor(Number(skip) / Number(limit)) + 1,
+      },
     });
   } catch (error) {
     logger.error(error);
-    res.status(500).send({ error: 'Internal server error' });
+    res.status(500).send({ error: "Internal server error" });
   } finally {
     await session.close();
   }
 });
 
-const schema = makeExecutableSchema({ typeDefs, resolvers })
-const httpServer = http.createServer(app)
+const schema = makeExecutableSchema({ typeDefs, resolvers });
+const httpServer = http.createServer(app);
 
 // GraphQL over HTTP
-import { persistedQueriesPlugin } from './graphql/plugins/persistedQueries.js';
+import { persistedQueriesPlugin } from "./graphql/plugins/persistedQueries.js";
 
 const apollo = new ApolloServer({
   schema,
   plugins: [persistedQueriesPlugin],
-})
-await apollo.start()
-app.use('/graphql', express.json(), expressMiddleware(apollo, { context: getContext }))
+});
+await apollo.start();
+app.use(
+  "/graphql",
+  express.json(),
+  expressMiddleware(apollo, { context: getContext }),
+);
 
 // Subscriptions
-const wss = new WebSocketServer({ server: httpServer as import('http').Server, path: '/graphql' })
-useServer({ schema, context: getContext }, wss)
+const wss = new WebSocketServer({
+  server: httpServer as import("http").Server,
+  path: "/graphql",
+});
+useServer({ schema, context: getContext }, wss);
 
-import { initSocket, getIO } from './realtime/socket.js'; // New import
+import { initSocket, getIO } from "./realtime/socket.js"; // New import
 
-const port = Number(process.env.PORT || 4000)
-httpServer.listen(port, () => logger.info({ port }, 'server listening'))
+const port = Number(process.env.PORT || 4000);
+httpServer.listen(port, () => logger.info({ port }, "server listening"));
 
 // Initialize Socket.IO
 const io = initSocket(httpServer);
 
-import { closeNeo4jDriver } from './db/neo4j.js';
-import { closePostgresPool } from './db/postgres.js';
-import { closeRedisClient } from './db/redis.js';
+import { closeNeo4jDriver } from "./db/neo4j.js";
+import { closePostgresPool } from "./db/postgres.js";
+import { closeRedisClient } from "./db/redis.js";
 
 // Graceful shutdown
 const shutdown = async (sig: NodeJS.Signals) => {
-  logger.info({ sig }, 'shutting down');
+  logger.info({ sig }, "shutting down");
   wss.close();
   io.close(); // Close Socket.IO server
   await Promise.allSettled([
@@ -113,10 +130,13 @@ const shutdown = async (sig: NodeJS.Signals) => {
     closePostgresPool(),
     closeRedisClient(),
   ]);
-  httpServer.close(err => {
-    if (err) { logger.error(err); process.exitCode = 1 }
+  httpServer.close((err) => {
+    if (err) {
+      logger.error(err);
+      process.exitCode = 1;
+    }
     process.exit();
   });
 };
-process.on('SIGINT', shutdown)
-process.on('SIGTERM', shutdown)
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/server/src/monitoring/health.js
+++ b/server/src/monitoring/health.js
@@ -1,12 +1,13 @@
 /**
  * Health check endpoints and monitoring
  */
-const os = require('os');
-const { performance } = require('perf_hooks');
+const os = require("os");
+const { performance } = require("perf_hooks");
+const { metrics } = require("./metrics");
 
 // Health check status cache
 let healthStatus = {
-  status: 'unknown',
+  status: "unknown",
   timestamp: new Date().toISOString(),
   checks: {},
 };
@@ -17,29 +18,29 @@ let healthStatus = {
 async function checkDatabase() {
   try {
     // Check PostgreSQL connection
-    const { Pool } = require('pg');
+    const { Pool } = require("pg");
     const pool = new Pool({
       connectionString: process.env.DATABASE_URL,
       max: 1,
       connectionTimeoutMillis: 5000,
     });
-    
+
     const start = performance.now();
-    const result = await pool.query('SELECT 1 as healthy');
+    const result = await pool.query("SELECT 1 as healthy");
     const responseTime = performance.now() - start;
-    
+
     await pool.end();
-    
+
     return {
-      status: 'healthy',
+      status: "healthy",
       responseTime: Math.round(responseTime),
-      details: 'PostgreSQL connection successful',
+      details: "PostgreSQL connection successful",
     };
   } catch (error) {
     return {
-      status: 'unhealthy',
+      status: "unhealthy",
       error: error.message,
-      details: 'PostgreSQL connection failed',
+      details: "PostgreSQL connection failed",
     };
   }
 }
@@ -48,36 +49,48 @@ async function checkDatabase() {
  * Check Neo4j connectivity
  */
 async function checkNeo4j() {
+  const neo4j = require("neo4j-driver");
+  let driver;
+  let session;
+  const start = performance.now();
   try {
-    const neo4j = require('neo4j-driver');
-    const driver = neo4j.driver(
-      process.env.NEO4J_URI || 'bolt://localhost:7687',
+    driver = neo4j.driver(
+      process.env.NEO4J_URI || "bolt://localhost:7687",
       neo4j.auth.basic(
-        process.env.NEO4J_USER || 'neo4j',
-        process.env.NEO4J_PASSWORD || 'password'
+        process.env.NEO4J_USER || "neo4j",
+        process.env.NEO4J_PASSWORD || "password",
       ),
-      { connectionTimeout: 5000 }
+      { connectionTimeout: 5000 },
     );
-    
-    const session = driver.session();
-    const start = performance.now();
-    
-    await session.run('RETURN 1 as healthy');
+
+    session = driver.session();
+    await session.run("RETURN 1 as healthy");
     const responseTime = performance.now() - start;
-    
+    metrics.dbQueryDuration
+      .labels("neo4j", "health")
+      .observe(responseTime / 1000);
+    metrics.dbQueriesTotal.labels("neo4j", "health", "success").inc();
+
     await session.close();
     await driver.close();
-    
+
     return {
-      status: 'healthy',
+      status: "healthy",
       responseTime: Math.round(responseTime),
-      details: 'Neo4j connection successful',
+      details: "Neo4j connection successful",
     };
   } catch (error) {
+    const responseTime = performance.now() - start;
+    metrics.dbQueryDuration
+      .labels("neo4j", "health")
+      .observe(responseTime / 1000);
+    metrics.dbQueriesTotal.labels("neo4j", "health", "error").inc();
+    if (session) await session.close();
+    if (driver) await driver.close();
     return {
-      status: 'unhealthy',
+      status: "unhealthy",
       error: error.message,
-      details: 'Neo4j connection failed',
+      details: "Neo4j connection failed",
     };
   }
 }
@@ -87,30 +100,30 @@ async function checkNeo4j() {
  */
 async function checkRedis() {
   try {
-    const Redis = require('ioredis');
+    const Redis = require("ioredis");
     const redis = new Redis({
-      host: process.env.REDIS_HOST || 'localhost',
+      host: process.env.REDIS_HOST || "localhost",
       port: process.env.REDIS_PORT || 6379,
       connectTimeout: 5000,
       lazyConnect: true,
     });
-    
+
     const start = performance.now();
     await redis.ping();
     const responseTime = performance.now() - start;
-    
+
     redis.disconnect();
-    
+
     return {
-      status: 'healthy',
+      status: "healthy",
       responseTime: Math.round(responseTime),
-      details: 'Redis connection successful',
+      details: "Redis connection successful",
     };
   } catch (error) {
     return {
-      status: 'unhealthy',
+      status: "unhealthy",
       error: error.message,
-      details: 'Redis connection failed',
+      details: "Redis connection failed",
     };
   }
 }
@@ -120,35 +133,35 @@ async function checkRedis() {
  */
 async function checkMlService() {
   try {
-    const fetch = require('node-fetch');
-    const mlServiceUrl = process.env.ML_SERVICE_URL || 'http://localhost:8001';
-    
+    const fetch = require("node-fetch");
+    const mlServiceUrl = process.env.ML_SERVICE_URL || "http://localhost:8001";
+
     const start = performance.now();
     const response = await fetch(`${mlServiceUrl}/health`, {
       timeout: 5000,
     });
     const responseTime = performance.now() - start;
-    
+
     if (response.ok) {
       const data = await response.json();
       return {
-        status: 'healthy',
+        status: "healthy",
         responseTime: Math.round(responseTime),
-        details: 'ML service reachable',
+        details: "ML service reachable",
         mlServiceStatus: data.status,
       };
     } else {
       return {
-        status: 'unhealthy',
+        status: "unhealthy",
         responseTime: Math.round(responseTime),
         details: `ML service returned ${response.status}`,
       };
     }
   } catch (error) {
     return {
-      status: 'unhealthy',
+      status: "unhealthy",
       error: error.message,
-      details: 'ML service unreachable',
+      details: "ML service unreachable",
     };
   }
 }
@@ -161,12 +174,12 @@ function checkSystemResources() {
   const totalMemory = os.totalmem();
   const freeMemory = os.freemem();
   const memoryUsagePercent = ((totalMemory - freeMemory) / totalMemory) * 100;
-  
+
   const cpuUsage = process.cpuUsage();
   const loadAverage = os.loadavg();
-  
-  const status = memoryUsagePercent > 90 ? 'unhealthy' : 'healthy';
-  
+
+  const status = memoryUsagePercent > 90 ? "unhealthy" : "healthy";
+
   return {
     status,
     memory: {
@@ -179,10 +192,13 @@ function checkSystemResources() {
     cpu: {
       user: cpuUsage.user,
       system: cpuUsage.system,
-      loadAverage: loadAverage.map(load => Math.round(load * 100) / 100),
+      loadAverage: loadAverage.map((load) => Math.round(load * 100) / 100),
     },
     uptime: Math.round(process.uptime()),
-    details: status === 'healthy' ? 'System resources within limits' : 'High memory usage detected',
+    details:
+      status === "healthy"
+        ? "System resources within limits"
+        : "High memory usage detected",
   };
 }
 
@@ -191,47 +207,65 @@ function checkSystemResources() {
  */
 async function performHealthCheck() {
   const startTime = performance.now();
-  
+
   try {
-    const [database, neo4j, redis, mlService, systemResources] = await Promise.allSettled([
-      checkDatabase(),
-      checkNeo4j(),
-      checkRedis(),
-      checkMlService(),
-      Promise.resolve(checkSystemResources()),
-    ]);
-    
+    const [database, neo4j, redis, mlService, systemResources] =
+      await Promise.allSettled([
+        checkDatabase(),
+        checkNeo4j(),
+        checkRedis(),
+        checkMlService(),
+        Promise.resolve(checkSystemResources()),
+      ]);
+
     const checks = {
-      database: database.status === 'fulfilled' ? database.value : { status: 'unhealthy', error: database.reason?.message },
-      neo4j: neo4j.status === 'fulfilled' ? neo4j.value : { status: 'unhealthy', error: neo4j.reason?.message },
-      redis: redis.status === 'fulfilled' ? redis.value : { status: 'unhealthy', error: redis.reason?.message },
-      mlService: mlService.status === 'fulfilled' ? mlService.value : { status: 'unhealthy', error: mlService.reason?.message },
-      systemResources: systemResources.status === 'fulfilled' ? systemResources.value : { status: 'unhealthy', error: systemResources.reason?.message },
+      database:
+        database.status === "fulfilled"
+          ? database.value
+          : { status: "unhealthy", error: database.reason?.message },
+      neo4j:
+        neo4j.status === "fulfilled"
+          ? neo4j.value
+          : { status: "unhealthy", error: neo4j.reason?.message },
+      redis:
+        redis.status === "fulfilled"
+          ? redis.value
+          : { status: "unhealthy", error: redis.reason?.message },
+      mlService:
+        mlService.status === "fulfilled"
+          ? mlService.value
+          : { status: "unhealthy", error: mlService.reason?.message },
+      systemResources:
+        systemResources.status === "fulfilled"
+          ? systemResources.value
+          : { status: "unhealthy", error: systemResources.reason?.message },
     };
-    
-    const allHealthy = Object.values(checks).every(check => check.status === 'healthy');
-    const overallStatus = allHealthy ? 'healthy' : 'unhealthy';
-    
+
+    const allHealthy = Object.values(checks).every(
+      (check) => check.status === "healthy",
+    );
+    const overallStatus = allHealthy ? "healthy" : "unhealthy";
+
     const totalTime = Math.round(performance.now() - startTime);
-    
+
     healthStatus = {
       status: overallStatus,
       timestamp: new Date().toISOString(),
       responseTime: totalTime,
-      version: process.env.npm_package_version || '1.0.0',
-      environment: process.env.NODE_ENV || 'development',
+      version: process.env.npm_package_version || "1.0.0",
+      environment: process.env.NODE_ENV || "development",
       checks,
     };
-    
+
     return healthStatus;
   } catch (error) {
     healthStatus = {
-      status: 'unhealthy',
+      status: "unhealthy",
       timestamp: new Date().toISOString(),
       error: error.message,
       checks: {},
     };
-    
+
     return healthStatus;
   }
 }
@@ -248,7 +282,7 @@ function getCachedHealthStatus() {
  */
 async function livenessProbe() {
   return {
-    status: 'alive',
+    status: "alive",
     timestamp: new Date().toISOString(),
     uptime: Math.round(process.uptime()),
     pid: process.pid,
@@ -263,11 +297,12 @@ async function readinessProbe() {
     // Quick checks for critical dependencies
     const dbCheck = await checkDatabase();
     const redisCheck = await checkRedis();
-    
-    const ready = dbCheck.status === 'healthy' && redisCheck.status === 'healthy';
-    
+
+    const ready =
+      dbCheck.status === "healthy" && redisCheck.status === "healthy";
+
     return {
-      status: ready ? 'ready' : 'not_ready',
+      status: ready ? "ready" : "not_ready",
       timestamp: new Date().toISOString(),
       checks: {
         database: dbCheck.status,
@@ -276,7 +311,7 @@ async function readinessProbe() {
     };
   } catch (error) {
     return {
-      status: 'not_ready',
+      status: "not_ready",
       timestamp: new Date().toISOString(),
       error: error.message,
     };
@@ -288,12 +323,12 @@ const healthCheckInterval = setInterval(async () => {
   try {
     await performHealthCheck();
   } catch (error) {
-    console.error('Health check error:', error);
+    console.error("Health check error:", error);
   }
 }, 30000);
 
 // Cleanup interval on process exit
-process.on('SIGTERM', () => {
+process.on("SIGTERM", () => {
   clearInterval(healthCheckInterval);
 });
 

--- a/server/src/monitoring/metrics.js
+++ b/server/src/monitoring/metrics.js
@@ -1,7 +1,7 @@
 /**
  * Prometheus metrics collection for IntelGraph Platform
  */
-const client = require('prom-client');
+const client = require("prom-client");
 
 // Create a Registry which registers the metrics
 const register = new client.Registry();
@@ -17,167 +17,174 @@ client.collectDefaultMetrics({
 
 // HTTP Request metrics
 const httpRequestDuration = new client.Histogram({
-  name: 'http_request_duration_seconds',
-  help: 'Duration of HTTP requests in seconds',
-  labelNames: ['method', 'route', 'status_code'],
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status_code"],
   buckets: [0.1, 0.5, 1, 2, 5, 10],
 });
 
 const httpRequestsTotal = new client.Counter({
-  name: 'http_requests_total',
-  help: 'Total number of HTTP requests',
-  labelNames: ['method', 'route', 'status_code'],
+  name: "http_requests_total",
+  help: "Total number of HTTP requests",
+  labelNames: ["method", "route", "status_code"],
 });
 
 // GraphQL metrics
 const graphqlRequestDuration = new client.Histogram({
-  name: 'graphql_request_duration_seconds',
-  help: 'Duration of GraphQL requests in seconds',
-  labelNames: ['operation', 'operation_type'],
+  name: "graphql_request_duration_seconds",
+  help: "Duration of GraphQL requests in seconds",
+  labelNames: ["operation", "operation_type"],
   buckets: [0.1, 0.5, 1, 2, 5, 10],
 });
 
 const graphqlRequestsTotal = new client.Counter({
-  name: 'graphql_requests_total',
-  help: 'Total number of GraphQL requests',
-  labelNames: ['operation', 'operation_type', 'status'],
+  name: "graphql_requests_total",
+  help: "Total number of GraphQL requests",
+  labelNames: ["operation", "operation_type", "status"],
 });
 
 const graphqlErrors = new client.Counter({
-  name: 'graphql_errors_total',
-  help: 'Total number of GraphQL errors',
-  labelNames: ['operation', 'error_type'],
+  name: "graphql_errors_total",
+  help: "Total number of GraphQL errors",
+  labelNames: ["operation", "error_type"],
 });
 
 // Database metrics
 const dbConnectionsActive = new client.Gauge({
-  name: 'db_connections_active',
-  help: 'Number of active database connections',
-  labelNames: ['database'],
+  name: "db_connections_active",
+  help: "Number of active database connections",
+  labelNames: ["database"],
 });
 
 const dbQueryDuration = new client.Histogram({
-  name: 'db_query_duration_seconds',
-  help: 'Duration of database queries in seconds',
-  labelNames: ['database', 'operation'],
+  name: "db_query_duration_seconds",
+  help: "Duration of database queries in seconds",
+  labelNames: ["database", "operation"],
   buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5],
 });
 
 const dbQueriesTotal = new client.Counter({
-  name: 'db_queries_total',
-  help: 'Total number of database queries',
-  labelNames: ['database', 'operation', 'status'],
+  name: "db_queries_total",
+  help: "Total number of database queries",
+  labelNames: ["database", "operation", "status"],
 });
 
 // AI/ML Processing metrics
 const aiJobsQueued = new client.Gauge({
-  name: 'ai_jobs_queued',
-  help: 'Number of AI/ML jobs in queue',
-  labelNames: ['job_type'],
+  name: "ai_jobs_queued",
+  help: "Number of AI/ML jobs in queue",
+  labelNames: ["job_type"],
 });
 
 const aiJobsProcessing = new client.Gauge({
-  name: 'ai_jobs_processing',
-  help: 'Number of AI/ML jobs currently processing',
-  labelNames: ['job_type'],
+  name: "ai_jobs_processing",
+  help: "Number of AI/ML jobs currently processing",
+  labelNames: ["job_type"],
 });
 
 const aiJobDuration = new client.Histogram({
-  name: 'ai_job_duration_seconds',
-  help: 'Duration of AI/ML job processing in seconds',
-  labelNames: ['job_type', 'status'],
+  name: "ai_job_duration_seconds",
+  help: "Duration of AI/ML job processing in seconds",
+  labelNames: ["job_type", "status"],
   buckets: [1, 5, 10, 30, 60, 300, 600],
 });
 
 const aiJobsTotal = new client.Counter({
-  name: 'ai_jobs_total',
-  help: 'Total number of AI/ML jobs processed',
-  labelNames: ['job_type', 'status'],
+  name: "ai_jobs_total",
+  help: "Total number of AI/ML jobs processed",
+  labelNames: ["job_type", "status"],
 });
 
 // Graph operations metrics
 const graphNodesTotal = new client.Gauge({
-  name: 'graph_nodes_total',
-  help: 'Total number of nodes in the graph',
-  labelNames: ['investigation_id'],
+  name: "graph_nodes_total",
+  help: "Total number of nodes in the graph",
+  labelNames: ["investigation_id"],
 });
 
 const graphEdgesTotal = new client.Gauge({
-  name: 'graph_edges_total',
-  help: 'Total number of edges in the graph',
-  labelNames: ['investigation_id'],
+  name: "graph_edges_total",
+  help: "Total number of edges in the graph",
+  labelNames: ["investigation_id"],
 });
 
 const graphOperationDuration = new client.Histogram({
-  name: 'graph_operation_duration_seconds',
-  help: 'Duration of graph operations in seconds',
-  labelNames: ['operation', 'investigation_id'],
+  name: "graph_operation_duration_seconds",
+  help: "Duration of graph operations in seconds",
+  labelNames: ["operation", "investigation_id"],
   buckets: [0.1, 0.5, 1, 2, 5, 10],
 });
 
 // WebSocket metrics
 const websocketConnections = new client.Gauge({
-  name: 'websocket_connections_active',
-  help: 'Number of active WebSocket connections',
+  name: "websocket_connections_active",
+  help: "Number of active WebSocket connections",
 });
 
 const websocketMessages = new client.Counter({
-  name: 'websocket_messages_total',
-  help: 'Total number of WebSocket messages',
-  labelNames: ['direction', 'event_type'],
+  name: "websocket_messages_total",
+  help: "Total number of WebSocket messages",
+  labelNames: ["direction", "event_type"],
 });
 
 // Investigation metrics
 const investigationsActive = new client.Gauge({
-  name: 'investigations_active',
-  help: 'Number of active investigations',
+  name: "investigations_active",
+  help: "Number of active investigations",
 });
 
 const investigationOperations = new client.Counter({
-  name: 'investigation_operations_total',
-  help: 'Total number of investigation operations',
-  labelNames: ['operation', 'user_id'],
+  name: "investigation_operations_total",
+  help: "Total number of investigation operations",
+  labelNames: ["operation", "user_id"],
 });
 
 // Error tracking
 const applicationErrors = new client.Counter({
-  name: 'application_errors_total',
-  help: 'Total number of application errors',
-  labelNames: ['module', 'error_type', 'severity'],
+  name: "application_errors_total",
+  help: "Total number of application errors",
+  labelNames: ["module", "error_type", "severity"],
 });
 
 // Memory usage for specific components
 const memoryUsage = new client.Gauge({
-  name: 'application_memory_usage_bytes',
-  help: 'Memory usage by application component',
-  labelNames: ['component'],
+  name: "application_memory_usage_bytes",
+  help: "Memory usage by application component",
+  labelNames: ["component"],
+});
+
+// Neo4j memory metrics
+const neo4jMemoryUsage = new client.Gauge({
+  name: "neo4j_memory_usage_bytes",
+  help: "Memory usage reported by Neo4j",
+  labelNames: ["type"],
 });
 
 // Pipeline SLI metrics (labels: source, pipeline, env)
 const pipelineUptimeRatio = new client.Gauge({
-  name: 'pipeline_uptime_ratio',
-  help: 'Pipeline availability ratio (0..1) over current window',
-  labelNames: ['source', 'pipeline', 'env'],
+  name: "pipeline_uptime_ratio",
+  help: "Pipeline availability ratio (0..1) over current window",
+  labelNames: ["source", "pipeline", "env"],
 });
 const pipelineFreshnessSeconds = new client.Gauge({
-  name: 'pipeline_freshness_seconds',
-  help: 'Freshness (seconds) from source event to load completion',
-  labelNames: ['source', 'pipeline', 'env'],
+  name: "pipeline_freshness_seconds",
+  help: "Freshness (seconds) from source event to load completion",
+  labelNames: ["source", "pipeline", "env"],
 });
 const pipelineCompletenessRatio = new client.Gauge({
-  name: 'pipeline_completeness_ratio',
-  help: 'Data completeness ratio (0..1) expected vs actual',
-  labelNames: ['source', 'pipeline', 'env'],
+  name: "pipeline_completeness_ratio",
+  help: "Data completeness ratio (0..1) expected vs actual",
+  labelNames: ["source", "pipeline", "env"],
 });
 const pipelineCorrectnessRatio = new client.Gauge({
-  name: 'pipeline_correctness_ratio',
-  help: 'Validation pass rate ratio (0..1)',
-  labelNames: ['source', 'pipeline', 'env'],
+  name: "pipeline_correctness_ratio",
+  help: "Validation pass rate ratio (0..1)",
+  labelNames: ["source", "pipeline", "env"],
 });
 const pipelineLatencySeconds = new client.Histogram({
-  name: 'pipeline_latency_seconds',
-  help: 'End-to-end processing latency seconds',
-  labelNames: ['source', 'pipeline', 'env'],
+  name: "pipeline_latency_seconds",
+  help: "End-to-end processing latency seconds",
+  labelNames: ["source", "pipeline", "env"],
   buckets: [5, 15, 30, 60, 120, 300, 600, 1200],
 });
 
@@ -203,6 +210,7 @@ register.registerMetric(investigationsActive);
 register.registerMetric(investigationOperations);
 register.registerMetric(applicationErrors);
 register.registerMetric(memoryUsage);
+register.registerMetric(neo4jMemoryUsage);
 register.registerMetric(pipelineUptimeRatio);
 register.registerMetric(pipelineFreshnessSeconds);
 register.registerMetric(pipelineCompletenessRatio);
@@ -210,19 +218,19 @@ register.registerMetric(pipelineCorrectnessRatio);
 register.registerMetric(pipelineLatencySeconds);
 // New domain metrics
 const graphExpandRequestsTotal = new client.Counter({
-  name: 'graph_expand_requests_total',
-  help: 'Total expandNeighbors requests',
-  labelNames: ['cached'],
+  name: "graph_expand_requests_total",
+  help: "Total expandNeighbors requests",
+  labelNames: ["cached"],
 });
 const aiRequestTotal = new client.Counter({
-  name: 'ai_request_total',
-  help: 'AI request events',
-  labelNames: ['status'],
+  name: "ai_request_total",
+  help: "AI request events",
+  labelNames: ["status"],
 });
 const resolverLatencyMs = new client.Histogram({
-  name: 'resolver_latency_ms',
-  help: 'Resolver latency in ms',
-  labelNames: ['operation'],
+  name: "resolver_latency_ms",
+  help: "Resolver latency in ms",
+  labelNames: ["operation"],
   buckets: [5, 10, 25, 50, 100, 200, 400, 800, 1600],
 });
 register.registerMetric(graphExpandRequestsTotal);
@@ -232,10 +240,10 @@ register.registerMetric(resolverLatencyMs);
 // Update memory usage periodically
 setInterval(() => {
   const usage = process.memoryUsage();
-  memoryUsage.set({ component: 'heap_used' }, usage.heapUsed);
-  memoryUsage.set({ component: 'heap_total' }, usage.heapTotal);
-  memoryUsage.set({ component: 'external' }, usage.external);
-  memoryUsage.set({ component: 'rss' }, usage.rss);
+  memoryUsage.set({ component: "heap_used" }, usage.heapUsed);
+  memoryUsage.set({ component: "heap_total" }, usage.heapTotal);
+  memoryUsage.set({ component: "external" }, usage.external);
+  memoryUsage.set({ component: "rss" }, usage.rss);
 }, 30000); // Every 30 seconds
 
 module.exports = {
@@ -260,15 +268,16 @@ module.exports = {
     websocketMessages,
     investigationsActive,
     investigationOperations,
-  applicationErrors,
-  memoryUsage,
-  graphExpandRequestsTotal,
-  aiRequestTotal,
-  resolverLatencyMs,
-  pipelineUptimeRatio,
-  pipelineFreshnessSeconds,
-  pipelineCompletenessRatio,
-  pipelineCorrectnessRatio,
-  pipelineLatencySeconds,
-},
+    applicationErrors,
+    memoryUsage,
+    neo4jMemoryUsage,
+    graphExpandRequestsTotal,
+    aiRequestTotal,
+    resolverLatencyMs,
+    pipelineUptimeRatio,
+    pipelineFreshnessSeconds,
+    pipelineCompletenessRatio,
+    pipelineCorrectnessRatio,
+    pipelineLatencySeconds,
+  },
 };

--- a/server/src/monitoring/neo4jMetrics.js
+++ b/server/src/monitoring/neo4jMetrics.js
@@ -1,0 +1,44 @@
+const neo4j = require("neo4j-driver");
+const { metrics } = require("./metrics");
+
+async function collectNeo4jMetrics() {
+  let driver;
+  let session;
+  try {
+    driver = neo4j.driver(
+      process.env.NEO4J_URI || "bolt://localhost:7687",
+      neo4j.auth.basic(
+        process.env.NEO4J_USER || "neo4j",
+        process.env.NEO4J_PASSWORD || "password",
+      ),
+      { connectionTimeout: 5000 },
+    );
+    session = driver.session();
+    const result = await session.run(
+      "CALL dbms.queryJmx('java.lang:type=Memory') YIELD attributes RETURN attributes",
+    );
+    const attrs = result.records[0]?.get("attributes");
+    if (Array.isArray(attrs)) {
+      const heap = attrs.find((a) => a.key === "HeapMemoryUsage")?.value;
+      if (heap) {
+        const used = heap.used?.toNumber ? heap.used.toNumber() : heap.used;
+        const committed = heap.committed?.toNumber
+          ? heap.committed.toNumber()
+          : heap.committed;
+        metrics.neo4jMemoryUsage.labels("heap_used").set(used);
+        metrics.neo4jMemoryUsage.labels("heap_committed").set(committed);
+      }
+    }
+  } catch (err) {
+    // swallow errors to avoid crashing the process
+  } finally {
+    if (session) await session.close();
+    if (driver) await driver.close();
+  }
+}
+
+// initial run and periodic collection
+collectNeo4jMetrics();
+setInterval(collectNeo4jMetrics, 60000);
+
+module.exports = { collectNeo4jMetrics };


### PR DESCRIPTION
## Summary
- expose Neo4j memory consumption via Prometheus gauge
- record Neo4j health check latency and query totals
- periodically collect Neo4j JMX memory metrics

## Testing
- `npm run lint -- server/src/index.ts server/src/monitoring/health.js server/src/monitoring/metrics.js server/src/monitoring/neo4jMetrics.js` *(fails: You are linting "src", but all of the files matching the glob pattern "src" are ignored)*
- `npx prettier --write server/src/index.ts server/src/monitoring/health.js server/src/monitoring/metrics.js server/src/monitoring/neo4jMetrics.js`
- `npm test` *(fails: tests in visualization service and others)*

------
https://chatgpt.com/codex/tasks/task_e_689f70ddefb88333a51cd5ea8cc182aa