### PR TITLE
feat: log ML service failures in AI job resolver [backend-ai]

### DIFF
--- a/server/src/tests/ai.integration.test.ts
+++ b/server/src/tests/ai.integration.test.ts
@@ -323,8 +323,12 @@ describe("AI Integration", () => {
         )
       ).rejects.toThrow("ML service unavailable");
 
-      // Job should still be inserted even if ML service fails
+      // Job should still be inserted and marked failed if ML service fails
       expect(mockDb.jobs.insert).toHaveBeenCalled();
+      expect(mockDb.jobs.update).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ status: "FAILED", error: "ML service unavailable" })
+      );
     });
 
     it("should handle database errors", async () => {


### PR DESCRIPTION
## Summary
- add logger-based error handling for ML service calls
- mark AI jobs as FAILED when ML request errors occur
- test coverage for job failure path

## Testing
- `npm run lint:server` *(fails: files matching src ignored)*
- `npm run format` *(fails: YAML syntax errors in workflows)*
- `cd server && npx jest src/tests/ai.integration.test.ts --runInBand` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689f939c5a148333b44c4cd5815dda12