### PR TITLE
feat: add transformative feature placeholders

### DIFF
--- a/project_management/new_issues_import.csv
+++ b/project_management/new_issues_import.csv
@@ -486,4 +486,52 @@ Ship a customizable dashboard with AI insights and key metrics.
 - Widgets: entities, relationships, anomalies, model health
 - Drag-and-drop layout with save/load presets
 - Shareable dashboards with RBAC controls
-- GraphQL queries optimized; loading states covered","dashboard,frontend,enhancement"}
+- GraphQL queries optimized; loading states covered","dashboard,frontend,enhancement"
+"Quantum-Resistant Threat Modeling Engine","## Description
+Develop a modeling engine that continually re-hardens detection signatures using post-quantum cryptography and forecasts quantum-enabled attacks.
+
+## Acceptance Criteria
+- Post-quantum signature generation library
+- Scheduled signature re-hardening job
+- Validated integrity via PQC verification routines
+- Documentation and runbook","AI,enhancement,security"
+"Cross-Domain Adversary Simulation & Cognitive Twins","## Description
+Simulate evolving attacker personas (“cognitive twins”) that adapt tactics based on live telemetry to stress-test defenses.
+
+## Acceptance Criteria
+- Engine to generate and evolve attacker profiles
+- Telemetry ingestion hooks for behavior adaptation
+- Scenario API to launch simulations and capture outcomes
+- Metrics dashboard for twin performance","AI,enhancement,backend"
+"Adaptive Behavioral DNA Correlation Network","## Description
+Build a behavioral DNA profile for every entity and correlate across tenants to surface subtle supply-chain compromises.
+
+## Acceptance Criteria
+- Behavioral feature extractor for entities
+- Cross-tenant correlation service with privacy guards
+- Alerting rules for abnormal DNA matches
+- Unit tests covering correlation edge cases","AI,enhancement,backend,security"
+"Autonomous OT/ICS Digital-Twin Red Team","## Description
+Deploy a self-learning digital twin of OT/ICS environments that automatically stress-tests controls and predicts cascade failures.
+
+## Acceptance Criteria
+- OT/ICS environment model with feedback loop
+- Automated attack playbook execution
+- Risk report generation with mitigation suggestions
+- Integration tests against sample OT datasets","AI,enhancement,backend"
+"Mission-Critical Service Continuity Orchestrator","## Description
+Track dependencies between business services and threat vectors, dynamically reprioritizing detection rules to maintain continuity during attacks.
+
+## Acceptance Criteria
+- Service dependency graph with priority scores
+- Runtime rule tuner responding to active threats
+- Failover recommendation engine
+- Documentation with example scenarios","AI,enhancement,backend"
+"Deepfake & Cognitive Manipulation Sentinel","## Description
+Detect synthetic content and psychological manipulation in collaboration channels to protect executives and critical projects.
+
+## Acceptance Criteria
+- Media analysis pipeline for audio/video/text
+- Detection API exposing confidence scores
+- Alerting integration with existing notification system
+- Benchmark dataset and accuracy report","AI,enhancement,backend,security"

--- a/server/src/ai/behavioralDnaNetwork.ts
+++ b/server/src/ai/behavioralDnaNetwork.ts
@@ -1,0 +1,4 @@
+export function correlateBehavioralDna(): number {
+  // Placeholder for behavioral DNA correlation network.
+  return 0;
+}

--- a/server/src/ai/cognitiveTwins.ts
+++ b/server/src/ai/cognitiveTwins.ts
@@ -1,0 +1,8 @@
+export interface CognitiveTwin {
+  id: string;
+}
+
+export function simulateCognitiveTwins(): CognitiveTwin[] {
+  // Placeholder for cross-domain adversary simulation.
+  return [];
+}

--- a/server/src/ai/deepfakeSentinel.ts
+++ b/server/src/ai/deepfakeSentinel.ts
@@ -1,0 +1,9 @@
+export interface DeepfakeAnalysisResult {
+  isDeepfake: boolean;
+  confidence: number;
+}
+
+export function analyzeContent(content: string): DeepfakeAnalysisResult {
+  // Placeholder for deepfake detection algorithm.
+  return { isDeepfake: false, confidence: 0 };
+}

--- a/server/src/ai/otDigitalTwinRedTeam.ts
+++ b/server/src/ai/otDigitalTwinRedTeam.ts
@@ -1,0 +1,4 @@
+export function runOtRedTeam(): boolean {
+  // Placeholder for autonomous OT/ICS digital-twin red teaming.
+  return false;
+}

--- a/server/src/ai/quantumModelEngine.ts
+++ b/server/src/ai/quantumModelEngine.ts
@@ -1,0 +1,4 @@
+export function modelQuantumThreats(): string {
+  // Placeholder for future quantum-resistant threat modeling logic.
+  return "quantum-threat-modeling-unimplemented";
+}

--- a/server/src/ai/serviceContinuityOrchestrator.ts
+++ b/server/src/ai/serviceContinuityOrchestrator.ts
@@ -1,0 +1,3 @@
+export function orchestrateContinuity(): void {
+  // Placeholder for mission-critical service continuity orchestrator.
+}

--- a/server/src/tests/featurePlaceholders.test.ts
+++ b/server/src/tests/featurePlaceholders.test.ts
@@ -1,0 +1,17 @@
+import { modelQuantumThreats } from "../ai/quantumModelEngine";
+import { simulateCognitiveTwins } from "../ai/cognitiveTwins";
+import { correlateBehavioralDna } from "../ai/behavioralDnaNetwork";
+import { runOtRedTeam } from "../ai/otDigitalTwinRedTeam";
+import { orchestrateContinuity } from "../ai/serviceContinuityOrchestrator";
+import { analyzeContent } from "../ai/deepfakeSentinel";
+
+describe("feature placeholders", () => {
+  it("returns placeholder outputs", () => {
+    expect(modelQuantumThreats()).toBe("quantum-threat-modeling-unimplemented");
+    expect(simulateCognitiveTwins()).toEqual([]);
+    expect(correlateBehavioralDna()).toBe(0);
+    expect(runOtRedTeam()).toBe(false);
+    expect(orchestrateContinuity()).toBeUndefined();
+    expect(analyzeContent("sample").isDeepfake).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- track six disruptive feature ideas in issue import CSV
- scaffold placeholder modules for quantum modeling, cognitive twins, behavioral DNA, OT digital twins, continuity orchestration, and deepfake sentinel
- add test harness exercising the new placeholders

## Testing
- `npm run lint` *(fails: config requires migration)*
- `npm run format` *(fails: YAML syntax errors in workflows)*
- `npm test` *(fails: missing modules like uuid)*

------
https://chatgpt.com/codex/tasks/task_e_689fa59141e88333b2b26fddfb2c01ef