### PR TITLE
ci: verify full stack deployment builds and starts

### DIFF
--- a/.github/workflows/smoke-compose.yml
+++ b/.github/workflows/smoke-compose.yml
@@ -1,4 +1,4 @@
-name: Server Smoke (Compose)
+name: Full Deployment Smoke (Compose)
 
 on:
   workflow_dispatch:
@@ -14,24 +14,24 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Compose
         run: docker version && docker compose version || true
-      - name: Launch services (server + deps)
+      - name: Launch services (full stack)
         run: |
           docker compose -f docker-compose.yml up -d --build postgres neo4j redis
           # warm up DBs
           sleep 10
-          docker compose -f docker-compose.yml up -d --build server
+          docker compose -f docker-compose.yml up -d --build server client
       - name: Wait for health
         run: |
           for i in {1..60}; do
-            curl -fsS http://localhost:4000/health && exit 0 || true
+            curl -fsS http://localhost:4000/health && curl -fsS http://localhost:3000 && exit 0 || true
             sleep 5
           done
-          echo "Server failed to become healthy" >&2
-          docker compose -f docker-compose.yml logs server
+          echo "Services failed to become healthy" >&2
+          docker compose -f docker-compose.yml logs server client
           exit 1
-      - name: Print server logs (on success)
+      - name: Print service logs (on success)
         if: success()
-        run: docker compose -f docker-compose.yml logs --no-color server | tail -n 200
+        run: docker compose -f docker-compose.yml logs --no-color server client | tail -n 200
       - name: Cleanup
         if: always()
         run: docker compose -f docker-compose.yml down -v


### PR DESCRIPTION
## Summary
- expand smoke test workflow to build and start client along with server and dependencies
- check health for both GraphQL API and frontend in CI

## Testing
- `npm test` *(fails: Visualization Service should create geospatial map visualizations; Graph Operations tests, Copilot persistence test, AuthService tests, health test, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a00ad35eb48333846cca266f45e93f