### PR TITLE
docs: add velocity plans for sprints v4–v6

### DIFF
--- a/docs/velocity-plan-v4.md
+++ b/docs/velocity-plan-v4.md
@@ -1,0 +1,43 @@
+IntelGraph — Velocity Plan v4: Tenant Safety & Performance Hardening
+
+Owner: Guy — Theme: multi-tenant isolation + big graph performance
+
+Priorities
+
+Tenant isolation across API/Neo4j/Postgres/Redis + OPA tests
+
+Neighborhood cache with invalidation
+
+Neo4j indexing pass & query hints
+
+Cytoscape LOD for large graphs
+
+PR scaffolds
+
+security/multi-tenant — feat(security): enforce tenant scoping across API/DB/cache
+
+perf/neighborhood-cache — feat(perf): Redis neighborhood cache + invalidation
+
+perf/neo4j-indexing — feat(perf): Neo4j indexes + query tuning
+
+ui/cytoscape-lod — feat(ui): LOD for large graphs
+
+Acceptance criteria
+
+No cross-tenant reads/writes; OPA/unit tests pass
+
+Neighborhood cache hit ≥70%; invalidation verified
+
+Hot endpoint p95 ↓≥30%; PROFILE shows index usage
+
+50k elements interactive (<16ms/frame), labels toggle
+
+Observability
+
+Metrics: neighborhood_cache_hit_ratio, neo4j_query_ms
+
+Alerts: cache hit <50% (warn), p95 query > target (warn)
+
+Next steps
+
+Cut branches, open draft PRs, wire tests into CI

--- a/docs/velocity-plan-v5.md
+++ b/docs/velocity-plan-v5.md
@@ -1,0 +1,43 @@
+IntelGraph — Velocity Plan v5: Real-Time Collaboration & Presence
+
+Owner: Guy — Theme: multi-user editing with deterministic consistency
+
+Priorities
+
+CRDT/LWW versioned mutations + idempotency
+
+Presence rooms + avatars
+
+Conflict telemetry & UX toasts
+
+Golden Path 2-user collab E2E
+
+PR scaffolds
+
+realtime/versioned-ops — feat(realtime): CRDT/LWW with idempotent ops
+
+realtime/presence — feat(realtime): presence rooms + avatars
+
+ui/conflict-toasts — feat(ui): conflict/resolution toasts
+
+test/e2e-collab — test(e2e): 2-user collab path
+
+Acceptance criteria
+
+Duplicate op ID → no-op; LWW resolves races
+
+Presence visible; ghost sessions <0.5%
+
+Conflict toast appears on collisions; audit trail
+
+Collab E2E passes in CI
+
+Observability
+
+Metrics: realtime_conflicts_total, idempotent_hits_total, socket_rtt_ms
+
+Alerts: conflict rate >2% (15m), RTT >150ms (5m)
+
+Next steps
+
+Cut branches, open draft PRs, integrate E2E into required checks

--- a/docs/velocity-plan-v6.md
+++ b/docs/velocity-plan-v6.md
@@ -1,0 +1,43 @@
+IntelGraph — Velocity Plan v6: Security, Compliance & Ops Excellence
+
+Owner: Guy — Theme: production hardening & recovery confidence
+
+Priorities
+
+Per-tenant/user rate limits + circuit breaker
+
+DLP: PII tagging & export redaction
+
+Retention policies & archival hooks
+
+Backup + DR drill with runbooks
+
+PR scaffolds
+
+security/rate-limit — feat(security): per-tenant/user limits + breaker
+
+security/dlp — feat(security): PII tagging + redaction
+
+ops/retention — feat(ops): retention policies & archival
+
+ops/backup-drill — chore(ops): DR drill & runbooks
+
+Acceptance criteria
+
+Abuse tests return 429; breaker opens/closes correctly
+
+Exports respect redaction by role/sensitivity; PII not logged
+
+TTLs enforced; audit trail for deletions/archival
+
+DR restore: RPO ≤ 15m, RTO ≤ 30m; report committed
+
+Observability
+
+Metrics: rate_limit_exceeded_total, breaker_state, backup timings
+
+Alerts: breaker open >5m (page), snapshot failure (page)
+
+Next steps
+
+Cut branches, draft PRs, schedule DR drill & publish runbooks


### PR DESCRIPTION
## Summary
Adds velocity plans for v4–v6 covering tenant safety, collaboration, and ops excellence.

## Scope
- [ ] Code
- [ ] Tests
- [x] Docs
- [ ] Dashboards/Alerts (if applicable)

## Acceptance Criteria
- n/a

## How to Test
1. n/a

## Rollout / Risk
- Flags: none
- Rollback: revert commit
- Risk: low

## Metrics
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68a01435285c8333aa5dcb3e3dc8779a