### PR TITLE
feat(graphql): wire graphrag and similarity resolvers

### DIFF
--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -1,15 +1,17 @@
-import entityResolvers from './entity.js';
-import relationshipResolvers from './relationship.js';
-import userResolvers from './user.js';
-import investigationResolvers from './investigation.js';
-import aiAnalysisResolvers from './aiAnalysis.js';
-import { GraphQLScalarType, Kind } from 'graphql';
+import entityResolvers from "./entity.js";
+import relationshipResolvers from "./relationship.js";
+import userResolvers from "./user.js";
+import investigationResolvers from "./investigation.js";
+import aiAnalysisResolvers from "./aiAnalysis.js";
+import graphragResolvers from "./graphragResolvers.js";
+import similarityResolvers from "./similarity.js";
+import { GraphQLScalarType, Kind } from "graphql";
 // import subscriptionResolvers from './subscriptions.js'; // Temporarily disabled - file doesn't exist
 
 // Simple JSON scalar implementation
 const GraphQLJSON = new GraphQLScalarType({
-  name: 'JSON',
-  description: 'JSON scalar type',
+  name: "JSON",
+  description: "JSON scalar type",
   serialize: (value) => value,
   parseValue: (value) => value,
   parseLiteral: (ast) => {
@@ -27,6 +29,8 @@ const resolvers = {
     ...userResolvers.Query,
     ...investigationResolvers.Query,
     ...aiAnalysisResolvers.Query,
+    ...graphragResolvers.Query,
+    ...similarityResolvers.Query,
   },
   Mutation: {
     ...entityResolvers.Mutation,
@@ -34,10 +38,21 @@ const resolvers = {
     ...userResolvers.Mutation,
     ...investigationResolvers.Mutation,
     ...aiAnalysisResolvers.Mutation,
+    ...graphragResolvers.Mutation,
   },
-  Subscription: { // New Subscription field
+  Subscription: {
+    // New Subscription field
     // ...subscriptionResolvers.Subscription, // Temporarily disabled
   },
+  ...(graphragResolvers.GraphRAGResponse && {
+    GraphRAGResponse: graphragResolvers.GraphRAGResponse,
+  }),
+  ...(graphragResolvers.WhyPath && {
+    WhyPath: graphragResolvers.WhyPath,
+  }),
+  ...(graphragResolvers.Citations && {
+    Citations: graphragResolvers.Citations,
+  }),
 };
 
 export default resolvers;


### PR DESCRIPTION
## Summary
- expose Graphrag and similarity GraphQL resolvers
- surface extra GraphRAG response types in resolver map

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format` *(fails: Prettier YAML syntax errors in workflows)*
- `npm test` *(fails: visualization service, graph-operations, copilot persistence, and war room sync tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0151578fc8333873eb9f44f014999