### PR TITLE
feat: add timescaledb service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,13 @@ POSTGRES_DB=intelgraph_dev
 POSTGRES_USER=intelgraph
 POSTGRES_PASSWORD=devpassword
 
+# Database - TimescaleDB
+TIMESCALEDB_HOST=localhost
+TIMESCALEDB_PORT=5433
+TIMESCALEDB_DB=intelgraph_timeseries
+TIMESCALEDB_USER=timescale
+TIMESCALEDB_PASSWORD=devpassword
+
 # Database - Redis
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd intelgraph
 
 ### 🎯 Core Platform (MVP-0 Complete)
 - **🔐 Authentication & Security**: JWT + RBAC + OPA policies + rate limiting
-- **📊 Graph Analytics**: Neo4j + PostgreSQL + Redis with performance optimizations
+- **📊 Graph Analytics**: Neo4j + PostgreSQL + TimescaleDB + Redis with performance optimizations
 - **⚛️ React Frontend**: Material-UI + Redux + real-time updates + responsive design
 - **🤖 AI Copilot System**: Goal-driven query orchestration with live progress streaming
 - **🔍 Investigation Workflow**: End-to-end investigation management + versioning
@@ -129,6 +129,7 @@ cd intelgraph
 #### Databases
 - **Graph Database**: Neo4j 5 Community Edition
 - **Relational Database**: PostgreSQL 16 with pgvector
+- **Time-series Database**: TimescaleDB 2
 - **Cache/Session Store**: Redis 7 with persistence
 - **File Storage**: Local filesystem with S3 compatibility
 
@@ -151,14 +152,14 @@ cd intelgraph
 │ • Material-UI   │    │ • Rate Limiting │    │ • Constraints   │
 └─────────────────┘    └─────────────────┘    └─────────────────┘
                                 │
-                       ┌─────────────────┐    ┌─────────────────┐
-                       │  PostgreSQL DB  │    │    Redis Cache  │
-                       │                 │    │                 │
-                       │ • User Data     │    │ • Sessions      │
-                       │ • Audit Logs    │    │ • Real-time     │
-                       │ • Metadata      │    │ • Rate Limiting │
-                       │ • Vector Store  │    │ • Pub/Sub       │
-                       └─────────────────┘    └─────────────────┘
+                       ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+                       │  PostgreSQL DB  │    │   TimescaleDB   │    │    Redis Cache  │
+                       │                 │    │                 │    │                 │
+                       │ • User Data     │    │ • Time-series   │    │ • Sessions      │
+                       │ • Audit Logs    │    │ • Metrics       │    │ • Real-time     │
+                       │ • Metadata      │    │                 │    │ • Rate Limiting │
+                       │ • Vector Store  │    │                 │    │ • Pub/Sub       │
+                       └─────────────────┘    └─────────────────┘    └─────────────────┘
 ```
 
 ### Data Flow
@@ -167,7 +168,7 @@ cd intelgraph
 2. **Authentication**: JWT token validation and RBAC checks
 3. **Rate Limiting**: Redis-based request throttling
 4. **Business Logic**: Resolver functions process requests
-5. **Database Operations**: Neo4j for graph data, PostgreSQL for metadata
+5. **Database Operations**: Neo4j for graph data, PostgreSQL for metadata, TimescaleDB for time-series metrics
 6. **Real-time Updates**: Socket.io broadcasts changes to connected clients
 7. **Caching**: Redis caches frequent queries and session data
 
@@ -247,6 +248,12 @@ POSTGRES_DB=intelgraph_dev
 POSTGRES_USER=intelgraph
 POSTGRES_PASSWORD=devpassword
 
+TIMESCALEDB_HOST=localhost
+TIMESCALEDB_PORT=5433
+TIMESCALEDB_DB=intelgraph_timeseries
+TIMESCALEDB_USER=timescale
+TIMESCALEDB_PASSWORD=devpassword
+
 REDIS_HOST=localhost
 REDIS_PASSWORD=devpassword
 
@@ -262,7 +269,7 @@ VITE_WS_URL=http://localhost:4000
 
 ### Database Setup
 
-The platform uses three databases:
+The platform uses four databases:
 
 1. **Neo4j** (Graph Database)
    - URL: http://localhost:7474
@@ -277,7 +284,14 @@ The platform uses three databases:
    - Password: `devpassword`
    - Purpose: User data, audit logs, metadata
 
-3. **Redis** (Cache & Sessions)
+3. **TimescaleDB** (Time-series Database)
+   - Host: localhost:5433
+   - Database: `intelgraph_timeseries`
+   - Username: `timescale`
+   - Password: `devpassword`
+   - Purpose: Metrics and event storage
+
+4. **Redis** (Cache & Sessions)
    - Host: localhost:6379
    - Password: `devpassword`
    - Purpose: Session storage, caching, real-time pub/sub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-intelgraph}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - TIMESCALEDB_HOST=${TIMESCALEDB_HOST:-timescaledb}
+      - TIMESCALEDB_PORT=${TIMESCALEDB_PORT:-5432}
+      - TIMESCALEDB_DB=${TIMESCALEDB_DB:-intelgraph_timeseries}
+      - TIMESCALEDB_USER=${TIMESCALEDB_USER:-timescale}
+      - TIMESCALEDB_PASSWORD=${TIMESCALEDB_PASSWORD:-timescale_pass}
       - REDIS_HOST=${REDIS_HOST:-redis}
       - REDIS_PORT=${REDIS_PORT:-6379}
       - CLIENT_URL=${CLIENT_URL:-http://localhost:3000}
@@ -28,6 +33,7 @@ services:
       - "9229:9229"
     depends_on:
       - postgres
+      - timescaledb
       - neo4j
       - redis
     volumes:
@@ -98,6 +104,35 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+
+  timescaledb:
+    image: timescale/timescaledb:2.11.1-pg14
+    container_name: intelgraph-timescaledb
+    environment:
+      - POSTGRES_DB=${TIMESCALEDB_DB:-intelgraph_timeseries}
+      - POSTGRES_USER=${TIMESCALEDB_USER:-timescale}
+      - POSTGRES_PASSWORD=${TIMESCALEDB_PASSWORD:-timescale_pass}
+    ports:
+      - "5433:5432"
+    volumes:
+      - timescaledbdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
       interval: 10s
@@ -195,3 +230,4 @@ services:
 volumes:
   pgdata:
   neo4jdata:
+  timescaledbdata:


### PR DESCRIPTION
## Summary
- add TimescaleDB service and configuration
- document TimescaleDB usage alongside Neo4j and PostgreSQL

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format` *(fails: Prettier YAML syntax errors)*
- `npm test` *(fails: multiple test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a017be78848333a77a2d641dbc0a11