### PR TITLE
ci: add PR velocity automation tooling

### DIFF
--- a/.github/workflows/auto-merge-ready.yml
+++ b/.github/workflows/auto-merge-ready.yml
@@ -1,0 +1,24 @@
+name: Auto Merge Ready PRs
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ready-to-merge') &&
+      github.event.pull_request.draft == false
+    steps:
+      - uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash
+          required-statuses: |
+            ci/tests
+            ci/lint

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,17 @@
+name: danger
+on: [pull_request]
+
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install Danger
+        run: npm install danger --no-save
+      - name: Run Danger
+        run: npx danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,15 @@
+name: reviewdog
+on: [pull_request]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: npm ci
+      - name: Run ESLint with reviewdog
+        uses: reviewdog/action-eslint@v1
+        with:
+          reporter: github-pr-review
+          eslint_flags: "--ext .js,.ts ."

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,35 @@
+import { danger, warn, fail, markdown } from "danger";
+
+const modifiedFiles = danger.git.modified_files.concat(
+  danger.git.created_files,
+);
+
+// Warn if tests aren’t updated
+const testChanges = modifiedFiles.filter((f) =>
+  /(__tests__|test|spec)/i.test(f),
+).length;
+if (testChanges === 0) {
+  warn("No tests were updated. Is this change tested?");
+}
+
+// Enforce documentation updates
+const docsModified = modifiedFiles.some((f) => f.startsWith("docs/"));
+if (!docsModified) {
+  warn("Consider documenting this change in `docs/`.");
+}
+
+// Fail if TODO left
+schedule(async () => {
+  const results = await Promise.all(
+    modifiedFiles.map(async (file) => {
+      const diff = await danger.git.diffForFile(file);
+      return diff && diff.includes("TODO");
+    }),
+  );
+  if (results.some(Boolean)) {
+    fail("Remove TODO comments before merging.");
+  }
+});
+
+// Summary
+markdown("## PR Review Automated by Danger :robot:");

--- a/monitoring/dashboards/pr-velocity.json
+++ b/monitoring/dashboards/pr-velocity.json
@@ -1,0 +1,32 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "datasource": "Prometheus",
+        "enable": true,
+        "iconColor": "red",
+        "name": "Deploys"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Open PRs",
+      "targets": [
+        {
+          "expr": "github_pull_requests_open_total"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "PR Lead Time",
+      "targets": [
+        {
+          "expr": "increase(github_pull_request_open_to_merge_seconds_sum[1w]) / increase(github_pull_request_open_to_merge_seconds_count[1w])"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/announce-velocity-plan.sh
+++ b/scripts/announce-velocity-plan.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+echo "
+\U0001F680 **Velocity Plan Kickoff**
+- PR Blitz Sessions: 10AM & 3PM daily
+- Tag PRs with 'ready-to-merge' after passing tests
+- Danger & reviewdog automated review in place
+Let's clear the backlog and keep feedback flowing!
+" | slack-cli chat send --channel '#dev-updates'
+


### PR DESCRIPTION
## Summary
- auto-merge ready-to-merge PRs after checks
- automate PR review with Danger and reviewdog
- add PR velocity dashboard and announcement script

## Testing
- `npm test` *(fails: Visualization Service test, Graph Operations tests, copilot persistence, warRoomSync, AI Integration, GNN integration, monitoring, etc.)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format` *(fails: YAML syntax errors in existing workflows)*

------
https://chatgpt.com/codex/tasks/task_e_68a01cc6049c8333afdcc2d8ebd1fa33