### PR TITLE
fix: ensure redis auth and update health checks

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,10 +26,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
         reservations:
-          cpus: '0.25'
+          cpus: "0.25"
           memory: 256M
     cap_drop:
       - ALL
@@ -77,17 +77,17 @@ services:
     networks:
       - intelgraph-dev
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4000/graphql"]
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health/ready"]
       interval: 30s
       timeout: 10s
       retries: 3
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
         reservations:
-          cpus: '0.25'
+          cpus: "0.25"
           memory: 256M
     cap_drop:
       - ALL
@@ -110,17 +110,21 @@ services:
     networks:
       - intelgraph-dev
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:7474 || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 --spider http://localhost:7474 || exit 1",
+        ]
       interval: 30s
       timeout: 10s
       retries: 5
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 512M
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 256M
 
   # PostgreSQL Database
@@ -145,10 +149,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
 
   # Redis Cache
@@ -169,10 +173,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
 
   # AI/ML Microservice
@@ -210,10 +214,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
 
   # ML Worker (Celery)
@@ -221,7 +225,15 @@ services:
     build:
       context: ./ml
       dockerfile: Dockerfile
-    command: ["celery", "-A", "app.celery_app", "worker", "--loglevel=INFO", "--concurrency=2"]
+    command:
+      [
+        "celery",
+        "-A",
+        "app.celery_app",
+        "worker",
+        "--loglevel=INFO",
+        "--concurrency=2",
+      ]
     environment:
       - REDIS_URL=redis://:devpassword@redis:6379/0
       - NEO4J_URI=bolt://neo4j:7687
@@ -243,10 +255,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1.0'
+          cpus: "1.0"
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
 
   # Database Administration

--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -1,8 +1,8 @@
-import neo4j, { Driver, Session } from 'neo4j-driver';
-import { Pool, PoolClient } from 'pg';
-import Redis from 'ioredis';
-import config from './index.js';
-import logger from '../utils/logger.js';
+import neo4j, { Driver, Session } from "neo4j-driver";
+import { Pool, PoolClient } from "pg";
+import Redis from "ioredis";
+import config from "./index.js";
+import logger from "../utils/logger.js";
 
 let neo4jDriver: Driver | null = null;
 let postgresPool: Pool | null = null;
@@ -13,21 +13,21 @@ async function connectNeo4j(): Promise<Driver> {
   try {
     neo4jDriver = neo4j.driver(
       config.neo4j.uri,
-      neo4j.auth.basic(config.neo4j.username, config.neo4j.password)
+      neo4j.auth.basic(config.neo4j.username, config.neo4j.password),
     );
 
     // Test connection
     const session = neo4jDriver.session();
-    await session.run('RETURN 1');
+    await session.run("RETURN 1");
     await session.close();
 
     // Run migrations to set up constraints and indexes
     await runNeo4jMigrations();
-    
-    logger.info('✅ Connected to Neo4j');
+
+    logger.info("✅ Connected to Neo4j");
     return neo4jDriver;
   } catch (error) {
-    logger.error('❌ Failed to connect to Neo4j:', error);
+    logger.error("❌ Failed to connect to Neo4j:", error);
     throw error;
   }
 }
@@ -35,62 +35,68 @@ async function connectNeo4j(): Promise<Driver> {
 async function runNeo4jMigrations(): Promise<void> {
   try {
     // Import migration manager lazily to avoid circular dependencies
-    const { migrationManager } = await import('../db/migrations/index.js');
+    const { migrationManager } = await import("../db/migrations/index.js");
     await migrationManager.migrate();
-    logger.info('Neo4j migrations completed successfully');
+    logger.info("Neo4j migrations completed successfully");
   } catch (error) {
-    logger.warn('Migration system not available, falling back to legacy constraints');
+    logger.warn(
+      "Migration system not available, falling back to legacy constraints",
+    );
     await createNeo4jConstraints();
   }
 }
 
 async function createNeo4jConstraints(): Promise<void> {
-  if (!neo4jDriver) throw new Error('Neo4j driver not initialized');
+  if (!neo4jDriver) throw new Error("Neo4j driver not initialized");
   const session = neo4jDriver.session();
-  
+
   try {
     const constraints = [
-      'CREATE CONSTRAINT entity_id IF NOT EXISTS FOR (e:Entity) REQUIRE e.id IS UNIQUE',
-      'CREATE CONSTRAINT entity_uuid IF NOT EXISTS FOR (e:Entity) REQUIRE e.uuid IS UNIQUE',
-      'CREATE CONSTRAINT user_id IF NOT EXISTS FOR (u:User) REQUIRE u.id IS UNIQUE',
-      'CREATE CONSTRAINT user_email IF NOT EXISTS FOR (u:User) REQUIRE u.email IS UNIQUE',
-      'CREATE CONSTRAINT investigation_id IF NOT EXISTS FOR (i:Investigation) REQUIRE i.id IS UNIQUE',
-      'CREATE CONSTRAINT relationship_id IF NOT EXISTS FOR ()-[r:RELATIONSHIP]-() REQUIRE r.id IS UNIQUE'
+      "CREATE CONSTRAINT entity_id IF NOT EXISTS FOR (e:Entity) REQUIRE e.id IS UNIQUE",
+      "CREATE CONSTRAINT entity_uuid IF NOT EXISTS FOR (e:Entity) REQUIRE e.uuid IS UNIQUE",
+      "CREATE CONSTRAINT user_id IF NOT EXISTS FOR (u:User) REQUIRE u.id IS UNIQUE",
+      "CREATE CONSTRAINT user_email IF NOT EXISTS FOR (u:User) REQUIRE u.email IS UNIQUE",
+      "CREATE CONSTRAINT investigation_id IF NOT EXISTS FOR (i:Investigation) REQUIRE i.id IS UNIQUE",
+      "CREATE CONSTRAINT relationship_id IF NOT EXISTS FOR ()-[r:RELATIONSHIP]-() REQUIRE r.id IS UNIQUE",
     ];
 
     for (const constraint of constraints) {
       try {
         await session.run(constraint);
       } catch (error: any) {
-        if (!error.message.includes('already exists')) {
-          logger.warn('Failed to create constraint:', constraint, error.message);
+        if (!error.message.includes("already exists")) {
+          logger.warn(
+            "Failed to create constraint:",
+            constraint,
+            error.message,
+          );
         }
       }
     }
 
     const indexes = [
-      'CREATE INDEX entity_type IF NOT EXISTS FOR (e:Entity) ON (e.type)',
-      'CREATE INDEX entity_label IF NOT EXISTS FOR (e:Entity) ON (e.label)',
-      'CREATE INDEX entity_created IF NOT EXISTS FOR (e:Entity) ON (e.createdAt)',
-      'CREATE INDEX investigation_status IF NOT EXISTS FOR (i:Investigation) ON (i.status)',
-      'CREATE INDEX user_username IF NOT EXISTS FOR (u:User) ON (u.username)',
-      'CREATE FULLTEXT INDEX entity_search IF NOT EXISTS FOR (e:Entity) ON EACH [e.label, e.description]',
-      'CREATE FULLTEXT INDEX investigation_search IF NOT EXISTS FOR (i:Investigation) ON EACH [i.title, i.description]'
+      "CREATE INDEX entity_type IF NOT EXISTS FOR (e:Entity) ON (e.type)",
+      "CREATE INDEX entity_label IF NOT EXISTS FOR (e:Entity) ON (e.label)",
+      "CREATE INDEX entity_created IF NOT EXISTS FOR (e:Entity) ON (e.createdAt)",
+      "CREATE INDEX investigation_status IF NOT EXISTS FOR (i:Investigation) ON (i.status)",
+      "CREATE INDEX user_username IF NOT EXISTS FOR (u:User) ON (u.username)",
+      "CREATE FULLTEXT INDEX entity_search IF NOT EXISTS FOR (e:Entity) ON EACH [e.label, e.description]",
+      "CREATE FULLTEXT INDEX investigation_search IF NOT EXISTS FOR (i:Investigation) ON EACH [i.title, i.description]",
     ];
 
     for (const index of indexes) {
       try {
         await session.run(index);
       } catch (error: any) {
-        if (!error.message.includes('already exists')) {
-          logger.warn('Failed to create index:', index, error.message);
+        if (!error.message.includes("already exists")) {
+          logger.warn("Failed to create index:", index, error.message);
         }
       }
     }
-    
-    logger.info('Neo4j constraints and indexes created');
+
+    logger.info("Neo4j constraints and indexes created");
   } catch (error) {
-    logger.error('Failed to create Neo4j constraints:', error);
+    logger.error("Failed to create Neo4j constraints:", error);
   } finally {
     await session.close();
   }
@@ -111,23 +117,23 @@ async function connectPostgres(): Promise<Pool> {
     });
 
     const client = await postgresPool.connect();
-    await client.query('SELECT NOW()');
+    await client.query("SELECT NOW()");
     client.release();
 
     await createPostgresTables();
-    
-    logger.info('✅ Connected to PostgreSQL');
+
+    logger.info("✅ Connected to PostgreSQL");
     return postgresPool;
   } catch (error) {
-    logger.error('❌ Failed to connect to PostgreSQL:', error);
+    logger.error("❌ Failed to connect to PostgreSQL:", error);
     throw error;
   }
 }
 
 async function createPostgresTables(): Promise<void> {
-  if (!postgresPool) throw new Error('PostgreSQL pool not initialized');
+  if (!postgresPool) throw new Error("PostgreSQL pool not initialized");
   const client = await postgresPool.connect();
-  
+
   try {
     // Users table
     await client.query(`
@@ -187,14 +193,22 @@ async function createPostgresTables(): Promise<void> {
       )
     `);
 
-    await client.query('CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id)');
-    await client.query('CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs(created_at)');
-    await client.query('CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON user_sessions(user_id)');
-    await client.query('CREATE INDEX IF NOT EXISTS idx_analysis_investigation ON analysis_results(investigation_id)');
-    
-    logger.info('PostgreSQL tables created');
+    await client.query(
+      "CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id)",
+    );
+    await client.query(
+      "CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs(created_at)",
+    );
+    await client.query(
+      "CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON user_sessions(user_id)",
+    );
+    await client.query(
+      "CREATE INDEX IF NOT EXISTS idx_analysis_investigation ON analysis_results(investigation_id)",
+    );
+
+    logger.info("PostgreSQL tables created");
   } catch (error) {
-    logger.error('Failed to create PostgreSQL tables:', error);
+    logger.error("Failed to create PostgreSQL tables:", error);
   } finally {
     client.release();
   }
@@ -215,68 +229,68 @@ async function connectRedis(): Promise<Redis | null> {
       family: 4,
       enableOfflineQueue: false,
       reconnectOnError: (err: Error) => {
-        const targetError = 'READONLY';
+        const targetError = "READONLY";
         return err.message.includes(targetError);
       },
       retryStrategy: (times: number) => {
         const delay = Math.min(times * 50, 2000);
         return delay;
-      }
+      },
     };
 
-    // Only add password if it's provided and not the default dev password
-    if (config.redis.password && config.redis.password !== 'devpassword') {
+    // Add password if provided
+    if (config.redis.password) {
       redisConfig.password = config.redis.password;
     }
 
     redisClient = new Redis(redisConfig);
 
-    redisClient.on('error', (error) => {
-      logger.error('Redis error:', error.message);
+    redisClient.on("error", (error) => {
+      logger.error("Redis error:", error.message);
     });
 
-    redisClient.on('connect', () => {
-      logger.info('Redis connected');
+    redisClient.on("connect", () => {
+      logger.info("Redis connected");
     });
 
-    redisClient.on('ready', () => {
-      logger.info('✅ Redis ready');
+    redisClient.on("ready", () => {
+      logger.info("✅ Redis ready");
     });
 
-    redisClient.on('reconnecting', () => {
-      logger.info('Redis reconnecting...');
+    redisClient.on("reconnecting", () => {
+      logger.info("Redis reconnecting...");
     });
 
-    redisClient.on('end', () => {
-      logger.warn('Redis connection ended');
+    redisClient.on("end", () => {
+      logger.warn("Redis connection ended");
     });
 
     await redisClient.connect();
     await redisClient.ping();
-    
-    logger.info('✅ Connected to Redis');
+
+    logger.info("✅ Connected to Redis");
     return redisClient;
   } catch (error: any) {
-    logger.error('❌ Failed to connect to Redis:', error.message);
+    logger.error("❌ Failed to connect to Redis:", error.message);
     // Don't throw error to allow server to start without Redis if needed
-    logger.warn('Server will continue without Redis caching');
+    logger.warn("Server will continue without Redis caching");
     return null;
   }
 }
 
 function getNeo4jDriver(): Driver {
-  if (!neo4jDriver) throw new Error('Neo4j driver not initialized');
+  if (!neo4jDriver) throw new Error("Neo4j driver not initialized");
   return neo4jDriver;
 }
 
 function getPostgresPool(): Pool {
-  if (!postgresPool) throw new Error('PostgreSQL pool not initialized');
+  if (!postgresPool) throw new Error("PostgreSQL pool not initialized");
   return postgresPool;
 }
 
 function getRedisClient(): Redis | null {
   if (!redisClient) {
-    logger.warn('Redis client not available');
+    logger.warn("Redis client not available");
     return null;
   }
   return redisClient;
@@ -285,15 +299,15 @@ function getRedisClient(): Redis | null {
 async function closeConnections(): Promise<void> {
   if (neo4jDriver) {
     await neo4jDriver.close();
-    logger.info('Neo4j connection closed');
+    logger.info("Neo4j connection closed");
   }
   if (postgresPool) {
     await postgresPool.end();
-    logger.info('PostgreSQL connection closed');
+    logger.info("PostgreSQL connection closed");
   }
   if (redisClient) {
     redisClient.disconnect();
-    logger.info('Redis connection closed');
+    logger.info("Redis connection closed");
   }
 }
 
@@ -304,5 +318,5 @@ export {
   getNeo4jDriver,
   getPostgresPool,
   getRedisClient,
-  closeConnections
+  closeConnections,
 };

--- a/server/src/realtime/analyticsBridge.js
+++ b/server/src/realtime/analyticsBridge.js
@@ -1,17 +1,28 @@
-const Redis = require('ioredis');
-const logger = require('../utils/logger');
-const AuthService = require('../services/AuthService');
-const { evaluate } = require('../services/AccessControl');
+const Redis = require("ioredis");
+const logger = require("../utils/logger");
+const AuthService = require("../services/AuthService");
+const { evaluate } = require("../services/AccessControl");
 
-const STREAM_KEY = process.env.ANALYTICS_RESULTS_STREAM || 'analytics:results';
-const GROUP = process.env.ANALYTICS_RESULTS_GROUP || 'analytics-bridge';
+const STREAM_KEY = process.env.ANALYTICS_RESULTS_STREAM || "analytics:results";
+const GROUP = process.env.ANALYTICS_RESULTS_GROUP || "analytics-bridge";
 
 class AnalyticsBridge {
   constructor(io, redisUrl) {
     this.io = io;
-    this.ns = io.of('/graph-analytics');
-    this.redis = new Redis(redisUrl || process.env.REDIS_URL || 'redis://localhost:6379/1');
-    this.consumer = `${process.env.HOSTNAME || 'c'}-${Math.random().toString(36).slice(2, 8)}`;
+    this.ns = io.of("/graph-analytics");
+
+    const redisOptions = redisUrl ||
+      process.env.REDIS_URL || {
+        host: process.env.REDIS_HOST || "localhost",
+        port: Number(process.env.REDIS_PORT || 6379),
+        password: process.env.REDIS_PASSWORD || undefined,
+        db: Number(process.env.REDIS_DB || 1),
+      };
+    this.redis = new Redis(redisOptions);
+
+    this.consumer = `${process.env.HOSTNAME || "c"}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
     this.running = false;
     this._setupNamespace();
   }
@@ -19,35 +30,47 @@ class AnalyticsBridge {
   _setupNamespace() {
     const authService = new AuthService();
     // Require JWT and attach user (bypassable for tests/dev by env)
-    const bypassAuth = process.env.DISABLE_SOCKET_AUTH === '1' || process.env.NODE_ENV === 'test';
+    const bypassAuth =
+      process.env.DISABLE_SOCKET_AUTH === "1" ||
+      process.env.NODE_ENV === "test";
     this.ns.use(async (socket, next) => {
       try {
         if (bypassAuth) {
-          socket.user = { id: 'test', role: 'ANALYST' };
+          socket.user = { id: "test", role: "ANALYST" };
           return next();
         }
-        const token = socket.handshake.auth?.token || socket.handshake.headers?.authorization?.replace('Bearer ', '');
+        const token =
+          socket.handshake.auth?.token ||
+          socket.handshake.headers?.authorization?.replace("Bearer ", "");
         const user = await authService.verifyToken(token);
-        if (!user) return next(new Error('Unauthorized'));
+        if (!user) return next(new Error("Unauthorized"));
         socket.user = user;
         next();
       } catch (e) {
-        next(new Error('Unauthorized'));
+        next(new Error("Unauthorized"));
       }
     });
 
-    this.ns.on('connection', (socket) => {
-      socket.on('join_job', async ({ jobId }) => {
+    this.ns.on("connection", (socket) => {
+      socket.on("join_job", async ({ jobId }) => {
         if (!jobId) return;
         // ABAC gate for job visibility
-        const decision = await evaluate('analytics_job_view', socket.user, { jobId }, {});
+        const decision = await evaluate(
+          "analytics_job_view",
+          socket.user,
+          { jobId },
+          {},
+        );
         if (!decision?.allow) {
-          socket.emit('error', { code: 'FORBIDDEN', message: 'Not authorized to view job' });
+          socket.emit("error", {
+            code: "FORBIDDEN",
+            message: "Not authorized to view job",
+          });
           return;
         }
         socket.join(`job:${jobId}`);
       });
-      socket.on('leave_job', ({ jobId }) => {
+      socket.on("leave_job", ({ jobId }) => {
         if (!jobId) return;
         socket.leave(`job:${jobId}`);
       });
@@ -56,23 +79,24 @@ class AnalyticsBridge {
 
   async _ensureGroup() {
     try {
-      await this.redis.xgroup('CREATE', STREAM_KEY, GROUP, '$', 'MKSTREAM');
+      await this.redis.xgroup("CREATE", STREAM_KEY, GROUP, "$", "MKSTREAM");
       logger.info(`Created consumer group ${GROUP} on ${STREAM_KEY}`);
     } catch (e) {
       // Group exists
-      if (!String(e.message || '').includes('BUSYGROUP')) {
-        logger.warn('xgroup create error', e);
+      if (!String(e.message || "").includes("BUSYGROUP")) {
+        logger.warn("xgroup create error", e);
       }
     }
   }
 
   _classify(event) {
-    const msg = (event.message || '').toLowerCase();
-    const level = (event.level || 'INFO').toUpperCase();
-    if (level === 'ERROR' || msg.includes('fail')) return 'error';
-    if (msg.startsWith('job:done') || msg.startsWith('job:complete')) return 'complete';
-    if (msg.includes('done') || msg.includes('result')) return 'result';
-    return 'progress';
+    const msg = (event.message || "").toLowerCase();
+    const level = (event.level || "INFO").toUpperCase();
+    if (level === "ERROR" || msg.includes("fail")) return "error";
+    if (msg.startsWith("job:done") || msg.startsWith("job:complete"))
+      return "complete";
+    if (msg.includes("done") || msg.includes("result")) return "result";
+    return "progress";
   }
 
   async start() {
@@ -88,16 +112,34 @@ class AnalyticsBridge {
   async _loop() {
     while (this.running) {
       try {
-        const res = await this.redis.xreadgroup('GROUP', GROUP, this.consumer, 'BLOCK', 200, 'COUNT', 64, 'STREAMS', STREAM_KEY, '>');
+        const res = await this.redis.xreadgroup(
+          "GROUP",
+          GROUP,
+          this.consumer,
+          "BLOCK",
+          200,
+          "COUNT",
+          64,
+          "STREAMS",
+          STREAM_KEY,
+          ">",
+        );
         if (!res) continue; // timeout
         for (const [_stream, entries] of res) {
           for (const [id, fields] of entries) {
             try {
               const raw = fields.event || fields.data || fields.payload || null;
-              if (!raw) { await this.redis.xack(STREAM_KEY, GROUP, id); continue; }
+              if (!raw) {
+                await this.redis.xack(STREAM_KEY, GROUP, id);
+                continue;
+              }
               const ev = JSON.parse(raw);
               const type = this._classify(ev);
-              const jobId = ev.job_id || ev.jobId || ev.payload?.job_id || ev.payload?.jobId;
+              const jobId =
+                ev.job_id ||
+                ev.jobId ||
+                ev.payload?.job_id ||
+                ev.payload?.jobId;
               if (jobId) {
                 this.ns.to(`job:${jobId}`).emit(type, ev);
               } else {
@@ -106,15 +148,19 @@ class AnalyticsBridge {
               }
               await this.redis.xack(STREAM_KEY, GROUP, id);
             } catch (e) {
-              logger.error('analyticsBridge entry error', { err: e });
+              logger.error("analyticsBridge entry error", { err: e });
               // ack to avoid poison pill loop
-              try { await this.redis.xack(STREAM_KEY, GROUP, id); } catch (_) { /* Intentionally empty */ }
+              try {
+                await this.redis.xack(STREAM_KEY, GROUP, id);
+              } catch (_) {
+                /* Intentionally empty */
+              }
             }
           }
         }
       } catch (e) {
-        logger.error('analyticsBridge loop error', { err: e });
-        await new Promise(r => setTimeout(r, 500));
+        logger.error("analyticsBridge loop error", { err: e });
+        await new Promise((r) => setTimeout(r, 500));
       }
     }
   }

--- a/start.sh
+++ b/start.sh
@@ -155,7 +155,7 @@ start_services() {
     
     # Wait for server to be ready
     log_info "Waiting for server to be ready..."
-    wait_for_service "server" "http://localhost:4000/graphql" 60
+    wait_for_service "server" "http://localhost:4000/health/ready" 60
     
     # Start client
     log_info "Starting client..."
@@ -220,7 +220,7 @@ show_service_status() {
     
     # Check each service
     check_service_health "Frontend" "http://localhost:3000" "React Application"
-    check_service_health "Backend" "http://localhost:4000/graphql" "GraphQL API"
+    check_service_health "Backend" "http://localhost:4000/health/ready" "Server Health"
     check_service_health "Neo4j" "http://localhost:7474" "Graph Database"
     check_service_health "Adminer" "http://localhost:8080" "Database Admin"
     


### PR DESCRIPTION
## Summary
- pass Redis connection details to analytics bridge
- always include Redis password and use readiness health endpoint
- wait for server readiness instead of GraphQL responses during startup

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*
- `npm run format` *(fails: Prettier syntax errors in repository)*
- `npm test` *(fails: multiple test suites, e.g. graph-operations, copilot)*

------
https://chatgpt.com/codex/tasks/task_e_68a016b3d2b48333946964a116e5ae37