### PR TITLE
feat: enforce WS persisted queries and block gitleaks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,4 +11,3 @@ jobs:
           fetch-depth: 0
       - name: gitleaks
         uses: zricethezav/gitleaks-action@v2
-        continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
+      "pre-commit": "npx gitleaks protect --staged --verbose && lint-staged",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,7 +19,7 @@ import { getContext } from './lib/auth.js'
 import { getNeo4jDriver } from './db/neo4j.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
-// import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
+import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -126,13 +126,13 @@ const wss = new WebSocketServer({
   path: "/graphql",
 });
 
-// const wsPersistedQueries = new WSPersistedQueriesMiddleware();
-// const wsMiddleware = wsPersistedQueries.createMiddleware();
+const wsPersistedQueries = new WSPersistedQueriesMiddleware();
+const wsMiddleware = wsPersistedQueries.createMiddleware();
 
-useServer({ 
-  schema, 
+useServer({
+  schema,
   context: getContext,
-  // ...wsMiddleware
+  ...wsMiddleware,
 }, wss);
 
 if (process.env.NODE_ENV === 'production') {

--- a/triage/findings.csv
+++ b/triage/findings.csv
@@ -1,2 +1,2 @@
 Category,Item,Detail,Impact,Likelihood,Effort,PriorityScore
-Security,Security,gitleaks not installed — secrets scan skipped,5,2,1,30
+Security,Security,gitleaks blocking enabled in CI and pre-commit,1,1,1,1


### PR DESCRIPTION
## Summary
- enforce persisted query allowlist on WebSocket GraphQL connections
- fail CI on gitleaks findings and run gitleaks in pre-commit
- update triage finding for gitleaks

## Testing
- `npm test` *(fails: 32 failed, 14 passed)*
- `npm run lint` *(fails: 2675 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a05807acd08333908908875ff8d078