### PR TITLE
fix: handle redis failure in analytics bridge

### DIFF
--- a/server/src/realtime/analyticsBridge.js
+++ b/server/src/realtime/analyticsBridge.js
@@ -20,6 +20,13 @@ class AnalyticsBridge {
       };
     this.redis = new Redis(redisOptions);
 
+    this.redis.on("error", (err) => {
+      logger.warn(
+        `Redis connection failed for analytics bridge - using mock. Error: ${err.message}`,
+      );
+      this.redis = createMockRedis();
+    });
+
     this.consumer = `${process.env.HOSTNAME || "c"}-${Math.random()
       .toString(36)
       .slice(2, 8)}`;
@@ -164,6 +171,15 @@ class AnalyticsBridge {
       }
     }
   }
+}
+
+function createMockRedis() {
+  return {
+    xgroup: async () => {},
+    xreadgroup: async () => null,
+    xack: async () => {},
+    on: () => {},
+  };
 }
 
 module.exports = { AnalyticsBridge };


### PR DESCRIPTION
## Summary
- prevent unhandled Redis errors during startup by adding error handler and mock fallback in analytics bridge

## Testing
- `npm run lint` *(fails: 2675 errors)*
- `npm run format` *(fails: SyntaxError in workflow files)*
- `npx prettier server/src/realtime/analyticsBridge.js --write`
- `npx eslint server/src/realtime/analyticsBridge.js` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: multiple test failures and configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f09f2c588333add41e4970755a91