### PR TITLE
feat: add deletion helpers for Neo4j store

### DIFF
--- a/python/intelgraph_py/storage/neo4j_store.py
+++ b/python/intelgraph_py/storage/neo4j_store.py
@@ -44,3 +44,15 @@ class Neo4jStore:
     )
     return self._run(q, {"id": id, "depth": depth})
 
+  def delete_entity(self, id: str):
+    q = "MATCH (n:Entity {id: $id}) DETACH DELETE n"
+    self._run(q, {"id": id})
+
+  def delete_relationship(self, src: str, dst: str, kind: str):
+    q = (
+      "MATCH (a:Entity {id: $src})-"
+      "[r:REL {kind: $kind}]->"
+      "(b:Entity {id: $dst}) DELETE r"
+    )
+    self._run(q, {"src": src, "dst": dst, "kind": kind})
+

--- a/python/tests/test_neo4j_store.py
+++ b/python/tests/test_neo4j_store.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock, patch
+from intelgraph_py.storage.neo4j_store import Neo4jStore
+
+
+@patch("intelgraph_py.storage.neo4j_store.GraphDatabase")
+def test_delete_entity(mock_graph):
+  mock_driver = MagicMock()
+  mock_graph.driver.return_value = mock_driver
+  store = Neo4jStore("bolt://x", "u", "p")
+  store._run = MagicMock()
+  store.delete_entity("123")
+  store._run.assert_called_once_with(
+    "MATCH (n:Entity {id: $id}) DETACH DELETE n",
+    {"id": "123"},
+  )
+
+
+@patch("intelgraph_py.storage.neo4j_store.GraphDatabase")
+def test_delete_relationship(mock_graph):
+  mock_driver = MagicMock()
+  mock_graph.driver.return_value = mock_driver
+  store = Neo4jStore("bolt://x", "u", "p")
+  store._run = MagicMock()
+  store.delete_relationship("a", "b", "KNOWS")
+  store._run.assert_called_once_with(
+    "MATCH (a:Entity {id: $src})-[r:REL {kind: $kind}]->(b:Entity {id: $dst}) DELETE r",
+    {"src": "a", "dst": "b", "kind": "KNOWS"},
+  )


### PR DESCRIPTION
## Summary
- add delete_entity and delete_relationship helpers to Neo4j store
- test neo4j store deletion helpers

## Testing
- `npm test` *(fails: visualization service, graph operations, war room sync, ai integration, and many others)*
- `npm run lint` *(fails: 2675 errors, 739 warnings)*
- `npm run format` *(fails: syntax errors in workflow and helm files)*
- `cd python && pytest` *(fails: ModuleNotFoundError: No module named 'intelgraph_py')*

------
https://chatgpt.com/codex/tasks/task_e_68a0f15b22d88333ac247c563f88fc54