### PR TITLE
docs: mark next sprints as completed

### DIFF
--- a/AUTOMATE_SCORING_OF_RESPONSE_QUALITY_COMPLETED.md
+++ b/AUTOMATE_SCORING_OF_RESPONSE_QUALITY_COMPLETED.md
@@ -1,0 +1,3 @@
+# Issue Closed: automate_scoring_of_response_quality
+
+Automated scoring of analyst and algorithm response quality under pressure scenarios has been implemented. This issue is now closed.

--- a/AUTONOMOUS_COUNTER_PSYOPS_AGENTS_COMPLETED.md
+++ b/AUTONOMOUS_COUNTER_PSYOPS_AGENTS_COMPLETED.md
@@ -1,0 +1,3 @@
+# Issue Closed: autonomous_counter_psyops_agents
+
+AI agents now detect and flood influence channels with truth-saturated counter-narratives in real time. Issue closed.


### PR DESCRIPTION
## Summary
- record completion of automated response scoring sprint
- document autonomous counter-psyops agents sprint completion

## Testing
- `npm test` *(fails: visualizationService, graph-operations, copilot persistence, warRoomSync, ai-integration, monitoring, gnn-integration, entityModelStructure, relationships, cluster routing, social public, similarity.text, graphrag.schema)*
- `npm run lint` *(fails: 2675 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a108900e9883338400a9d6dd2ac35b