### PR TITLE
feat(server): add status endpoint for service info

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,45 +1,54 @@
-import 'dotenv/config'
-import http from 'http'
-import express from 'express'
-import { ApolloServer } from '@apollo/server'
-import { expressMiddleware } from '@as-integrations/express4'
-import { makeExecutableSchema } from '@graphql-tools/schema'
-import { useServer } from 'graphql-ws/lib/use/ws'
-import { WebSocketServer } from 'ws'
-import cors from 'cors'
-import helmet from 'helmet'
-import rateLimit from 'express-rate-limit'
-import pino from 'pino'
-import { pinoHttp } from 'pino-http'
-import monitoringRouter from './routes/monitoring.js'
-import aiRouter from './routes/ai.js'
-import { typeDefs } from './graphql/schema.js'
-import resolvers from './graphql/resolvers/index.js'
-import { getContext } from './lib/auth.js'
-import { getNeo4jDriver } from './db/neo4j.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
+import "dotenv/config";
+import http from "http";
+import express from "express";
+import { ApolloServer } from "@apollo/server";
+import { expressMiddleware } from "@as-integrations/express4";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { useServer } from "graphql-ws/lib/use/ws";
+import { WebSocketServer } from "ws";
+import cors from "cors";
+import helmet from "helmet";
+import rateLimit from "express-rate-limit";
+import pino from "pino";
+import { pinoHttp } from "pino-http";
+import monitoringRouter from "./routes/monitoring.js";
+import aiRouter from "./routes/ai.js";
+import statusRouter from "./routes/status.js";
+import { typeDefs } from "./graphql/schema.js";
+import resolvers from "./graphql/resolvers/index.js";
+import { getContext } from "./lib/auth.js";
+import { getNeo4jDriver } from "./db/neo4j.js";
+import path from "path";
+import { fileURLToPath } from "url";
+import WSPersistedQueriesMiddleware from "./graphql/middleware/wsPersistedQueries.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const app = express()
+const app = express();
 const logger: pino.Logger = pino();
-app.use(helmet())
-app.use(cors({ origin: process.env.CORS_ORIGIN?.split(',') ?? ['http://localhost:3000'], credentials: true }))
-app.use(pinoHttp({ logger, redact: ['req.headers.authorization'] }))
+app.use(helmet());
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN?.split(",") ?? ["http://localhost:3000"],
+    credentials: true,
+  }),
+);
+app.use(pinoHttp({ logger, redact: ["req.headers.authorization"] }));
 
 // Rate limiting (exempt monitoring endpoints)
-app.use('/monitoring', monitoringRouter)
-app.use('/api/ai', aiRouter)
-app.use(rateLimit({
-  windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
-  max: Number(process.env.RATE_LIMIT_MAX || 600),
-  message: { error: 'Too many requests, please try again later' }
-}))
+app.use("/monitoring", monitoringRouter);
+app.use("/api/ai", aiRouter);
+app.use(
+  rateLimit({
+    windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
+    max: Number(process.env.RATE_LIMIT_MAX || 600),
+    message: { error: "Too many requests, please try again later" },
+  }),
+);
+app.use("/api/status", statusRouter);
 
-app.get('/search/evidence', async (req, res) => {
+app.get("/search/evidence", async (req, res) => {
   const { q, skip = 0, limit = 10 } = req.query;
 
   if (!q) {
@@ -89,8 +98,10 @@ app.get('/search/evidence', async (req, res) => {
       },
     });
   } catch (error) {
-    logger.error(`Error in search/evidence: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    res.status(500).send({ error: 'Internal server error' });
+    logger.error(
+      `Error in search/evidence: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+    res.status(500).send({ error: "Internal server error" });
   } finally {
     await session.close();
   }
@@ -100,10 +111,10 @@ const schema = makeExecutableSchema({ typeDefs, resolvers });
 const httpServer = http.createServer(app);
 
 // GraphQL over HTTP
-import { persistedQueriesPlugin } from './graphql/plugins/persistedQueries.js';
-import pbacPlugin from './graphql/plugins/pbac.js';
-import resolverMetricsPlugin from './graphql/plugins/resolverMetrics.js';
-import { depthLimit } from './graphql/validation/depthLimit.js';
+import { persistedQueriesPlugin } from "./graphql/plugins/persistedQueries.js";
+import pbacPlugin from "./graphql/plugins/pbac.js";
+import resolverMetricsPlugin from "./graphql/plugins/resolverMetrics.js";
+import { depthLimit } from "./graphql/validation/depthLimit.js";
 
 const apollo = new ApolloServer({
   schema,
@@ -112,13 +123,17 @@ const apollo = new ApolloServer({
   // TODO: Complete PBAC Apollo Server 5 compatibility in separate task
   // plugins: [persistedQueriesPlugin as any, pbacPlugin() as any],
   // Disable introspection and playground in production
-  introspection: process.env.NODE_ENV !== 'production',
+  introspection: process.env.NODE_ENV !== "production",
   // Note: ApolloServer 4+ doesn't have playground config, handled by Apollo Studio
   // GraphQL query validation rules
   validationRules: [depthLimit(8)],
-})
-await apollo.start()
-app.use('/graphql', express.json(), expressMiddleware(apollo, { context: getContext }))
+});
+await apollo.start();
+app.use(
+  "/graphql",
+  express.json(),
+  expressMiddleware(apollo, { context: getContext }),
+);
 
 // Subscriptions with Persisted Query validation
 
@@ -130,45 +145,48 @@ const wss = new WebSocketServer({
 const wsPersistedQueries = new WSPersistedQueriesMiddleware();
 const wsMiddleware = wsPersistedQueries.createMiddleware();
 
-useServer({
-  schema,
-  context: getContext,
-  ...wsMiddleware,
-}, wss);
+useServer(
+  {
+    schema,
+    context: getContext,
+    ...wsMiddleware,
+  },
+  wss,
+);
 
-if (process.env.NODE_ENV === 'production') {
-  const clientDistPath = path.resolve(__dirname, '../../client/dist');
+if (process.env.NODE_ENV === "production") {
+  const clientDistPath = path.resolve(__dirname, "../../client/dist");
   app.use(express.static(clientDistPath));
-  app.get('*', (_req, res) => {
-    res.sendFile(path.join(clientDistPath, 'index.html'));
+  app.get("*", (_req, res) => {
+    res.sendFile(path.join(clientDistPath, "index.html"));
   });
 }
 
-import { initSocket, getIO } from './realtime/socket.js'; // New import
+import { initSocket, getIO } from "./realtime/socket.js"; // New import
 
-const port = Number(process.env.PORT || 4000)
+const port = Number(process.env.PORT || 4000);
 httpServer.listen(port, async () => {
   logger.info(`Server listening on port ${port}`);
-  
+
   // Create sample data for development
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === "development") {
     setTimeout(async () => {
       try {
         await createSampleData();
       } catch (error) {
-        logger.warn('Failed to create sample data, continuing without it');
+        logger.warn("Failed to create sample data, continuing without it");
       }
     }, 2000); // Wait 2 seconds for connections to be established
   }
-})
+});
 
 // Initialize Socket.IO
 const io = initSocket(httpServer);
 
-import { closeNeo4jDriver } from './db/neo4j.js';
-import { closePostgresPool } from './db/postgres.js';
-import { closeRedisClient } from './db/redis.js';
-import { createSampleData } from './utils/sampleData.js';
+import { closeNeo4jDriver } from "./db/neo4j.js";
+import { closePostgresPool } from "./db/postgres.js";
+import { closeRedisClient } from "./db/redis.js";
+import { createSampleData } from "./utils/sampleData.js";
 
 // Graceful shutdown
 const shutdown = async (sig: NodeJS.Signals) => {
@@ -180,8 +198,13 @@ const shutdown = async (sig: NodeJS.Signals) => {
     closePostgresPool(),
     closeRedisClient(),
   ]);
-  httpServer.close(err => {
-    if (err) { logger.error(`Error during shutdown: ${err instanceof Error ? err.message : 'Unknown error'}`); process.exitCode = 1 }
+  httpServer.close((err) => {
+    if (err) {
+      logger.error(
+        `Error during shutdown: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+      process.exitCode = 1;
+    }
     process.exit();
   });
 };

--- a/server/src/routes/status.ts
+++ b/server/src/routes/status.ts
@@ -1,0 +1,11 @@
+import express, { Request, Response } from "express";
+import StatusService from "../services/StatusService.js";
+
+const router = express.Router();
+const statusService = new StatusService();
+
+router.get("/", (_req: Request, res: Response) => {
+  res.json(statusService.getStatus());
+});
+
+export default router;

--- a/server/src/services/StatusService.ts
+++ b/server/src/services/StatusService.ts
@@ -1,0 +1,23 @@
+export interface StatusInfo {
+  service: string;
+  version: string;
+  environment: string;
+  nodeVersion: string;
+  uptime: number;
+  timestamp: string;
+}
+
+export class StatusService {
+  getStatus(): StatusInfo {
+    return {
+      service: "intelgraph-server",
+      version: process.env.npm_package_version || "1.0.0",
+      environment: process.env.NODE_ENV || "development",
+      nodeVersion: process.version,
+      uptime: Math.round(process.uptime()),
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
+
+export default StatusService;

--- a/server/tests/status.test.ts
+++ b/server/tests/status.test.ts
@@ -1,0 +1,17 @@
+import request from "supertest";
+import express from "express";
+import statusRouter from "../src/routes/status.js";
+
+describe("Status endpoint", () => {
+  const app = express();
+  app.use("/api/status", statusRouter);
+
+  it("returns service information", async () => {
+    const res = await request(app).get("/api/status").expect(200);
+    expect(res.body).toHaveProperty("service");
+    expect(res.body).toHaveProperty("version");
+    expect(res.body).toHaveProperty("environment");
+    expect(res.body).toHaveProperty("uptime");
+    expect(res.body).toHaveProperty("timestamp");
+  });
+});


### PR DESCRIPTION
## Summary
- expose `/api/status` to report service version, env and uptime
- implement `StatusService` for centralized status info
- cover status route with basic test

## Testing
- `npm run lint` *(fails: 3414 problems)*
- `npm run format` *(fails: Map keys must be unique in .github/workflows/cd-deploy.yml)*
- `cd server && npm run test:coverage` *(33 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1086029088333b3c4f268bae565c8