### PR TITLE
feat: add streaming microexpression analysis

### DIFF
--- a/python/intelgraph_py/analytics/vision.py
+++ b/python/intelgraph_py/analytics/vision.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable, Iterator, List, Optional, Tuple
+
+import numpy as np
+
+try:
+  import cv2  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+  cv2 = None  # type: ignore
+
+
+def detect_faces(image: np.ndarray) -> List[Tuple[int, int, int, int]]:
+  """Detect faces in an image.
+
+  Uses OpenCV Haar cascades when available. If OpenCV is not installed,
+  returns an empty list.
+  """
+  if cv2 is None:
+    return []
+  gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+  classifier = cv2.CascadeClassifier(
+    cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
+  )
+  faces = classifier.detectMultiScale(gray, 1.1, 4)
+  return [(int(x), int(y), int(w), int(h)) for (x, y, w, h) in faces]
+
+
+nparray = np.ndarray
+
+
+class MicroexpressionAnalyzer:
+  """Incremental microexpression analyzer.
+
+  Maintains a sliding window of grayscale frames and computes the mean
+  frame-to-frame difference which can be treated as microexpression intensity.
+  """
+
+  def __init__(self, window: int = 3):
+    self.window = window
+    self.frames: deque[nparray] = deque(maxlen=window)
+
+  def update(self, frame: nparray) -> Optional[float]:
+    """Ingest a new frame and return the current microexpression score."""
+    if cv2 is not None:
+      gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    else:
+      gray = frame.mean(axis=2)
+    self.frames.append(gray)
+    if len(self.frames) < self.window:
+      return None
+    diffs = [
+      float(np.mean(np.abs(self.frames[i] - self.frames[i + 1])))
+      for i in range(self.window - 1)
+    ]
+    return float(np.mean(diffs))
+
+
+def ingest_stream(frames: Iterable[nparray], analyzer: MicroexpressionAnalyzer) -> Iterator[Optional[float]]:
+  """Consume a stream of frames yielding microexpression metrics."""
+  for frame in frames:
+    yield analyzer.update(frame)

--- a/python/tests/test_microexpression.py
+++ b/python/tests/test_microexpression.py
@@ -1,0 +1,20 @@
+import numpy as np
+from intelgraph_py.analytics.vision import MicroexpressionAnalyzer, ingest_stream, detect_faces
+
+
+def test_detect_faces_returns_list():
+  img = np.zeros((64, 64, 3), dtype=np.uint8)
+  faces = detect_faces(img)
+  assert isinstance(faces, list)
+
+
+def test_microexpression_streaming():
+  analyzer = MicroexpressionAnalyzer(window=3)
+  frames = [
+    np.zeros((2, 2, 3), dtype=np.uint8),
+    np.ones((2, 2, 3), dtype=np.uint8) * 10,
+    np.ones((2, 2, 3), dtype=np.uint8) * 20,
+  ]
+  metrics = list(ingest_stream(frames, analyzer))
+  assert metrics[0] is None and metrics[1] is None
+  assert isinstance(metrics[2], float) and metrics[2] > 0


### PR DESCRIPTION
## Summary
- add `vision` analytics module for facial detection and microexpression tracking
- support streaming frame ingestion with sliding-window analyzer
- test microexpression analyzer on synthetic frame stream

## Testing
- `PYTHONPATH=. pytest tests/test_microexpression.py`
- `npm test` *(fails: No mock result configured for query and multiple syntax issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a10920b3388333875af9ec062ab499