### PR TITLE
feat: enable telemetry and metrics automation

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,45 +1,59 @@
-import 'dotenv/config'
-import http from 'http'
-import express from 'express'
-import { ApolloServer } from '@apollo/server'
-import { expressMiddleware } from '@as-integrations/express4'
-import { makeExecutableSchema } from '@graphql-tools/schema'
-import { useServer } from 'graphql-ws/lib/use/ws'
-import { WebSocketServer } from 'ws'
-import cors from 'cors'
-import helmet from 'helmet'
-import rateLimit from 'express-rate-limit'
-import pino from 'pino'
-import { pinoHttp } from 'pino-http'
-import monitoringRouter from './routes/monitoring.js'
-import aiRouter from './routes/ai.js'
-import { typeDefs } from './graphql/schema.js'
-import resolvers from './graphql/resolvers/index.js'
-import { getContext } from './lib/auth.js'
-import { getNeo4jDriver } from './db/neo4j.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
+import "dotenv/config";
+import http from "http";
+import express from "express";
+import { ApolloServer } from "@apollo/server";
+import { expressMiddleware } from "@as-integrations/express4";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { useServer } from "graphql-ws/lib/use/ws";
+import { WebSocketServer } from "ws";
+import cors from "cors";
+import helmet from "helmet";
+import rateLimit from "express-rate-limit";
+import pino from "pino";
+import { pinoHttp } from "pino-http";
+import monitoringRouter from "./routes/monitoring.js";
+import aiRouter from "./routes/ai.js";
+import { typeDefs } from "./graphql/schema.js";
+import resolvers from "./graphql/resolvers/index.js";
+import { getContext } from "./lib/auth.js";
+import { getNeo4jDriver } from "./db/neo4j.js";
+import path from "path";
+import { fileURLToPath } from "url";
+import WSPersistedQueriesMiddleware from "./graphql/middleware/wsPersistedQueries.js";
+import telemetryService from "./monitoring/telemetry.js";
+import {
+  httpMetricsMiddleware,
+  graphqlMetricsMiddleware,
+} from "./monitoring/middleware.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const app = express()
+const app = express();
 const logger: pino.Logger = pino();
-app.use(helmet())
-app.use(cors({ origin: process.env.CORS_ORIGIN?.split(',') ?? ['http://localhost:3000'], credentials: true }))
-app.use(pinoHttp({ logger, redact: ['req.headers.authorization'] }))
+app.use(helmet());
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN?.split(",") ?? ["http://localhost:3000"],
+    credentials: true,
+  }),
+);
+app.use(pinoHttp({ logger, redact: ["req.headers.authorization"] }));
+app.use(telemetryService.expressMiddleware());
+app.use(httpMetricsMiddleware);
 
 // Rate limiting (exempt monitoring endpoints)
-app.use('/monitoring', monitoringRouter)
-app.use('/api/ai', aiRouter)
-app.use(rateLimit({
-  windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
-  max: Number(process.env.RATE_LIMIT_MAX || 600),
-  message: { error: 'Too many requests, please try again later' }
-}))
+app.use("/monitoring", monitoringRouter);
+app.use("/api/ai", aiRouter);
+app.use(
+  rateLimit({
+    windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
+    max: Number(process.env.RATE_LIMIT_MAX || 600),
+    message: { error: "Too many requests, please try again later" },
+  }),
+);
 
-app.get('/search/evidence', async (req, res) => {
+app.get("/search/evidence", async (req, res) => {
   const { q, skip = 0, limit = 10 } = req.query;
 
   if (!q) {
@@ -89,8 +103,10 @@ app.get('/search/evidence', async (req, res) => {
       },
     });
   } catch (error) {
-    logger.error(`Error in search/evidence: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    res.status(500).send({ error: 'Internal server error' });
+    logger.error(
+      `Error in search/evidence: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+    res.status(500).send({ error: "Internal server error" });
   } finally {
     await session.close();
   }
@@ -100,25 +116,33 @@ const schema = makeExecutableSchema({ typeDefs, resolvers });
 const httpServer = http.createServer(app);
 
 // GraphQL over HTTP
-import { persistedQueriesPlugin } from './graphql/plugins/persistedQueries.js';
-import pbacPlugin from './graphql/plugins/pbac.js';
-import resolverMetricsPlugin from './graphql/plugins/resolverMetrics.js';
-import { depthLimit } from './graphql/validation/depthLimit.js';
+import { persistedQueriesPlugin } from "./graphql/plugins/persistedQueries.js";
+import pbacPlugin from "./graphql/plugins/pbac.js";
+import resolverMetricsPlugin from "./graphql/plugins/resolverMetrics.js";
+import { depthLimit } from "./graphql/validation/depthLimit.js";
 
 const apollo = new ApolloServer({
   schema,
   // Order matters: PBAC early in execution lifecycle
-  plugins: [persistedQueriesPlugin as any, resolverMetricsPlugin as any],
+  plugins: [
+    persistedQueriesPlugin as any,
+    resolverMetricsPlugin as any,
+    graphqlMetricsMiddleware() as any,
+  ],
   // TODO: Complete PBAC Apollo Server 5 compatibility in separate task
   // plugins: [persistedQueriesPlugin as any, pbacPlugin() as any],
   // Disable introspection and playground in production
-  introspection: process.env.NODE_ENV !== 'production',
+  introspection: process.env.NODE_ENV !== "production",
   // Note: ApolloServer 4+ doesn't have playground config, handled by Apollo Studio
   // GraphQL query validation rules
   validationRules: [depthLimit(8)],
-})
-await apollo.start()
-app.use('/graphql', express.json(), expressMiddleware(apollo, { context: getContext }))
+});
+await apollo.start();
+app.use(
+  "/graphql",
+  express.json(),
+  expressMiddleware(apollo, { context: getContext }),
+);
 
 // Subscriptions with Persisted Query validation
 
@@ -130,45 +154,48 @@ const wss = new WebSocketServer({
 const wsPersistedQueries = new WSPersistedQueriesMiddleware();
 const wsMiddleware = wsPersistedQueries.createMiddleware();
 
-useServer({
-  schema,
-  context: getContext,
-  ...wsMiddleware,
-}, wss);
+useServer(
+  {
+    schema,
+    context: getContext,
+    ...wsMiddleware,
+  },
+  wss,
+);
 
-if (process.env.NODE_ENV === 'production') {
-  const clientDistPath = path.resolve(__dirname, '../../client/dist');
+if (process.env.NODE_ENV === "production") {
+  const clientDistPath = path.resolve(__dirname, "../../client/dist");
   app.use(express.static(clientDistPath));
-  app.get('*', (_req, res) => {
-    res.sendFile(path.join(clientDistPath, 'index.html'));
+  app.get("*", (_req, res) => {
+    res.sendFile(path.join(clientDistPath, "index.html"));
   });
 }
 
-import { initSocket, getIO } from './realtime/socket.js'; // New import
+import { initSocket, getIO } from "./realtime/socket.js"; // New import
 
-const port = Number(process.env.PORT || 4000)
+const port = Number(process.env.PORT || 4000);
 httpServer.listen(port, async () => {
   logger.info(`Server listening on port ${port}`);
-  
+
   // Create sample data for development
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === "development") {
     setTimeout(async () => {
       try {
         await createSampleData();
       } catch (error) {
-        logger.warn('Failed to create sample data, continuing without it');
+        logger.warn("Failed to create sample data, continuing without it");
       }
     }, 2000); // Wait 2 seconds for connections to be established
   }
-})
+});
 
 // Initialize Socket.IO
 const io = initSocket(httpServer);
 
-import { closeNeo4jDriver } from './db/neo4j.js';
-import { closePostgresPool } from './db/postgres.js';
-import { closeRedisClient } from './db/redis.js';
-import { createSampleData } from './utils/sampleData.js';
+import { closeNeo4jDriver } from "./db/neo4j.js";
+import { closePostgresPool } from "./db/postgres.js";
+import { closeRedisClient } from "./db/redis.js";
+import { createSampleData } from "./utils/sampleData.js";
 
 // Graceful shutdown
 const shutdown = async (sig: NodeJS.Signals) => {
@@ -180,8 +207,13 @@ const shutdown = async (sig: NodeJS.Signals) => {
     closePostgresPool(),
     closeRedisClient(),
   ]);
-  httpServer.close(err => {
-    if (err) { logger.error(`Error during shutdown: ${err instanceof Error ? err.message : 'Unknown error'}`); process.exitCode = 1 }
+  httpServer.close((err) => {
+    if (err) {
+      logger.error(
+        `Error during shutdown: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+      process.exitCode = 1;
+    }
     process.exit();
   });
 };

--- a/server/src/realtime/socket.js
+++ b/server/src/realtime/socket.js
@@ -1,6 +1,7 @@
-const { Server } = require('socket.io');
-const AuthService = require('../services/AuthService');
-const logger = require('../utils/logger');
+const { Server } = require("socket.io");
+const AuthService = require("../services/AuthService");
+const logger = require("../utils/logger");
+const { trackWebSocketConnection } = require("../monitoring/middleware");
 
 let connections = 0;
 let presenceDisabled = false;
@@ -11,52 +12,68 @@ let ioInstance = null;
 function initSocket(httpServer) {
   const io = new Server(httpServer, {
     cors: {
-      origin: process.env.CORS_ORIGIN || process.env.CLIENT_URL || 'http://localhost:3000',
+      origin:
+        process.env.CORS_ORIGIN ||
+        process.env.CLIENT_URL ||
+        "http://localhost:3000",
       credentials: true,
     },
   });
 
   // Namespace for realtime graph/AI
-  const ns = io.of('/realtime');
+  const ns = io.of("/realtime");
+  trackWebSocketConnection(ns);
   const auth = new AuthService();
   ns.use(async (socket, next) => {
     try {
-      const token = socket.handshake.auth?.token || socket.handshake.headers?.authorization?.replace('Bearer ', '');
+      const token =
+        socket.handshake.auth?.token ||
+        socket.handshake.headers?.authorization?.replace("Bearer ", "");
       const user = await auth.verifyToken(token);
-      if (!user) return next(new Error('Unauthorized'));
+      if (!user) return next(new Error("Unauthorized"));
       socket.user = user;
       next();
-    } catch (e) { next(new Error('Unauthorized')); }
+    } catch (e) {
+      next(new Error("Unauthorized"));
+    }
   });
 
-  ns.on('connection', (socket) => {
+  ns.on("connection", (socket) => {
     logger.info(`Realtime connected ${socket.id}`);
     connections += 1;
     if (connections > maxConnections && !presenceDisabled) {
       presenceDisabled = true;
-      ns.emit('presence_disabled', { reason: 'load_shed', maxConnections });
+      ns.emit("presence_disabled", { reason: "load_shed", maxConnections });
     }
     if (!presenceDisabled) {
       // announce join
-      ns.emit('presence:join', { userId: socket.user?.id, sid: socket.id, ts: Date.now() });
+      ns.emit("presence:join", {
+        userId: socket.user?.id,
+        sid: socket.id,
+        ts: Date.now(),
+      });
     }
-    socket.on('join_ai_entity', ({ entityId }) => {
+    socket.on("join_ai_entity", ({ entityId }) => {
       // add any RBAC validation here if required
       if (!entityId) return;
       socket.join(`ai:entity:${entityId}`);
     });
-    socket.on('leave_ai_entity', ({ entityId }) => {
+    socket.on("leave_ai_entity", ({ entityId }) => {
       if (!entityId) return;
       socket.leave(`ai:entity:${entityId}`);
     });
-    socket.on('disconnect', () => {
+    socket.on("disconnect", () => {
       connections = Math.max(0, connections - 1);
       if (presenceDisabled && connections < Math.floor(maxConnections * 0.9)) {
         presenceDisabled = false;
-        ns.emit('presence_enabled', { reason: 'load_normalized' });
+        ns.emit("presence_enabled", { reason: "load_normalized" });
       }
       if (!presenceDisabled) {
-        ns.emit('presence:leave', { userId: socket.user?.id, sid: socket.id, ts: Date.now() });
+        ns.emit("presence:leave", {
+          userId: socket.user?.id,
+          sid: socket.id,
+          ts: Date.now(),
+        });
       }
       logger.info(`Realtime disconnect ${socket.id}`);
     });
@@ -66,6 +83,8 @@ function initSocket(httpServer) {
   return io;
 }
 
-function getIO() { return ioInstance; }
+function getIO() {
+  return ioInstance;
+}
 
 module.exports = { initSocket, getIO };


### PR DESCRIPTION
## Summary
- add telemetry and http metric middlewares to capture request spans and metrics automatically
- enable GraphQL metrics plugin for resolver-level tracking
- wire websocket server to report connection and message metrics

## Testing
- `npm run format` *(fails: SyntaxError in workflow files)*
- `npm run lint` *(fails: 2675 errors, 739 warnings)*
- `npm test` *(fails: multiple test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a120cf23a883339dfe9412db6f6579