### PR TITLE
fix: trim debug console logs from client bootstrap

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,50 +1,55 @@
-import React, { useEffect, useMemo } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { Provider } from 'react-redux';
-import { ApolloProvider } from '@apollo/client';
-import { ThemeProvider, CssBaseline, Container, Box } from '@mui/material';
-import { getIntelGraphTheme } from './theme/intelgraphTheme';
+import React, { useEffect, useMemo } from "react";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from "react-router-dom";
+import { Provider } from "react-redux";
+import { ApolloProvider } from "@apollo/client";
+import { ThemeProvider, CssBaseline, Container, Box } from "@mui/material";
+import { getIntelGraphTheme } from "./theme/intelgraphTheme";
 
 // Store and Apollo setup
-import { store } from './store';
-import { apolloClient } from './services/apollo';
-import { useSelector } from 'react-redux';
+import { store } from "./store";
+import { apolloClient } from "./services/apollo";
+import { useSelector } from "react-redux";
 
 // Components
-import Layout from './components/common/Layout';
-import LoginPage from './components/auth/LoginPage';
-import Dashboard from './components/dashboard/Dashboard';
-import InvestigationPage from './components/investigation/InvestigationPage';
-import EnhancedGraphExplorer from './components/graph/EnhancedGraphExplorer';
-import AdvancedGraphView from './components/graph/AdvancedGraphView';
-import AdvancedCollaborativeGraph from './components/graph/AdvancedCollaborativeGraph';
-import GraphCollaborationDemo from './components/graph/GraphCollaborationDemo';
-import AIAnalysisPanel from './components/ai/AIAnalysisPanel';
-import NotFound from './components/common/NotFound';
-import AdminTokens from './components/admin/AdminTokens';
-import AdminRoles from './components/admin/AdminRoles';
-import PolicyPreview from './components/admin/PolicyPreview';
-import InstanceConnections from './components/admin/InstanceConnections';
-import ActivityLog from './components/activity/ActivityLog';
-import GraphVersionHistory from './components/versioning/GraphVersionHistory';
-import CopilotGoals from './components/ai/CopilotGoals';
-import AISuggestionsPanel from './components/ai/AISuggestionsPanel';
-import ReportGenerator from './components/reports/ReportGenerator';
-import SimulationPanel from './components/simulation/SimulationPanel';
-import SentimentPanel from './components/sentiment/SentimentPanel';
-import VisionPanel from './components/vision/VisionPanel';
-import GeoMapPage from './components/geoint/GeoMapPage';
-import SystemPanel from './components/system/SystemPanel';
-import FederatedSearchPanel from './components/federation/FederatedSearchPanel';
-import ExternalDataPanel from './components/osint/ExternalDataPanel';
-import IntelGraphCanvas from './components/graph/IntelGraphCanvas';
+import Layout from "./components/common/Layout";
+import LoginPage from "./components/auth/LoginPage";
+import Dashboard from "./components/dashboard/Dashboard";
+import InvestigationPage from "./components/investigation/InvestigationPage";
+import EnhancedGraphExplorer from "./components/graph/EnhancedGraphExplorer";
+import AdvancedGraphView from "./components/graph/AdvancedGraphView";
+import AdvancedCollaborativeGraph from "./components/graph/AdvancedCollaborativeGraph";
+import GraphCollaborationDemo from "./components/graph/GraphCollaborationDemo";
+import AIAnalysisPanel from "./components/ai/AIAnalysisPanel";
+import NotFound from "./components/common/NotFound";
+import AdminTokens from "./components/admin/AdminTokens";
+import AdminRoles from "./components/admin/AdminRoles";
+import PolicyPreview from "./components/admin/PolicyPreview";
+import InstanceConnections from "./components/admin/InstanceConnections";
+import ActivityLog from "./components/activity/ActivityLog";
+import GraphVersionHistory from "./components/versioning/GraphVersionHistory";
+import CopilotGoals from "./components/ai/CopilotGoals";
+import AISuggestionsPanel from "./components/ai/AISuggestionsPanel";
+import ReportGenerator from "./components/reports/ReportGenerator";
+import SimulationPanel from "./components/simulation/SimulationPanel";
+import SentimentPanel from "./components/sentiment/SentimentPanel";
+import VisionPanel from "./components/vision/VisionPanel";
+import GeoMapPage from "./components/geoint/GeoMapPage";
+import SystemPanel from "./components/system/SystemPanel";
+import FederatedSearchPanel from "./components/federation/FederatedSearchPanel";
+import ExternalDataPanel from "./components/osint/ExternalDataPanel";
+import IntelGraphCanvas from "./components/graph/IntelGraphCanvas";
 
 function ThemedAppShell({ children }) {
-  const mode = useSelector((state) => state.ui.theme || 'light');
-  const rtl = useSelector((state) => state.ui.rtl ? 'rtl' : 'ltr');
+  const mode = useSelector((state) => state.ui.theme || "light");
+  const rtl = useSelector((state) => (state.ui.rtl ? "rtl" : "ltr"));
   const theme = useMemo(() => getIntelGraphTheme(mode), [mode]);
   useEffect(() => {
-    if (typeof document !== 'undefined') {
+    if (typeof document !== "undefined") {
       document.documentElement.dir = rtl;
     }
   }, [rtl]);
@@ -57,10 +62,6 @@ function ThemedAppShell({ children }) {
 }
 
 function App() {
-  useEffect(() => {
-    console.log('🚀 IntelGraph Platform Starting...');
-  }, []);
-
   return (
     <Provider store={store}>
       <ApolloProvider client={apolloClient}>
@@ -70,32 +71,207 @@ function App() {
               <Route path="/login" element={<LoginPage />} />
               <Route path="/" element={<Layout />}>
                 <Route index element={<Navigate to="/dashboard" replace />} />
-                <Route path="dashboard" element={<Container maxWidth="lg"><Dashboard /></Container>} />
-                <Route path="investigations" element={<Container maxWidth="lg"><InvestigationPage /></Container>} />
-                <Route path="graph" element={<Container maxWidth="xl"><EnhancedGraphExplorer /></Container>} />
-                <Route path="graph/advanced" element={<Box sx={{height:'calc(100vh - 120px)'}}><AdvancedGraphView /></Box>} />
-                <Route path="graph/advanced/:id" element={<Box sx={{height:'calc(100vh - 120px)'}}><AdvancedGraphView /></Box>} />
-                <Route path="graph/:id" element={<Container maxWidth="xl"><EnhancedGraphExplorer /></Container>} />
+                <Route
+                  path="dashboard"
+                  element={
+                    <Container maxWidth="lg">
+                      <Dashboard />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="investigations"
+                  element={
+                    <Container maxWidth="lg">
+                      <InvestigationPage />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="graph"
+                  element={
+                    <Container maxWidth="xl">
+                      <EnhancedGraphExplorer />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="graph/advanced"
+                  element={
+                    <Box sx={{ height: "calc(100vh - 120px)" }}>
+                      <AdvancedGraphView />
+                    </Box>
+                  }
+                />
+                <Route
+                  path="graph/advanced/:id"
+                  element={
+                    <Box sx={{ height: "calc(100vh - 120px)" }}>
+                      <AdvancedGraphView />
+                    </Box>
+                  }
+                />
+                <Route
+                  path="graph/:id"
+                  element={
+                    <Container maxWidth="xl">
+                      <EnhancedGraphExplorer />
+                    </Container>
+                  }
+                />
                 <Route path="graph/new-canvas" element={<IntelGraphCanvas />} />
-                <Route path="graph/collaborative" element={<Box sx={{height:'calc(100vh - 120px)'}}><AdvancedCollaborativeGraph /></Box>} />
-                <Route path="graph/demo" element={<Box sx={{height:'calc(100vh - 120px)'}}><GraphCollaborationDemo /></Box>} />
-                <Route path="versions" element={<Container maxWidth="lg"><GraphVersionHistory /></Container>} />
-                <Route path="activity" element={<Container maxWidth="lg"><ActivityLog /></Container>} />
-                <Route path="admin/instances" element={<Container maxWidth="lg"><InstanceConnections /></Container>} />
-                <Route path="admin/roles" element={<Container maxWidth="lg"><AdminRoles /></Container>} />
-                <Route path="admin/policy" element={<Container maxWidth="lg"><PolicyPreview /></Container>} />
-                <Route path="copilot" element={<Container maxWidth="lg"><CopilotGoals /></Container>} />
-                <Route path="ai/suggestions" element={<Container maxWidth="lg"><AISuggestionsPanel /></Container>} />
-                <Route path="ai/analysis" element={<Box sx={{height:'calc(100vh - 120px)'}}><AIAnalysisPanel /></Box>} />
-                <Route path="reports" element={<Container maxWidth="lg"><ReportGenerator /></Container>} />
-                <Route path="vision" element={<Container maxWidth="lg"><VisionPanel /></Container>} />
-                <Route path="geoint" element={<Container maxWidth="xl"><GeoMapPage /></Container>} />
-                <Route path="system" element={<Container maxWidth="lg"><SystemPanel /></Container>} />
-                <Route path="federation" element={<Container maxWidth="lg"><FederatedSearchPanel /></Container>} />
-                <Route path="external" element={<Container maxWidth="lg"><ExternalDataPanel /></Container>} />
-                <Route path="simulate" element={<Container maxWidth="lg"><SimulationPanel /></Container>} />
-                <Route path="sentiment" element={<Container maxWidth="lg"><SentimentPanel /></Container>} />
-                <Route path="admin/tokens" element={<Container maxWidth="lg"><AdminTokens /></Container>} />
+                <Route
+                  path="graph/collaborative"
+                  element={
+                    <Box sx={{ height: "calc(100vh - 120px)" }}>
+                      <AdvancedCollaborativeGraph />
+                    </Box>
+                  }
+                />
+                <Route
+                  path="graph/demo"
+                  element={
+                    <Box sx={{ height: "calc(100vh - 120px)" }}>
+                      <GraphCollaborationDemo />
+                    </Box>
+                  }
+                />
+                <Route
+                  path="versions"
+                  element={
+                    <Container maxWidth="lg">
+                      <GraphVersionHistory />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="activity"
+                  element={
+                    <Container maxWidth="lg">
+                      <ActivityLog />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="admin/instances"
+                  element={
+                    <Container maxWidth="lg">
+                      <InstanceConnections />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="admin/roles"
+                  element={
+                    <Container maxWidth="lg">
+                      <AdminRoles />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="admin/policy"
+                  element={
+                    <Container maxWidth="lg">
+                      <PolicyPreview />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="copilot"
+                  element={
+                    <Container maxWidth="lg">
+                      <CopilotGoals />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="ai/suggestions"
+                  element={
+                    <Container maxWidth="lg">
+                      <AISuggestionsPanel />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="ai/analysis"
+                  element={
+                    <Box sx={{ height: "calc(100vh - 120px)" }}>
+                      <AIAnalysisPanel />
+                    </Box>
+                  }
+                />
+                <Route
+                  path="reports"
+                  element={
+                    <Container maxWidth="lg">
+                      <ReportGenerator />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="vision"
+                  element={
+                    <Container maxWidth="lg">
+                      <VisionPanel />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="geoint"
+                  element={
+                    <Container maxWidth="xl">
+                      <GeoMapPage />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="system"
+                  element={
+                    <Container maxWidth="lg">
+                      <SystemPanel />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="federation"
+                  element={
+                    <Container maxWidth="lg">
+                      <FederatedSearchPanel />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="external"
+                  element={
+                    <Container maxWidth="lg">
+                      <ExternalDataPanel />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="simulate"
+                  element={
+                    <Container maxWidth="lg">
+                      <SimulationPanel />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="sentiment"
+                  element={
+                    <Container maxWidth="lg">
+                      <SentimentPanel />
+                    </Container>
+                  }
+                />
+                <Route
+                  path="admin/tokens"
+                  element={
+                    <Container maxWidth="lg">
+                      <AdminTokens />
+                    </Container>
+                  }
+                />
               </Route>
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/client/src/main.apollo.jsx
+++ b/client/src/main.apollo.jsx
@@ -1,38 +1,25 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.apollo.jsx'
-import './styles/globals.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.apollo.jsx";
+import "./styles/globals.css";
 
-console.log('🚀 Starting Apollo IntelGraph App...');
-
-// Global error handlers
-window.addEventListener('error', (event) => {
-  console.error('🚨 GLOBAL ERROR:', event.error);
-});
-
-window.addEventListener('unhandledrejection', (event) => {
-  console.error('🚨 UNHANDLED PROMISE REJECTION:', event.reason);
-});
-
-const root = document.getElementById('root');
+const root = document.getElementById("root");
 
 if (!root) {
-  console.error('❌ CRITICAL: Root element not found!');
+  document.body.innerHTML = `
+    <div style="padding: 20px; background: #ffcdd2; border: 2px solid #f44336; border-radius: 8px; margin: 20px; font-family: Arial;">
+      <h1 style="color: #d32f2f;">❌ Apollo App Failed</h1>
+      <p><strong>Root element not found!</strong></p>
+    </div>
+  `;
 } else {
   try {
-    console.log('📍 Creating React root with Redux + MUI + Apollo...');
-    
     ReactDOM.createRoot(root).render(
       <React.StrictMode>
         <App />
-      </React.StrictMode>
+      </React.StrictMode>,
     );
-    
-    console.log('✅ Apollo app rendered successfully');
-    
   } catch (error) {
-    console.error('❌ CRITICAL ERROR during render:', error);
-    
     root.innerHTML = `
       <div style="padding: 20px; background: #ffcdd2; border: 2px solid #f44336; border-radius: 8px; margin: 20px; font-family: Arial;">
         <h1 style="color: #d32f2f;">❌ Apollo App Failed</h1>

--- a/client/src/main.basic.jsx
+++ b/client/src/main.basic.jsx
@@ -1,47 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.basic.jsx'
-
-console.log('🚀 Starting Basic IntelGraph App...');
-
-// Detailed logging for debugging
-console.log('📍 Environment check:');
-console.log('- React version:', React.version);
-console.log('- ReactDOM:', ReactDOM);
-console.log('- document.readyState:', document.readyState);
-console.log('- window.location:', window.location.href);
-
-// Global error handlers
-window.addEventListener('error', (event) => {
-  console.error('🚨 GLOBAL ERROR:', event.error);
-  console.error('📍 Error details:', {
-    message: event.message,
-    filename: event.filename,
-    lineno: event.lineno,
-    colno: event.colno,
-    stack: event.error?.stack
-  });
-});
-
-window.addEventListener('unhandledrejection', (event) => {
-  console.error('🚨 UNHANDLED PROMISE REJECTION:', event.reason);
-});
-
-// Wait for DOM to be ready
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initializeApp);
-} else {
-  initializeApp();
-}
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.basic.jsx";
 
 function initializeApp() {
-  console.log('📍 Initializing app...');
-  
-  const root = document.getElementById('root');
-  console.log('📍 Root element:', root);
-  
+  const root = document.getElementById("root");
   if (!root) {
-    console.error('❌ CRITICAL: Root element not found!');
     document.body.innerHTML = `
       <div style="padding: 20px; background: #ffcdd2; border: 2px solid #f44336; margin: 20px; border-radius: 8px;">
         <h1 style="color: #d32f2f;">❌ Critical Error</h1>
@@ -52,46 +15,14 @@ function initializeApp() {
     `;
     return;
   }
-  
-  console.log('✅ Root element found:', {
-    id: root.id,
-    tagName: root.tagName,
-    className: root.className,
-    innerHTML: root.innerHTML.substring(0, 100)
-  });
-  
+
   try {
-    console.log('📍 Creating React root...');
-    const reactRoot = ReactDOM.createRoot(root);
-    console.log('✅ React root created successfully');
-    
-    console.log('📍 Rendering App component...');
-    reactRoot.render(
+    ReactDOM.createRoot(root).render(
       <React.StrictMode>
         <App />
-      </React.StrictMode>
+      </React.StrictMode>,
     );
-    console.log('✅ App component render called successfully');
-    
-    // Verify rendering after a short delay
-    setTimeout(() => {
-      const currentContent = root.innerHTML;
-      console.log('📍 Post-render verification:');
-      console.log('- Root innerHTML length:', currentContent.length);
-      console.log('- Root innerHTML preview:', currentContent.substring(0, 200));
-      
-      if (currentContent.length > 50) {
-        console.log('✅ SUCCESS: React content has been rendered to the DOM!');
-      } else {
-        console.error('❌ WARNING: Root element appears to be empty after render');
-      }
-    }, 1000);
-    
   } catch (error) {
-    console.error('❌ CRITICAL ERROR during React initialization:', error);
-    console.error('Error stack:', error.stack);
-    
-    // Fallback error display
     root.innerHTML = `
       <div style="padding: 20px; background: #ffcdd2; border: 2px solid #f44336; border-radius: 8px; margin: 20px; font-family: Arial;">
         <h1 style="color: #d32f2f;">❌ React Initialization Failed</h1>
@@ -106,4 +37,8 @@ function initializeApp() {
   }
 }
 
-console.log('📍 main.basic.jsx script execution completed');
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeApp);
+} else {
+  initializeApp();
+}


### PR DESCRIPTION
## Summary
- remove verbose console debugging from `main.basic.jsx` and `main.apollo.jsx`
- strip startup log call from root `App` component

## Testing
- `npm run lint` (fails: 3414 problems)
- `npm test` (fails: multiple failing tests)


------
https://chatgpt.com/codex/tasks/task_e_68a11fc024608333824e32402f096640