### PR TITLE
feat: add metrics endpoint and dev bootstrap

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,6 +25,8 @@ jobs:
           cache: 'npm'
       - name: Install root deps
         run: npm ci
+      - name: Prettier check
+        run: npx prettier --check .
       - name: Lint root
         run: npm run lint --if-present
       - name: Test server
@@ -37,6 +39,15 @@ jobs:
         run: |
           npm ci
           npm run test -- --run --reporter=junit
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Python lint
+        run: |
+          pip install black flake8 mypy
+          black --check python ml
+          flake8 python ml
+          mypy python ml --ignore-missing-imports
 
   docker-build-scan-push:
     needs: build-test

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ No code merges that break the golden path workflow:
 
 **Investigation → Entities → Relationships → Copilot → Results**
 
-### Quickstart
+### Getting Started
 ```bash
 git clone https://github.com/BrianCLong/intelgraph.git
 cd intelgraph
 cp .env.example .env
-make up
-make seed
-make smoke
+./scripts/dev-up.sh
 ```
+
+This single command boots Neo4j, Redis, and Postgres, applies all migrations, seeds demo data, and starts both the backend and frontend services.
 
 ✅ If smoke tests pass → you’re ready to code.
 ❌ If not → fix before contributing.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+pythonpath = ["."]
 
 [tool.setuptools]
 packages = ["intelgraph_py"]

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -97,6 +97,14 @@ wait_for_service "postgres"
 wait_for_service "neo4j"
 wait_for_service "redis"
 
+# Run migrations and seed demo data
+echo -e "${YELLOW}🗄 Applying database migrations...${NC}"
+docker-compose -f docker-compose.dev.yml exec -T server npm run migrate >/dev/null
+
+echo -e "${YELLOW}🌱 Seeding database...${NC}"
+docker-compose -f docker-compose.dev.yml exec -T server npm run seed:demo >/dev/null
+cat server/db/seeds/neo4j/sample_graph.cypher | docker-compose -f docker-compose.dev.yml exec -T neo4j cypher-shell -u neo4j -p devpassword >/dev/null
+
 # Give the app services a bit more time
 sleep 10
 

--- a/server/src/appFactory.ts
+++ b/server/src/appFactory.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import config from './config/index.js';
 import logger from './utils/logger.js';
+import { register } from './monitoring/metrics.js';
 
 interface AppOptions {
   lightweight?: boolean;
@@ -37,6 +38,11 @@ function createApp({ lightweight = false }: AppOptions = {}) {
       environment: config.env,
       version: '1.0.0'
     });
+  });
+
+  app.get('/metrics', async (_req, res) => {
+    res.set('Content-Type', register.contentType);
+    res.end(await register.metrics());
   });
 
   if (lightweight) return app;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,6 +20,7 @@ import { getNeo4jDriver } from './db/neo4j.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
+import { register } from './monitoring/metrics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -94,6 +95,15 @@ app.get('/search/evidence', async (req, res) => {
   } finally {
     await session.close();
   }
+});
+
+app.get('/health', (_req, res) => {
+  res.status(200).json({ status: 'OK' });
+});
+
+app.get('/metrics', async (_req, res) => {
+  res.set('Content-Type', register.contentType);
+  res.end(await register.metrics());
 });
 
 const schema = makeExecutableSchema({ typeDefs, resolvers });


### PR DESCRIPTION
## Summary
- run migrations and seed demo data in `dev-up.sh`
- expose `/metrics` endpoint in server
- document one-command setup in README
- enforce prettier and python linting in CI
- add pythonpath for tests and normalize dev bootstrap script

## Testing
- `cd python && pytest`
- `npm test` *(fails: TypeScript parsing errors, missing mocks, timeouts)*
- `npx playwright test` *(fails: React app mount error)*

------
https://chatgpt.com/codex/tasks/task_e_68a130bdd6748333998fb9c9af3b285b