### PR TITLE
feat: wire insight approval ui

### DIFF
--- a/client/src/ai/insightsHooks.js
+++ b/client/src/ai/insightsHooks.js
@@ -1,35 +1,36 @@
 import { gql } from "@apollo/client";
+import $ from "jquery";
 
 export const INSIGHTS_QUERY = gql`
-  query GetInsights($status: String) { 
-    insights(status: $status) { 
-      id 
-      kind 
-      payload 
-      status 
+  query GetInsights($status: String) {
+    insights(status: $status) {
+      id
+      kind
+      payload
+      status
       createdAt
       jobId
-    } 
+    }
   }
 `;
 
 export const APPROVE_MUT = gql`
-  mutation ApproveInsight($id: ID!) { 
-    approveInsight(id: $id) { 
-      id 
-      status 
+  mutation ApproveInsight($id: ID!) {
+    approveInsight(id: $id) {
+      id
+      status
       decidedAt
-    } 
+    }
   }
 `;
 
 export const REJECT_MUT = gql`
-  mutation RejectInsight($id: ID!, $reason: String) { 
-    rejectInsight(id: $id, reason: $reason) { 
-      id 
-      status 
+  mutation RejectInsight($id: ID!, $reason: String) {
+    rejectInsight(id: $id, reason: $reason) {
+      id
+      status
       decidedAt
-    } 
+    }
   }
 `;
 
@@ -46,7 +47,11 @@ export const AI_EXTRACT_ENTITIES_MUT = gql`
 
 export const AI_LINK_PREDICT_MUT = gql`
   mutation PredictLinks($graphSnapshotId: ID!, $topK: Int, $jobId: ID) {
-    aiLinkPredict(graphSnapshotId: $graphSnapshotId, topK: $topK, jobId: $jobId) {
+    aiLinkPredict(
+      graphSnapshotId: $graphSnapshotId
+      topK: $topK
+      jobId: $jobId
+    ) {
       id
       kind
       status
@@ -73,20 +78,65 @@ export function useInsightApproval() {
     },
     async rejectInsight(apollo, id, reason) {
       return apollo.mutate({ mutation: REJECT_MUT, variables: { id, reason } });
-    }
+    },
   };
 }
 
 export function useAIOperations() {
   return {
     async extractEntities(apollo, docs, jobId) {
-      return apollo.mutate({ mutation: AI_EXTRACT_ENTITIES_MUT, variables: { docs, jobId } });
+      return apollo.mutate({
+        mutation: AI_EXTRACT_ENTITIES_MUT,
+        variables: { docs, jobId },
+      });
     },
     async predictLinks(apollo, graphSnapshotId, topK = 50, jobId) {
-      return apollo.mutate({ mutation: AI_LINK_PREDICT_MUT, variables: { graphSnapshotId, topK, jobId } });
+      return apollo.mutate({
+        mutation: AI_LINK_PREDICT_MUT,
+        variables: { graphSnapshotId, topK, jobId },
+      });
     },
     async detectCommunities(apollo, graphSnapshotId, jobId) {
-      return apollo.mutate({ mutation: AI_COMMUNITY_DETECT_MUT, variables: { graphSnapshotId, jobId } });
-    }
+      return apollo.mutate({
+        mutation: AI_COMMUNITY_DETECT_MUT,
+        variables: { graphSnapshotId, jobId },
+      });
+    },
   };
+}
+
+export function wireInsightApprovalUI(apollo) {
+  $(document).on("click", ".insight-approve", function () {
+    const id = $(this).data("id");
+    apollo.mutate({ mutation: APPROVE_MUT, variables: { id } }).then(() => {
+      $(`#insight-${id}`).fadeOut(200);
+    });
+  });
+  $(document).on("click", ".insight-reject", function () {
+    const id = $(this).data("id");
+    apollo.mutate({ mutation: REJECT_MUT, variables: { id } }).then(() => {
+      $(`#insight-${id}`).fadeOut(200);
+    });
+  });
+}
+
+export function renderPendingInsights(apollo) {
+  apollo
+    .query({ query: INSIGHTS_QUERY, variables: { status: "PENDING" } })
+    .then(({ data }) => {
+      const $list = $("#pending-insights");
+      $list.empty();
+      data.insights.forEach((i) => {
+        $list.append(
+          `
+        <li id="insight-${i.id}" class="p-2 border rounded mb-2">
+          <pre class="overflow-x-auto">${JSON.stringify(i.payload, null, 2)}</pre>
+          <div class="mt-2">
+            <button class="insight-approve" data-id="${i.id}">Approve</button>
+            <button class="insight-reject" data-id="${i.id}">Reject</button>
+          </div>
+        </li>`,
+        );
+      });
+    });
 }


### PR DESCRIPTION
## Summary
- render pending AI insights with approve/reject buttons
- wire UI actions to GraphQL approve/reject mutations

## Testing
- `npx eslint client/src/ai/insightsHooks.js` (fails: Cannot find package '@eslint/js')
- `npx prettier client/src/ai/insightsHooks.js -w`
- `npm test` (fails: TypeError: Cannot read properties of undefined (reading 'address'))

------
https://chatgpt.com/codex/tasks/task_e_68a13f0449708333ae576600da8585b5