### PR TITLE
feat(ml): cache community detection results with Redis

### DIFF
--- a/ml/app/cache.py
+++ b/ml/app/cache.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Caching utilities for graph analytics using Redis."""
+
+import json
+import hashlib
+import os
+import logging
+from typing import Any, Dict, Iterable, Tuple
+
+import asyncio
+from redis.asyncio import Redis
+from redis.exceptions import RedisError
+
+from .monitoring import track_cache_operation, track_error
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+CACHE_TTL = int(os.getenv("COMMUNITY_CACHE_TTL", "3600"))
+_CACHE_PREFIX = "community:"
+
+_redis_client: Redis | None = None
+
+async def get_client() -> Redis:
+    """Get or create the Redis client."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = Redis.from_url(
+            REDIS_URL, encoding="utf-8", decode_responses=True
+        )
+    return _redis_client
+
+
+def fingerprint_graph(
+    edges: Iterable[Tuple[Any, Any]], algorithm: str, resolution: float
+) -> str:
+    """Create a stable fingerprint for a graph."""
+    edge_strings = [f"{min(u, v)}-{max(u, v)}" for u, v in edges]
+    edge_strings.sort()
+    base = f"{algorithm}|{resolution}|" + "|".join(edge_strings)
+    return hashlib.sha256(base.encode("utf-8")).hexdigest()
+
+
+async def get_cached_communities(fingerprint: str) -> Dict[str, Any] | None:
+    """Fetch cached community detection result if available."""
+    try:
+        client = await get_client()
+        cached = await client.get(_CACHE_PREFIX + fingerprint)
+        if cached:
+            track_cache_operation("community_detect", True)
+            return json.loads(cached)
+        track_cache_operation("community_detect", False)
+    except RedisError as exc:
+        logger.warning("Redis error during cache fetch: %s", exc)
+        track_error("cache", type(exc).__name__)
+    return None
+
+
+async def set_cached_communities(fingerprint: str, value: Dict[str, Any]) -> None:
+    """Store community detection result in cache."""
+    try:
+        client = await get_client()
+        await client.set(
+            _CACHE_PREFIX + fingerprint, json.dumps(value), ex=CACHE_TTL
+        )
+    except RedisError as exc:
+        logger.warning("Redis error during cache store: %s", exc)
+        track_error("cache", type(exc).__name__)


### PR DESCRIPTION
## Summary
- cache community detection outputs in Redis using graph fingerprinting and TTL
- track cache hit/miss metrics and handle Redis errors gracefully
- add unit tests for cache hit/miss scenarios

## Testing
- `PYTHONPATH=/workspace/intelgraph pytest ml/tests/test_tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68a14352cf9c8333af41b1d4835b7901