### PR TITLE
feat: add Celery scheduled analytics with alerts

### DIFF
--- a/python/apps/api/main.py
+++ b/python/apps/api/main.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI, Depends
+from pydantic import BaseModel
+from intelgraph_py.db import SessionLocal, Schedule, Subscription, init_db
+
+app = FastAPI()
+
+
+def get_db():
+  db = SessionLocal()
+  try:
+    yield db
+  finally:
+    db.close()
+
+
+class ScheduleCreate(BaseModel):
+  graph_id: str
+  interval: int
+  thresholds: dict = {}
+
+
+@app.post("/schedules")
+def create_schedule(data: ScheduleCreate, db = Depends(get_db)):
+  sched = Schedule(graph_id=data.graph_id, interval=data.interval, thresholds=data.thresholds)
+  db.add(sched)
+  db.commit()
+  db.refresh(sched)
+  return {"id": sched.id}
+
+
+class SubscriptionCreate(BaseModel):
+  graph_id: str
+  contact: str
+
+
+@app.post("/subscriptions")
+def create_subscription(data: SubscriptionCreate, db = Depends(get_db)):
+  sub = Subscription(graph_id=data.graph_id, contact=data.contact)
+  db.add(sub)
+  db.commit()
+  db.refresh(sub)
+  return {"id": sub.id}
+
+
+init_db()

--- a/python/intelgraph_py/db.py
+++ b/python/intelgraph_py/db.py
@@ -1,0 +1,34 @@
+import os
+from sqlalchemy import create_engine, Column, Integer, String, JSON, DateTime, func
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://localhost/intelgraph")
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+class Schedule(Base):
+  __tablename__ = "schedules"
+  id = Column(Integer, primary_key=True, index=True)
+  graph_id = Column(String, nullable=False)
+  interval = Column(Integer, nullable=False)
+  thresholds = Column(JSON, default={})
+  last_run_metrics = Column(JSON, nullable=True)
+
+class Subscription(Base):
+  __tablename__ = "subscriptions"
+  id = Column(Integer, primary_key=True, index=True)
+  graph_id = Column(String, nullable=False)
+  contact = Column(String, nullable=False)
+
+class AlertLog(Base):
+  __tablename__ = "alert_logs"
+  id = Column(Integer, primary_key=True, index=True)
+  graph_id = Column(String, nullable=False)
+  detail = Column(JSON, nullable=False)
+  created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+def init_db():
+  Base.metadata.create_all(bind=engine)

--- a/python/intelgraph_py/detection.py
+++ b/python/intelgraph_py/detection.py
@@ -1,0 +1,18 @@
+from typing import Dict, Optional
+
+
+def detect_changes(prev: Optional[Dict], curr: Dict, thresholds: Dict) -> Dict:
+  """Compare previous and current metrics and return anomalies."""
+  anomalies: Dict[str, float] = {}
+  if prev:
+    node_drift = abs(curr.get("nodes", 0) - prev.get("nodes", 0)) / max(prev.get("nodes", 1), 1)
+    if node_drift > thresholds.get("node_drift", 0.1):
+      anomalies["nodes"] = node_drift
+    edge_drift = abs(curr.get("edges", 0) - prev.get("edges", 0)) / max(prev.get("edges", 1), 1)
+    if edge_drift > thresholds.get("edge_drift", 0.1):
+      anomalies["edges"] = edge_drift
+    if abs(curr.get("clusters", 0) - prev.get("clusters", 0)) > thresholds.get("cluster_shift", 1):
+      anomalies["clusters"] = curr.get("clusters", 0) - prev.get("clusters", 0)
+  if curr.get("metric_score", 0) > thresholds.get("metric_score", 1.0):
+    anomalies["metric_score"] = curr.get("metric_score", 0)
+  return anomalies

--- a/python/intelgraph_py/tasks.py
+++ b/python/intelgraph_py/tasks.py
@@ -1,0 +1,44 @@
+import os
+from celery import Celery
+from typing import Dict
+from .db import SessionLocal, Schedule, Subscription, AlertLog
+from .detection import detect_changes
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+
+celery_app = Celery("intelgraph", broker=REDIS_URL, backend=REDIS_URL)
+celery_app.conf.task_default_queue = "intelgraph"
+
+ALERT_OUTBOX: list[tuple[str, Dict]] = []
+
+def fetch_graph_metrics(graph_id: str) -> Dict:
+  # Placeholder analytics; real implementation would query graph DB
+  return {"nodes": 0, "edges": 0, "clusters": 0, "metric_score": 0.0}
+
+def notify_subscribers(graph_id: str, detail: Dict):
+  session = SessionLocal()
+  try:
+    subs = session.query(Subscription).filter_by(graph_id=graph_id).all()
+    for sub in subs:
+      ALERT_OUTBOX.append((sub.contact, detail))
+  finally:
+    session.close()
+
+@celery_app.task
+def run_analytics(schedule_id: int):
+  session = SessionLocal()
+  try:
+    sched = session.get(Schedule, schedule_id)
+    if not sched:
+      return
+    metrics = fetch_graph_metrics(sched.graph_id)
+    changes = detect_changes(sched.last_run_metrics, metrics, sched.thresholds or {})
+    if changes:
+      log = AlertLog(graph_id=sched.graph_id, detail=changes)
+      session.add(log)
+      session.commit()
+      notify_subscribers(sched.graph_id, changes)
+    sched.last_run_metrics = metrics
+    session.commit()
+  finally:
+    session.close()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,12 @@ dependencies = [
   "networkx>=3.3",
   "scikit-learn>=1.4",
   "numpy>=1.26",
-  "gensim>=4.3"
+  "gensim>=4.3",
+  "celery>=5.3",
+  "fastapi>=0.111",
+  "redis>=5.0",
+  "sqlalchemy>=2.0",
+  "psycopg2-binary>=2.9"
 ]
 
 [project.optional-dependencies]

--- a/python/tests/test_task_flow.py
+++ b/python/tests/test_task_flow.py
@@ -1,0 +1,47 @@
+import os
+import importlib
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+root = Path(__file__).resolve().parents[1]
+db_file = root / "test.db"
+os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
+
+sys.path.append(str(root))
+
+# Reload modules to pick up new DB URL
+from intelgraph_py import db as db_module
+importlib.reload(db_module)
+db_module.init_db()
+
+from intelgraph_py import tasks as task_module
+importlib.reload(task_module)
+
+from apps.api.main import app
+
+
+def test_task_flow(monkeypatch):
+  client = TestClient(app)
+
+  res = client.post("/schedules", json={"graph_id": "g1", "interval": 60, "thresholds": {"node_drift": 0.2}})
+  sched_id = res.json()["id"]
+  client.post("/subscriptions", json={"graph_id": "g1", "contact": "user@example.com"})
+
+  session = db_module.SessionLocal()
+  sched = session.get(db_module.Schedule, sched_id)
+  sched.last_run_metrics = {"nodes": 100, "edges": 200, "clusters": 3, "metric_score": 0.5}
+  session.commit()
+  session.close()
+
+  def fake_metrics(graph_id: str):
+    return {"nodes": 130, "edges": 200, "clusters": 3, "metric_score": 0.5}
+
+  monkeypatch.setattr(task_module, "fetch_graph_metrics", fake_metrics)
+  task_module.celery_app.conf.task_always_eager = True
+  task_module.run_analytics.delay(sched_id)
+
+  session = db_module.SessionLocal()
+  assert session.query(db_module.AlertLog).count() == 1
+  session.close()
+  assert task_module.ALERT_OUTBOX[0][0] == "user@example.com"


### PR DESCRIPTION
## Summary
- add Celery task system for periodic analytics and alerting
- implement change detection and FastAPI routes for schedules and subscriptions
- log alerts and schedules in Postgres via SQLAlchemy

## Testing
- `npm run lint` *(fails: 3414 problems)*
- `npm run format` *(fails: syntax errors in workflow files)*
- `npm test` *(fails: multiple test suites)*
- `cd python && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1439aaeac833384901d15fc7e4103