### PR TITLE
feat(client): add AI insights panel with community overlays

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -38,6 +38,7 @@ import SystemPanel from './components/system/SystemPanel';
 import FederatedSearchPanel from './components/federation/FederatedSearchPanel';
 import ExternalDataPanel from './components/osint/ExternalDataPanel';
 import IntelGraphCanvas from './components/graph/IntelGraphCanvas';
+import CytoscapeGraph from './components/graph/CytoscapeGraph';
 
 function ThemedAppShell({ children }) {
   const mode = useSelector((state) => state.ui.theme || 'light');
@@ -77,6 +78,7 @@ function App() {
                 <Route path="graph/advanced/:id" element={<Box sx={{height:'calc(100vh - 120px)'}}><AdvancedGraphView /></Box>} />
                 <Route path="graph/:id" element={<Container maxWidth="xl"><EnhancedGraphExplorer /></Container>} />
                 <Route path="graph/new-canvas" element={<IntelGraphCanvas />} />
+                <Route path="graph/cytoscape" element={<Box sx={{height:'calc(100vh - 120px)'}}><CytoscapeGraph /></Box>} />
                 <Route path="graph/collaborative" element={<Box sx={{height:'calc(100vh - 120px)'}}><AdvancedCollaborativeGraph /></Box>} />
                 <Route path="graph/demo" element={<Box sx={{height:'calc(100vh - 120px)'}}><GraphCollaborationDemo /></Box>} />
                 <Route path="versions" element={<Container maxWidth="lg"><GraphVersionHistory /></Container>} />

--- a/client/src/components/graph/__tests__/AIInsightsPanel.test.jsx
+++ b/client/src/components/graph/__tests__/AIInsightsPanel.test.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import reducer from '../../../store/slices/graphInteractionSlice';
+import aiInsightsReducer from '../../../store/slices/aiInsightsSlice';
+import graphReducer from '../../../store/slices/graphSlice';
 import AIInsightsPanel from '../AIInsightsPanel';
 
-function makeStore(preloadedState) {
-  return configureStore({ reducer: { graphInteraction: reducer }, preloadedState });
-}
-
-test('renders placeholder when nothing selected', () => {
-  const store = makeStore();
+function setup() {
+  const store = configureStore({
+    reducer: {
+      aiInsights: aiInsightsReducer,
+      graph: graphReducer
+    }
+  });
   render(
     <Provider store={store}>
       <AIInsightsPanel open={true} onClose={() => {}} />
     </Provider>
   );
-  expect(screen.getByText(/Select a node or edge/i)).toBeInTheDocument();
-});
+  return store;
+}
 
+test('renders toggles and export buttons', () => {
+  setup();
+  expect(screen.getByLabelText(/Highlight Communities/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Metadata Popovers/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Export CSV/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Export JSON/i })).toBeInTheDocument();
+});

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -4,6 +4,7 @@ import graphSlice from './slices/graphSlice';
 import uiSlice from './slices/uiSlice';
 import graphInteraction from './slices/graphInteractionSlice';
 import graphUISlice from './slices/graphUISlice'; // Import the new graphUISlice
+import aiInsights from './slices/aiInsightsSlice';
 
 export const store = configureStore({
   reducer: {
@@ -12,6 +13,7 @@ export const store = configureStore({
     ui: uiSlice,
     graphInteraction,
     graphUI: graphUISlice, // Add the new graphUISlice
+    aiInsights,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/client/src/store/slices/aiInsightsSlice.js
+++ b/client/src/store/slices/aiInsightsSlice.js
@@ -1,0 +1,28 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const aiInsightsSlice = createSlice({
+  name: 'aiInsights',
+  initialState: {
+    panelOpen: false,
+    highlight: false,
+    popovers: false,
+  },
+  reducers: {
+    togglePanel(state) {
+      state.panelOpen = !state.panelOpen;
+    },
+    setPanelOpen(state, action) {
+      state.panelOpen = action.payload;
+    },
+    toggleHighlight(state) {
+      state.highlight = !state.highlight;
+    },
+    togglePopovers(state) {
+      state.popovers = !state.popovers;
+    },
+  },
+});
+
+export const { togglePanel, setPanelOpen, toggleHighlight, togglePopovers } = aiInsightsSlice.actions;
+
+export default aiInsightsSlice.reducer;

--- a/client/tests/e2e/ai-insights-panel.spec.ts
+++ b/client/tests/e2e/ai-insights-panel.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('AI Insights panel highlights communities and exports data', async ({ page }) => {
+  await page.goto('/graph/cytoscape');
+  await page.getByRole('button', { name: 'AI Insights' }).click();
+  await page.getByLabel('Highlight Communities').click();
+  const color = await page.evaluate(() => {
+    const n = (window as any).cy.nodes()[0];
+    return n.style('background-color');
+  });
+  expect(color).toBeTruthy();
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.getByRole('button', { name: 'Export JSON' }).click()
+  ]);
+  expect(download.suggestedFilename()).toContain('json');
+});


### PR DESCRIPTION
## Summary
- implement AI insights panel with toggles and exports
- color-code communities and popovers on Cytoscape graph
- add Playwright coverage for panel behavior

## Testing
- `npm run lint:client` (fails: RangeError Maximum call stack size exceeded)
- `npm test` (fails: 4 failed, 5 passed)
- `cd client && npx playwright test tests/e2e/ai-insights-panel.spec.ts` (fails: 3 failed)


------
https://chatgpt.com/codex/tasks/task_e_68a1436d781c8333a3b0ca500d870f1f