### PR TITLE
feat: initialize telemetry service and enhance dashboard responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
+## 2025-08-15
+
+- feat(ui): improve dashboard responsiveness and correct analytics import
+- feat(telemetry): initialize OpenTelemetry service on server startup
+
 ## 2025-08-14 (later)
+
 - feat(realtime): Redis Streams → Socket.IO analytics bridge (`/graph-analytics`) with consumer groups and progressive events
 - feat(graphql): Graph Ops schema/resolvers (`expandNeighbors`, `tagEntity`, `requestAIAnalysis`) with validation, RBAC, caching, and metrics
 - feat(worker): BullMQ AI worker emitting `ai:insight` to `/realtime` namespace rooms
@@ -8,6 +14,7 @@
 - docs: analytics bridge setup guide
 
 ## 2025-08-14
+
 - Added Copilot Goals (UI + GraphQL).
 - Added Copilot Query Orchestration (Goal -> Plan -> Tasks -> Results) with live events via Socket.IO.
 - Add comprehensive documentation suite (architecture, API, roadmap, project plan).

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,14 +1,20 @@
-import React, { useEffect } from 'react';
-import { Provider, useSelector } from 'react-redux';
-import { store } from './store'; // Import the Redux store
-import { fetchGraphData } from './store/slices/graphSlice'; // Import fetchGraphData thunk
-import GraphVisualization from './features/graph/GraphVisualization'; // Import the GraphVisualization component
-import AnalyticsDashboardPanel from './components/AnalyticsDashboardPanel'; // Import the new panel
-import { ApolloClient, InMemoryCache, ApolloProvider, HttpLink } from '@apollo/client';
+import React, { useEffect } from "react";
+import { Provider, useSelector } from "react-redux";
+import { store } from "./store"; // Import the Redux store
+import { fetchGraphData } from "./store/slices/graphSlice"; // Import fetchGraphData thunk
+import GraphVisualization from "./features/graph/GraphVisualization"; // Import the GraphVisualization component
+import AnalyticsDashboard from "./components/dashboard/AnalyticsDashboard"; // Import the analytics dashboard
+import {
+  ApolloClient,
+  InMemoryCache,
+  ApolloProvider,
+  HttpLink,
+} from "@apollo/client";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 // Initialize Apollo Client
 const httpLink = new HttpLink({
-  uri: 'http://localhost:4000/graphql', // Assuming your GraphQL server runs on port 4000
+  uri: "http://localhost:4000/graphql", // Assuming your GraphQL server runs on port 4000
 });
 
 const client = new ApolloClient({
@@ -21,24 +27,53 @@ function TestApp() {
     store.dispatch(fetchGraphData());
   }, []);
 
+  const isMobile = useMediaQuery("(max-width:768px)");
+
   // Persist relevant graph state to localStorage
   const graphState = useSelector((state) => state.graph);
   useEffect(() => {
-    localStorage.setItem('graphLayout', graphState.layout);
-    localStorage.setItem('graphLayoutOptions', JSON.stringify(graphState.layoutOptions));
-    localStorage.setItem('graphFeatureToggles', JSON.stringify(graphState.featureToggles));
-    localStorage.setItem('graphNodeTypeColors', JSON.stringify(graphState.nodeTypeColors));
-  }, [graphState.layout, graphState.layoutOptions, graphState.featureToggles, graphState.nodeTypeColors]);
+    localStorage.setItem("graphLayout", graphState.layout);
+    localStorage.setItem(
+      "graphLayoutOptions",
+      JSON.stringify(graphState.layoutOptions),
+    );
+    localStorage.setItem(
+      "graphFeatureToggles",
+      JSON.stringify(graphState.featureToggles),
+    );
+    localStorage.setItem(
+      "graphNodeTypeColors",
+      JSON.stringify(graphState.nodeTypeColors),
+    );
+  }, [
+    graphState.layout,
+    graphState.layoutOptions,
+    graphState.featureToggles,
+    graphState.nodeTypeColors,
+  ]);
 
   return (
     <ApolloProvider client={client}>
       <Provider store={store}>
-        <div style={{ height: '100vh', display: 'flex', flexDirection: 'row' }}> {/* Changed to row for side-by-side */}
+        <div
+          style={{
+            height: "100vh",
+            display: "flex",
+            flexDirection: isMobile ? "column" : "row",
+          }}
+        >
           <div style={{ flex: 1 }}>
             <GraphVisualization />
           </div>
-          <div style={{ width: '300px', padding: '10px', overflowY: 'auto', borderLeft: '1px solid #eee' }}>
-            <AnalyticsDashboardPanel />
+          <div
+            style={{
+              width: isMobile ? "100%" : "300px",
+              padding: "10px",
+              overflowY: "auto",
+              borderLeft: isMobile ? "none" : "1px solid #eee",
+            }}
+          >
+            <AnalyticsDashboard />
           </div>
         </div>
       </Provider>

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,15 +1,16 @@
-import http from 'http'
-import { useServer } from 'graphql-ws/lib/use/ws'
-import { WebSocketServer } from 'ws'
-import pino from 'pino'
-import { getContext } from './lib/auth.js'
-import path from 'path';
-import { fileURLToPath } from 'url';
-import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
-import { createApp } from './app.js';
-import { makeExecutableSchema } from '@graphql-tools/schema';
-import { typeDefs } from './graphql/schema.js';
-import resolvers from './graphql/resolvers/index.js';
+import http from "http";
+import { useServer } from "graphql-ws/lib/use/ws";
+import { WebSocketServer } from "ws";
+import pino from "pino";
+import { getContext } from "./lib/auth.js";
+import path from "path";
+import { fileURLToPath } from "url";
+import WSPersistedQueriesMiddleware from "./graphql/middleware/wsPersistedQueries.js";
+import { createApp } from "./app.js";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { typeDefs } from "./graphql/schema.js";
+import resolvers from "./graphql/resolvers/index.js";
+import "./monitoring/opentelemetry.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -30,45 +31,48 @@ const startServer = async () => {
   const wsPersistedQueries = new WSPersistedQueriesMiddleware();
   const wsMiddleware = wsPersistedQueries.createMiddleware();
 
-  useServer({
-    schema,
-    context: getContext,
-    ...wsMiddleware,
-  }, wss);
+  useServer(
+    {
+      schema,
+      context: getContext,
+      ...wsMiddleware,
+    },
+    wss,
+  );
 
-  if (process.env.NODE_ENV === 'production') {
-    const clientDistPath = path.resolve(__dirname, '../../client/dist');
+  if (process.env.NODE_ENV === "production") {
+    const clientDistPath = path.resolve(__dirname, "../../client/dist");
     app.use(express.static(clientDistPath));
-    app.get('*', (_req, res) => {
-      res.sendFile(path.join(clientDistPath, 'index.html'));
+    app.get("*", (_req, res) => {
+      res.sendFile(path.join(clientDistPath, "index.html"));
     });
   }
 
-  const { initSocket, getIO } = await import('./realtime/socket.js'); // New import
+  const { initSocket, getIO } = await import("./realtime/socket.js"); // New import
 
-  const port = Number(process.env.PORT || 4000)
+  const port = Number(process.env.PORT || 4000);
   httpServer.listen(port, async () => {
     logger.info(`Server listening on port ${port}`);
-    
+
     // Create sample data for development
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === "development") {
       setTimeout(async () => {
         try {
-          const { createSampleData } = await import('./utils/sampleData.js');
+          const { createSampleData } = await import("./utils/sampleData.js");
           await createSampleData();
         } catch (error) {
-          logger.warn('Failed to create sample data, continuing without it');
+          logger.warn("Failed to create sample data, continuing without it");
         }
       }, 2000); // Wait 2 seconds for connections to be established
     }
-  })
+  });
 
   // Initialize Socket.IO
   const io = initSocket(httpServer);
 
-  const { closeNeo4jDriver } = await import('./db/neo4j.js');
-  const { closePostgresPool } = await import('./db/postgres.js');
-  const { closeRedisClient } = await import('./db/redis.js');
+  const { closeNeo4jDriver } = await import("./db/neo4j.js");
+  const { closePostgresPool } = await import("./db/postgres.js");
+  const { closeRedisClient } = await import("./db/redis.js");
 
   // Graceful shutdown
   const shutdown = async (sig: NodeJS.Signals) => {
@@ -80,8 +84,13 @@ const startServer = async () => {
       closePostgresPool(),
       closeRedisClient(),
     ]);
-    httpServer.close(err => {
-      if (err) { logger.error(`Error during shutdown: ${err instanceof Error ? err.message : 'Unknown error'}`); process.exitCode = 1 }
+    httpServer.close((err) => {
+      if (err) {
+        logger.error(
+          `Error during shutdown: ${err instanceof Error ? err.message : "Unknown error"}`,
+        );
+        process.exitCode = 1;
+      }
       process.exit();
     });
   };


### PR DESCRIPTION
## Summary
- import and initialize OpenTelemetry at server startup
- make dashboard panel responsive and fix analytics import
- document telemetry and UI changes in changelog

## Testing
- `npm run lint` *(fails: cannot find package '@typescript-eslint/parser' initially, after installing, lint reports 3543 problems)*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a13e0131d48333a8b1560d060cc898