### PR TITLE
feat: expand insight panel controls and load testing

### DIFF
--- a/monitoring/LOAD_TESTING.md
+++ b/monitoring/LOAD_TESTING.md
@@ -1,0 +1,31 @@
+# API Load Testing
+
+Use this guide to stress test IntelGraph APIs and observe metrics through Grafana and Prometheus.
+
+## Run the test
+
+```bash
+node scripts/api-load-test.js http://localhost:4000/health 10000 200
+```
+
+- **Endpoint** – API URL to test
+- **Requests** – total number of requests
+- **Concurrency** – number of simultaneous requests (default 100)
+
+Prometheus collects request rate and latency while the test runs. Ensure the API exposes `/metrics` and Prometheus is scraping it.
+
+## Visualize
+
+Open Grafana and use the HTTP dashboard to watch traffic spikes and response times during the load test.
+
+Example PromQL queries:
+
+```promql
+rate(http_requests_total[1m])
+```
+
+```promql
+histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))
+```
+
+Import `deploy/grafana/dashboards/http.json` for a starter dashboard or build a custom panel.

--- a/scripts/api-load-test.js
+++ b/scripts/api-load-test.js
@@ -1,0 +1,38 @@
+/**
+ * Simple API load test script
+ * Usage: node scripts/api-load-test.js <endpoint> <requests> <concurrency>
+ */
+
+const axios = require("axios");
+
+const endpoint = process.argv[2] || "http://localhost:4000/health";
+const totalRequests = parseInt(process.argv[3] || "10000", 10);
+const concurrency = parseInt(process.argv[4] || "100", 10);
+
+let current = 0;
+
+async function worker() {
+  while (current < totalRequests) {
+    const requestNumber = current++;
+    try {
+      await axios.get(endpoint);
+    } catch {
+      // ignore errors
+    }
+  }
+}
+
+async function run() {
+  const start = Date.now();
+  const workers = Array.from({ length: concurrency }, () => worker());
+  await Promise.all(workers);
+  const duration = Date.now() - start;
+  console.log(
+    `Completed ${totalRequests} requests to ${endpoint} with concurrency ${concurrency} in ${duration}ms`,
+  );
+}
+
+run().catch((err) => {
+  console.error("Load test failed", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- allow users to set minimum confidence for link predictions with persistent settings
- add configurable concurrency to API load test script
- document Prometheus/Grafana queries for monitoring load tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx prettier -w client/src/components/InsightPanel.jsx scripts/api-load-test.js monitoring/LOAD_TESTING.md`
- `npm test` *(fails: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a16e601ad48333af8a647e633947c1