### PR TITLE
feat: add edge offline processing and sync

### DIFF
--- a/ml/README.md
+++ b/ml/README.md
@@ -10,6 +10,7 @@ A next-generation machine learning service featuring GPU acceleration, quantum c
 - **Distributed Training**: Multi-GPU and multi-node training with Accelerate/DeepSpeed
 - **Quantum ML Integration**: Quantum-enhanced algorithms with classical fallbacks
 - **Advanced Monitoring**: Real-time performance metrics and health checks
+- **Edge Deployment**: On-device image, audio, and text analysis with offline-first pipelines
 
 ### Architecture Support
 - **Multiple GNN Types**: GCN, GraphSAGE, GAT architectures
@@ -33,7 +34,8 @@ ml/
 │   ├── monitoring/
 │   │   ├── metrics.py             # Performance metrics collection
 │   │   └── health.py              # Health check systems
-│   └── tasks/
+│   ├── tasks/
+│   └── edge/                     # Offline processors & sync utilities
 ├── pyproject.toml                  # Python dependencies
 ├── simple_test.py                  # Concept verification tests
 └── README.md                       # This file

--- a/ml/app/edge/__init__.py
+++ b/ml/app/edge/__init__.py
@@ -1,0 +1,6 @@
+"""Edge deployment helpers for IntelGraph ML."""
+
+from .offline_processor import OfflineProcessor
+from .sync import SyncManager
+
+__all__ = ["OfflineProcessor", "SyncManager"]

--- a/ml/app/edge/offline_processor.py
+++ b/ml/app/edge/offline_processor.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+from PIL import Image
+import torch
+from torchvision import transforms
+
+
+class OfflineProcessor:
+    """Run lightweight models locally for image, audio and text data.
+
+    Models are stored as TorchScript modules inside ``model_dir`` so they can
+    be executed without a Python source dependency.  This makes the pipeline
+    suitable for edge devices that may operate for extended periods without
+    network connectivity.
+    """
+
+    def __init__(self, model_dir: Path | str) -> None:
+        self.model_dir = Path(model_dir)
+        self.image_model = torch.jit.load(self.model_dir / "image_model.pt")
+        self.audio_model = torch.jit.load(self.model_dir / "audio_model.pt")
+        self.text_model = torch.jit.load(self.model_dir / "text_model.pt")
+        self._img_tf = transforms.ToTensor()
+
+    # ------------------------------------------------------------------
+    def process_image(self, data: bytes) -> Dict[str, Any]:
+        """Classify a single image given raw byte input."""
+        img = Image.open(io.BytesIO(data)).convert("RGB")
+        tensor = self._img_tf(img).unsqueeze(0)
+        with torch.inference_mode():
+            logits = self.image_model(tensor)
+        prediction = int(torch.argmax(logits, dim=1).item())
+        return {"modality": "image", "prediction": prediction}
+
+    # ------------------------------------------------------------------
+    def process_audio(self, waveform: np.ndarray) -> Dict[str, Any]:
+        """Classify an audio waveform array."""
+        tensor = torch.tensor(waveform, dtype=torch.float32).unsqueeze(0)
+        with torch.inference_mode():
+            logits = self.audio_model(tensor)
+        prediction = int(torch.argmax(logits, dim=1).item())
+        return {"modality": "audio", "prediction": prediction}
+
+    # ------------------------------------------------------------------
+    def process_text(self, text: str) -> Dict[str, Any]:
+        """Classify text by encoding characters as numeric features."""
+        max_len = 16
+        encoded = [ord(c) / 255.0 for c in text[:max_len]]
+        if len(encoded) < max_len:
+            encoded += [0.0] * (max_len - len(encoded))
+        tensor = torch.tensor(encoded, dtype=torch.float32).unsqueeze(0)
+        with torch.inference_mode():
+            logits = self.text_model(tensor)
+        prediction = int(torch.argmax(logits, dim=1).item())
+        return {"modality": "text", "prediction": prediction}

--- a/ml/app/edge/sync.py
+++ b/ml/app/edge/sync.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+import httpx
+
+
+class SyncManager:
+    """Store inference results offline and sync when connectivity is restored."""
+
+    def __init__(self, storage_dir: Path | str, endpoint: str) -> None:
+        self.storage_dir = Path(storage_dir)
+        self.endpoint = endpoint
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    def store(self, record: Dict) -> Path:
+        """Persist a record locally with a checksum for validation."""
+        data = json.dumps(record, sort_keys=True).encode()
+        checksum = hashlib.sha256(data).hexdigest()
+        record_with_sum = {**record, "checksum": checksum}
+        path = self.storage_dir / f"{checksum}.json"
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(record_with_sum, f)
+        return path
+
+    # ------------------------------------------------------------------
+    def sync(self, client: Optional[httpx.Client] = None) -> None:
+        """Attempt to upload stored records to the central service."""
+        own_client = client or httpx.Client()
+        for path in list(self.storage_dir.glob("*.json")):
+            with open(path, "r", encoding="utf-8") as f:
+                record = json.load(f)
+            try:
+                resp = own_client.post(self.endpoint, json=record, timeout=5.0)
+                if resp.status_code == 200 and resp.json().get("checksum") == record.get("checksum"):
+                    path.unlink()  # Delete once server confirms
+            except Exception:
+                # Connectivity issues are ignored; records remain for later attempts
+                pass
+        if client is None:
+            own_client.close()

--- a/ml/tests/test_edge.py
+++ b/ml/tests/test_edge.py
@@ -1,0 +1,64 @@
+import io
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+from PIL import Image
+import httpx
+import json
+
+# Ensure the app package is on the import path when tests are executed from
+# the repository root.
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.edge import OfflineProcessor, SyncManager
+
+
+def _save_dummy_models(model_dir: Path) -> None:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    img_model = nn.Sequential(nn.Flatten(), nn.Linear(3 * 8 * 8, 2))
+    torch.jit.script(img_model).save(model_dir / "image_model.pt")
+    audio_model = nn.Sequential(nn.Flatten(), nn.Linear(100, 2))
+    torch.jit.script(audio_model).save(model_dir / "audio_model.pt")
+    text_model = nn.Sequential(nn.Linear(16, 2))
+    torch.jit.script(text_model).save(model_dir / "text_model.pt")
+
+
+def test_offline_processing_and_sync(tmp_path):
+    model_dir = tmp_path / "models"
+    _save_dummy_models(model_dir)
+    processor = OfflineProcessor(model_dir)
+
+    # Image
+    img = Image.fromarray(np.zeros((8, 8, 3), dtype=np.uint8))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    image_res = processor.process_image(buf.getvalue())
+    assert image_res["modality"] == "image"
+
+    # Audio
+    waveform = np.zeros(100, dtype=np.float32)
+    audio_res = processor.process_audio(waveform)
+    assert audio_res["modality"] == "audio"
+
+    # Text
+    text_res = processor.process_text("hi")
+    assert text_res["modality"] == "text"
+
+    # Sync
+    sync_dir = tmp_path / "sync"
+    manager = SyncManager(sync_dir, "https://example.com/upload")
+    record_path = manager.store(text_res)
+    assert record_path.exists()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode())
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport)
+    manager.sync(client=client)
+    assert not record_path.exists()
+    client.close()


### PR DESCRIPTION
## Summary
- add offline processors for image, audio, and text inference on edge devices
- introduce sync manager for offline result storage and validated upload
- document edge deployment utilities

## Testing
- `pre-commit run --files ml/app/edge/offline_processor.py ml/app/edge/sync.py ml/app/edge/__init__.py ml/tests/test_edge.py ml/README.md` *(fails: Invalid baseline)*
- `cd ml && pytest tests/test_edge.py`

------
https://chatgpt.com/codex/tasks/task_e_68a180c8c8c08333819364f39e9063ec