### PR TITLE
feat: scaffold ingestion bus and red team simulator

### DIFF
--- a/docs/global-threat-monitoring-architecture.md
+++ b/docs/global-threat-monitoring-architecture.md
@@ -1,0 +1,99 @@
+# Global Threat Monitoring & Adaptive Operations Architecture
+
+This document describes the reference design for enabling global threat monitoring, red team simulation, analyst mission packaging, orchestration workflows, adaptive feedback, and compartmented security within the Intelgraph platform.
+
+## 1. OSINT + GEOINT Integration Layer
+
+### Data Sources
+
+- Satellite imagery via STAC/COG endpoints
+- Open crisis indicators (ACLED, UN OCHA, RSS feeds, Twitter/X)
+- Existing Intelgraph entity updates and partner APIs
+
+### Ingestion Pipeline
+
+1. **Fetchers** pull or subscribe to external feeds on a fixed cadence.
+2. Events flow through a **message queue** (Kafka/NATS) for back‑pressure control.
+3. A **normalization service** converts raw items into a common schema with GeoJSON envelopes.
+4. Enriched records are written to the graph store and cached in Elasticsearch for spatial queries.
+
+### Geospatial Visualization
+
+- Leaflet/Mapbox layer rendering entity pins, event overlays, and dynamic heatmaps.
+- Timeline slider replays event evolution using cached snapshots.
+- Latency target: dashboard updates within 10 seconds of source publication.
+
+## 2. Red Teaming Simulation Engine
+
+### Architecture
+
+- **Scenario Library** stores adversary playbooks (phishing, disinformation, kinetic proxies).
+- **Agents** can be script driven or LLM backed; each agent publishes synthetic signals into the same queue used by live feeds.
+- **Control Panel** allows operators to launch scenarios, tune parameters, and review metrics.
+
+### Evaluation
+
+- Simulated events exercise alert thresholds and analyst workflows.
+- Engine records analyst acknowledgement time and accuracy, producing readiness scores.
+
+## 3. Analyst Mission Packaging & Export
+
+### Packaging Flow
+
+1. Analyst selects entities, timelines, annotations, and reports within the workspace.
+2. A packaging service gathers referenced assets and builds a manifest with risk levels and tags.
+3. Assets are rendered to PDF via Jinja2 templates and zipped alongside JSON metadata.
+4. Optional PGP encryption wraps the archive for classified transfer.
+
+### Output
+
+- Single click export produces a `.zip` bundle containing:
+  - `summary.pdf`
+  - `metadata.json`
+  - supporting attachments (imagery, reports)
+
+## 4. Threat Ops Orchestration Framework (Stage 1)
+
+### Workflow Mapping
+
+- Alerts are transformed into **events** with severity, entity, and geo context.
+- A lightweight rule engine maps events to workflows (e.g., high‑risk entity → open case, notify analyst).
+- Initial library includes three workflows: notification, task routing, and external case creation.
+
+### Implementation Notes
+
+- MVP implemented in Python with Temporal or a custom async scheduler.
+- Hooks exposed for later integration with enterprise case managers.
+
+## 5. Self‑Adaptive Threat Response Feedback Loop
+
+### Data Collection
+
+- Each workflow execution logs duration, analyst inputs, and outcomes.
+- Logs persist to a feedback store used for training and LLM evaluation.
+
+### Adaptive Logic
+
+- A periodic job runs an LLM or lightweight ML model to assess effectiveness of responses.
+- Recommendations adjust alert thresholds or swap workflows; changes require analyst approval.
+
+## 6. Advanced Security & Intel Labeling
+
+### Classification Model
+
+- Support standard markings: **U**, **C**, **S**, **TS**, plus caveats (NOFORN, REL TO).
+- Operational labels (Cyber, HUMINT, FISA) stored as attributes on graph nodes and edges.
+
+### Enforcement
+
+- Access control middleware checks user compartments against item labels (PostgreSQL RLS + ABAC).
+- Derived products inherit the highest classification of source material; export service preserves labels in metadata.
+
+## Deliverables Summary
+
+1. Real‑time OSINT/GEOINT dashboard.
+2. Configurable red team simulation engine.
+3. One‑click mission packaging with export.
+4. Threat ops orchestration MVP.
+5. Feedback‑driven workflow tuning logic.
+6. Compartmented access control system.

--- a/server/src/services/GlobalIngestor.js
+++ b/server/src/services/GlobalIngestor.js
@@ -1,0 +1,24 @@
+const OSINTFeedService = require("./OSINTFeedService");
+const bus = require("../workers/eventBus");
+
+class GlobalIngestor {
+  constructor({ feedService } = {}) {
+    this.feedService = feedService || new OSINTFeedService();
+    this.bus = bus;
+  }
+
+  async pollAndQueue(subject) {
+    const results = await this.feedService.poll(subject);
+    results.forEach((r) => {
+      this.bus.emit("raw-event", { source: r.source, data: r.data });
+    });
+    return results.length;
+  }
+
+  startPolling(subject, intervalMs = 60000) {
+    this.pollAndQueue(subject);
+    return setInterval(() => this.pollAndQueue(subject), intervalMs);
+  }
+}
+
+module.exports = GlobalIngestor;

--- a/server/src/services/RedTeamSimulator.js
+++ b/server/src/services/RedTeamSimulator.js
@@ -1,0 +1,25 @@
+const bus = require("../workers/eventBus");
+
+class RedTeamSimulator {
+  constructor({ scenarios } = {}) {
+    this.bus = bus;
+    this.scenarios = scenarios || {
+      "phishing-campaign": () => ({
+        type: "phishing",
+        entity: "CorpX",
+        severity: "medium",
+        location: { lat: 0, lon: 0 },
+      }),
+    };
+  }
+
+  inject(name) {
+    const generator = this.scenarios[name];
+    if (!generator) throw new Error(`Unknown scenario: ${name}`);
+    const payload = generator();
+    this.bus.emit("raw-event", { source: "red-team", data: payload });
+    return payload;
+  }
+}
+
+module.exports = RedTeamSimulator;

--- a/server/src/workers/eventBus.js
+++ b/server/src/workers/eventBus.js
@@ -1,0 +1,5 @@
+const { EventEmitter } = require("events");
+
+const eventBus = new EventEmitter();
+
+module.exports = eventBus;

--- a/server/src/workers/normalizationWorker.js
+++ b/server/src/workers/normalizationWorker.js
@@ -1,0 +1,16 @@
+const bus = require("./eventBus");
+
+function normalize(raw) {
+  const { source, data } = raw;
+  const normalized = {
+    source,
+    payload: data,
+    geo: data.location || null,
+    receivedAt: new Date().toISOString(),
+  };
+  bus.emit("normalized-event", normalized);
+}
+
+bus.on("raw-event", normalize);
+
+module.exports = { normalize };

--- a/server/tests/services/RedTeamSimulator.test.js
+++ b/server/tests/services/RedTeamSimulator.test.js
@@ -1,0 +1,19 @@
+const bus = require("../../src/workers/eventBus");
+const RedTeamSimulator = require("../../src/services/RedTeamSimulator");
+require("../../src/workers/normalizationWorker");
+
+describe("RedTeamSimulator", () => {
+  test("injects scenario events", (done) => {
+    const sim = new RedTeamSimulator();
+    bus.once("normalized-event", (evt) => {
+      try {
+        expect(evt.source).toBe("red-team");
+        expect(evt.payload.type).toBe("phishing");
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+    sim.inject("phishing-campaign");
+  });
+});


### PR DESCRIPTION
## Summary
- add event bus and normalization worker for streaming threat data
- scaffold red team simulator and global ingestor using existing feed service
- add unit test verifying red team injections emit normalized events

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in workflow YAML configs)*
- `npm test` *(fails: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a17e41c6648333add0bcfc02e0d793