### PR TITLE
feat: enforce compartment-based isolation

### DIFF
--- a/server/tests/compartment-isolation.test.ts
+++ b/server/tests/compartment-isolation.test.ts
@@ -1,0 +1,65 @@
+import { ForbiddenError } from "apollo-server-express";
+import { withAuthAndPolicy } from "../src/middleware/withAuthAndPolicy";
+
+describe("compartment-aware investigation isolation", () => {
+  const baseUser = {
+    id: "u1",
+    email: "user@example.com",
+    roles: ["analyst"],
+    permissions: [],
+    orgId: "org-1",
+    teamId: "team-1",
+  };
+
+  it("allows access within same org and team", async () => {
+    const resolver = withAuthAndPolicy("read", () => ({
+      type: "investigation",
+      id: "inv-1",
+      orgId: "org-1",
+      teamId: "team-1",
+    }))(async () => "ok");
+
+    const result = await resolver(
+      {},
+      {},
+      { user: baseUser },
+      { fieldName: "test", path: "testPath" },
+    );
+    expect(result).toBe("ok");
+  });
+
+  it("denies access when org differs", async () => {
+    const resolver = withAuthAndPolicy("read", () => ({
+      type: "investigation",
+      id: "inv-1",
+      orgId: "org-2",
+    }))(async () => "ok");
+
+    await expect(
+      resolver(
+        {},
+        {},
+        { user: baseUser },
+        { fieldName: "test", path: "testPath" },
+      ),
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it("denies access when team differs", async () => {
+    const resolver = withAuthAndPolicy("read", () => ({
+      type: "investigation",
+      id: "inv-1",
+      orgId: "org-1",
+      teamId: "team-2",
+    }))(async () => "ok");
+
+    await expect(
+      resolver(
+        {},
+        {},
+        { user: baseUser },
+        { fieldName: "test", path: "testPath" },
+      ),
+    ).rejects.toThrow(ForbiddenError);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce org and team compartment checks in policy layer
- log compartment leak attempts and include org/team in policy context
- test compartment isolation for investigations

## Testing
- `npm run lint` *(fails: 3650 problems, mostly console statements)*
- `npm run format` *(fails: syntax errors in workflow YAML files)*
- `npm test` *(fails: syntax errors in client and config files)*

------
https://chatgpt.com/codex/tasks/task_e_68a188989ff4833384e3cc1e01fa8f8f