### PR TITLE
docs: add virtual ICS attack chain output

### DIFF
--- a/AUTONOMOUS_OT_ICS_DIGITAL_TWIN_RED_TEAM_COMPLETED.md
+++ b/AUTONOMOUS_OT_ICS_DIGITAL_TWIN_RED_TEAM_COMPLETED.md
@@ -10,6 +10,8 @@ Finalized the autonomous digital twin environment for OT/ICS, enabling red team 
 
 - Modeled critical industrial components within a virtualized lab.
 - Automated attack playbooks to evaluate defensive coverage.
+- Added autonomous scenario generator to simulate multi-stage attack chains in the virtual ICS environment.
+- Each exercise outputs a chain-of-custody record and exposes a graph of affected assets for analysis.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- document autonomous scenario generator for OT/ICS digital twin red team
- note chain-of-custody logging and graph exposure outputs

## Testing
- `npm run lint` *(fails: 3652 problems (2823 errors, 829 warnings))*
- `npm run format` *(fails: Prettier SyntaxError in workflow files)*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a188d0c6a883338d0c70233b876916