### PR TITLE
feat: add basic deepfake detection results

### DIFF
--- a/server/src/ai/deepfakeSentinel.ts
+++ b/server/src/ai/deepfakeSentinel.ts
@@ -1,9 +1,25 @@
 export interface DeepfakeAnalysisResult {
   isDeepfake: boolean;
   confidence: number;
+  manipulated: boolean;
+  affectedTargets: string[];
 }
 
 export function analyzeContent(content: string): DeepfakeAnalysisResult {
-  // Placeholder for deepfake detection algorithm.
-  return { isDeepfake: false, confidence: 0 };
+  const text = content.toLowerCase();
+  const suspiciousKeywords = ["deepfake", "manipulated", "fake"];
+  const manipulationDetected = suspiciousKeywords.some((k) =>
+    text.includes(k)
+  );
+
+  const targets = Array.from(new Set(content.match(/@([\w-]+)/g) || [])).map(
+    (t) => t.slice(1)
+  );
+
+  return {
+    isDeepfake: manipulationDetected,
+    confidence: manipulationDetected ? 0.9 : 0,
+    manipulated: manipulationDetected,
+    affectedTargets: targets,
+  };
 }

--- a/server/src/tests/featurePlaceholders.test.ts
+++ b/server/src/tests/featurePlaceholders.test.ts
@@ -12,6 +12,18 @@ describe("feature placeholders", () => {
     expect(correlateBehavioralDna()).toBe(0);
     expect(runOtRedTeam()).toBe(false);
     expect(orchestrateContinuity()).toBeUndefined();
-    expect(analyzeContent("sample").isDeepfake).toBe(false);
+    const analysis = analyzeContent("sample");
+    expect(analysis.isDeepfake).toBe(false);
+    expect(analysis.manipulated).toBe(false);
+    expect(analysis.confidence).toBe(0);
+    expect(analysis.affectedTargets).toHaveLength(0);
+  });
+
+  it("detects manipulation keywords and targets", () => {
+    const flagged = analyzeContent("deepfake targeting @user1");
+    expect(flagged.isDeepfake).toBe(true);
+    expect(flagged.manipulated).toBe(true);
+    expect(flagged.confidence).toBeGreaterThan(0);
+    expect(flagged.affectedTargets).toContain("user1");
   });
 });


### PR DESCRIPTION
## Summary
- expand deepfake sentinel to return manipulation flag and affected targets
- add tests covering detection heuristics

## Testing
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Map keys must be unique in cd-deploy.yml)*

------
https://chatgpt.com/codex/tasks/task_e_68a188af27048333a8aa5b2477787c9f