### PR TITLE
feat: add adaptive subgraph caching

### DIFF
--- a/server/tests/graphrag.validator.test.js
+++ b/server/tests/graphrag.validator.test.js
@@ -28,6 +28,7 @@ describe("GraphRAGService schema validation", () => {
         },
       ],
       subgraphHash: "hash",
+      ttl: 300,
     });
   });
 


### PR DESCRIPTION
## Summary
- add Redis-backed frequency tracker for subgraph requests
- dynamically derive cache TTL from access velocity
- extend tests for updated subgraph context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Map keys must be unique)*
- `npm test` *(fails: Unexpected token in client components)*

------
https://chatgpt.com/codex/tasks/task_e_68a188b9eab08333a1471c8aff7288ff