### PR TITLE
chore(ai): GraphRAG schema validation metrics + user fallback

### DIFF
--- a/server/src/lib/errors.ts
+++ b/server/src/lib/errors.ts
@@ -1,0 +1,34 @@
+import { v4 as uuid } from "uuid";
+import pino from "pino";
+import { ZodError } from "zod";
+
+const logger = pino({ name: "ErrorMapper" });
+
+export class UserFacingError extends Error {
+  statusCode: number;
+  traceId: string;
+
+  constructor(message: string, statusCode: number, traceId: string) {
+    super(message);
+    this.statusCode = statusCode;
+    this.traceId = traceId;
+  }
+}
+
+export function mapGraphRAGError(error: unknown): UserFacingError {
+  const traceId = uuid();
+  let summary = "Unknown error";
+  if (error instanceof ZodError) {
+    summary = error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ');
+  } else if (error instanceof Error) {
+    summary = error.message;
+  }
+  logger.warn({ traceId, issues: summary }, "GraphRAG schema validation failed");
+  return new UserFacingError(
+    `Invalid GraphRAG response. Trace ID: ${traceId}`,
+    400,
+    traceId,
+  );
+}

--- a/server/src/monitoring/metrics.js
+++ b/server/src/monitoring/metrics.js
@@ -208,7 +208,8 @@ register.registerMetric(pipelineFreshnessSeconds);
 register.registerMetric(pipelineCompletenessRatio);
 register.registerMetric(pipelineCorrectnessRatio);
 register.registerMetric(pipelineLatencySeconds);
-// GraphRAG metrics
+
+// GraphRAG metrics for schema validation and caching
 const graphragSchemaFailuresTotal = new client.Counter({
   name: "graphrag_schema_failures_total",
   help: "Total number of GraphRAG schema validation failures",

--- a/server/src/tests/graphragService.test.ts
+++ b/server/src/tests/graphragService.test.ts
@@ -1,0 +1,112 @@
+import { GraphRAGService } from "../services/GraphRAGService.js";
+import {
+  graphragSchemaFailuresTotal,
+  graphragCacheHitRatio,
+} from "../monitoring/metrics.js";
+import { UserFacingError } from "../lib/errors.js";
+
+describe("GraphRAGService", () => {
+  const baseRequest = {
+    investigationId: "inv1",
+    question: "What is testing?",
+  };
+
+  function createService(llmResponses: string[]) {
+    const neo4jSession = {
+      run: jest.fn().mockResolvedValue({
+        records: [
+          {
+            get: (field: string) => {
+              if (field === "nodes") {
+                return [
+                  {
+                    properties: {
+                      id: "e1",
+                      type: "Entity",
+                      label: "Entity1",
+                      properties: "{}",
+                      confidence: 1,
+                    },
+                  },
+                ];
+              }
+              if (field === "relationships") {
+                return [
+                  {
+                    properties: {
+                      id: "r1",
+                      type: "REL",
+                      fromEntityId: "e1",
+                      toEntityId: "e1",
+                      properties: "{}",
+                      confidence: 1,
+                    },
+                  },
+                ];
+              }
+              return null;
+            },
+          },
+        ],
+      }),
+      close: jest.fn(),
+    };
+    const neo4jDriver = { session: () => neo4jSession } as any;
+
+    const store = new Map<string, string>();
+    const redis = {
+      get: jest.fn(async (key: string) => store.get(key) || null),
+      setex: jest.fn(async (key: string, _ttl: number, val: string) => {
+        store.set(key, val);
+      }),
+    } as any;
+
+    const llmService = {
+      complete: jest.fn(async () => llmResponses.shift() as string),
+    };
+
+    const embeddingService = {
+      generateEmbedding: jest.fn(async () => [0.1]),
+    };
+
+    const service = new GraphRAGService(
+      neo4jDriver,
+      llmService as any,
+      embeddingService as any,
+      redis,
+    );
+    return { service, neo4jSession, llmService };
+  }
+
+  beforeEach(() => {
+    graphragSchemaFailuresTotal.reset();
+    graphragCacheHitRatio.set(0);
+  });
+
+  test("returns valid response and uses cache", async () => {
+    const valid = JSON.stringify({
+      answer: "Test",
+      confidence: 0.9,
+      citations: { entityIds: ["e1"] },
+      why_paths: [
+        { from: "e1", to: "e1", relId: "r1", type: "REL" },
+      ],
+    });
+    const { service, neo4jSession } = createService([valid, valid]);
+
+    const first = await service.answer(baseRequest);
+    expect(first.answer).toBe("Test");
+    expect(graphragCacheHitRatio.get().values[0].value).toBe(0);
+
+    const second = await service.answer(baseRequest);
+    expect(second.answer).toBe("Test");
+    expect(graphragCacheHitRatio.get().values[0].value).toBeCloseTo(0.5);
+    expect(neo4jSession.run).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws user-facing error with trace id on invalid output", async () => {
+    const { service } = createService(["not-json", "not-json"]);
+    await expect(service.answer(baseRequest)).rejects.toBeInstanceOf(UserFacingError);
+    expect(graphragSchemaFailuresTotal.get().values[0].value).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add user-facing error mapper with trace IDs for GraphRAG
- track GraphRAG schema failures and cache efficiency metrics
- cover GraphRAG happy path, bad payload, and cache hit ratio in unit tests

## Testing
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*
- `npm install` *(fails: 404 Not Found - @turf/point-in-polygon@^7.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a188f3f0588333af251f8029ed5953