### PR TITLE
feat(ai): similarEntities resolver + entity drawer

### DIFF
--- a/server/src/graphql/resolvers/similarity.ts
+++ b/server/src/graphql/resolvers/similarity.ts
@@ -1,10 +1,46 @@
 import { z } from 'zod';
 import pino from 'pino';
+import { GraphQLError } from 'graphql';
+import { createHash } from 'crypto';
 import { getPostgresPool } from '../../config/database.js';
 import { withAuthAndPolicy } from '../../middleware/withAuthAndPolicy.js';
+import client from 'prom-client';
+import { register } from '../../monitoring/metrics.js';
+import EmbeddingService from '../../services/EmbeddingService.js';
 
 const log = pino({ name: 'similarity' });
 let pool: any = null;
+
+interface CacheEntry {
+  ts: number;
+  data: { id: string; score: number }[];
+}
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, CacheEntry>();
+
+const similarityMs = new client.Histogram({
+  name: 'similarity_ms',
+  help: 'similarity resolver latency in ms',
+  buckets: [5, 10, 25, 50, 100, 200, 400, 800],
+});
+const similarityCacheHitRatio = new client.Gauge({
+  name: 'similarity_cache_hit_ratio',
+  help: 'ratio of cache hits for similarity resolver',
+});
+register.registerMetric(similarityMs);
+register.registerMetric(similarityCacheHitRatio);
+let cacheHits = 0;
+let cacheMisses = 0;
+
+function updateCacheMetrics(hit: boolean) {
+  if (hit) {
+    cacheHits++;
+  } else {
+    cacheMisses++;
+  }
+  const total = cacheHits + cacheMisses;
+  similarityCacheHitRatio.set(total ? cacheHits / total : 0);
+}
 
 function getPool() {
   if (!pool) {
@@ -17,29 +53,51 @@ const Args = z.object({
   text: z.string().optional(),
   topK: z.number().int().min(1).max(100).default(20),
   tenantId: z.string()
-}).refine(a => a.entityId || a.text, { message:'entityId or text required' });
+}).refine((a) => a.entityId || a.text, { message: 'entityId or text required' });
+
+const embeddingService = new EmbeddingService();
 
 async function embeddingForText(text: string): Promise<number[]> {
-  // call embedding model (server-side). Return numeric array.
-  return new Array(1536).fill(0); // placeholder
+  try {
+    return await embeddingService.generateEmbedding({ text });
+  } catch (err) {
+    log.error({ err }, 'embedding generation failed');
+    return new Array(1536).fill(0);
+  }
 }
 
 export const similarityResolvers = {
   Query: {
     similarEntities: withAuthAndPolicy('read:entities', (args:any, ctx:any)=>({ type:'tenant', id: ctx.user.tenant }))(
       async (_: any, args: any, ctx: any) => {
+        const start = Date.now();
         const { entityId, text, topK } = Args.parse({ ...args, tenantId: ctx.user.tenant });
+
         let embedding: number[];
         if (entityId) {
           const r = await getPool().query(
             'SELECT embedding FROM entity_embeddings WHERE entity_id=$1 AND tenant_id=$2',
             [entityId, ctx.user.tenant]
           );
-          if (!r.rowCount) return [];
+          if (!r.rowCount || !r.rows[0].embedding) {
+            throw new GraphQLError('Embedding missing for entity', {
+              extensions: { code: 'UNPROCESSABLE_ENTITY' },
+            });
+          }
           embedding = r.rows[0].embedding;
         } else {
           embedding = await embeddingForText(text!);
         }
+
+        const hash = createHash('sha256').update(embedding.join(',')).digest('base64');
+        const key = `${hash}:${topK}`;
+        const hit = cache.get(key);
+        if (hit && Date.now() - hit.ts < CACHE_TTL_MS) {
+          updateCacheMetrics(true);
+          similarityMs.observe(Date.now() - start);
+          return hit.data;
+        }
+
         const rows = await getPool().query(
           `SELECT e.entity_id, 1 - (e.embedding <=> $1::vector) AS score
            FROM entity_embeddings e
@@ -48,9 +106,14 @@ export const similarityResolvers = {
            LIMIT $3`,
           [`[${embedding.join(',')}]`, ctx.user.tenant, topK]
         );
-        // hydrate minimal entity data (fast path) if a cache exists; else return ids+scores
+
+        const data = rows.rows.map((r: any) => ({ id: r.entity_id, score: Number(r.score) }));
+        cache.set(key, { data, ts: Date.now() });
+        updateCacheMetrics(false);
+
         log.info({ count: rows.rowCount }, 'similarEntities');
-        return rows.rows.map(r => ({ id: r.entity_id, score: Number(r.score) }));
+        similarityMs.observe(Date.now() - start);
+        return data;
       }
     )
   }

--- a/ui/components/EntityDrawer.tsx
+++ b/ui/components/EntityDrawer.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { gql, useQuery } from "@apollo/client";
+import { Drawer, List, ListItem, ListItemText } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+const SIMILAR_QUERY = gql`
+  query SimilarEntities($entityId: ID!, $topK: Int!) {
+    similarEntities(entityId: $entityId, topK: $topK) {
+      id
+      score
+    }
+  }
+`;
+
+interface Props {
+  entityId?: string;
+  open: boolean;
+  onClose: () => void;
+  topK?: number;
+}
+
+export default function EntityDrawer({
+  entityId,
+  open,
+  onClose,
+  topK = 20,
+}: Props) {
+  const navigate = useNavigate();
+  const { data, loading } = useQuery(SIMILAR_QUERY, {
+    variables: { entityId: entityId as string, topK },
+    skip: !open || !entityId,
+  });
+
+  return (
+    <Drawer anchor="right" open={open} onClose={onClose}>
+      <List sx={{ width: 360, p: 2 }}>
+        <ListItem>
+          <ListItemText primary="Similar Entities" />
+        </ListItem>
+        {loading && (
+          <ListItem>
+            <ListItemText primary="Loading..." />
+          </ListItem>
+        )}
+        {data?.similarEntities?.map((n: { id: string; score: number }) => (
+          <ListItem
+            key={n.id}
+            button
+            onClick={() => {
+              navigate(`/entities/${n.id}`);
+              onClose();
+            }}
+          >
+            <ListItemText
+              primary={n.id}
+              secondary={`${(n.score * 100).toFixed(1)}%`}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## Summary
- implement similarEntities resolver with pgvector search, caching and telemetry
- add EntityDrawer component to display and navigate similar entities

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in workflow YAML)*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a1891975b083339a4889fdd4901157