### PR TITLE
feat: add semantic search service

### DIFF
--- a/server/src/graphql/resolvers/entity.ts
+++ b/server/src/graphql/resolvers/entity.ts
@@ -1,9 +1,14 @@
-import { getNeo4jDriver, isNeo4jMockMode } from '../../db/neo4j.js';
-import { v4 as uuidv4 } from 'uuid';
-import pino from 'pino';
-import { pubsub, ENTITY_CREATED, ENTITY_UPDATED, ENTITY_DELETED } from '../subscriptions.js';
-import { getPostgresPool } from '../../db/postgres.js';
-import axios from 'axios'; // For calling ML service
+import { getNeo4jDriver, isNeo4jMockMode } from "../../db/neo4j.js";
+import { v4 as uuidv4 } from "uuid";
+import pino from "pino";
+import {
+  pubsub,
+  ENTITY_CREATED,
+  ENTITY_UPDATED,
+  ENTITY_DELETED,
+} from "../subscriptions.js";
+import { getPostgresPool } from "../../db/postgres.js";
+import axios from "axios"; // For calling ML service
 
 const logger = pino();
 const driver = getNeo4jDriver();
@@ -15,17 +20,17 @@ const entityResolvers = {
       if (isNeo4jMockMode()) {
         return getMockEntity(id);
       }
-      
+
       const session = driver.session();
       try {
         const result = await session.run(
-          'MATCH (n:Entity {id: $id}) RETURN n',
-          { id }
+          "MATCH (n:Entity {id: $id}) RETURN n",
+          { id },
         );
         if (result.records.length === 0) {
           return null;
         }
-        const record = result.records[0].get('n');
+        const record = result.records[0].get("n");
         return {
           id: record.properties.id,
           type: record.labels[0], // Assuming the first label is the primary type
@@ -34,23 +39,31 @@ const entityResolvers = {
           updatedAt: record.properties.updatedAt,
         };
       } catch (error) {
-        logger.error({ error, id }, 'Error fetching entity by ID');
+        logger.error({ error, id }, "Error fetching entity by ID");
         // Fallback to mock data if database connection fails
-        logger.warn('Falling back to mock entity data');
+        logger.warn("Falling back to mock entity data");
         return getMockEntity(id);
       } finally {
         await session.close();
       }
     },
-    entities: async (_: any, { type, q, limit, offset }: { type?: string, q?: string, limit: number, offset: number }) => {
+    entities: async (
+      _: any,
+      {
+        type,
+        q,
+        limit,
+        offset,
+      }: { type?: string; q?: string; limit: number; offset: number },
+    ) => {
       // Return mock data if database is not available
       if (isNeo4jMockMode()) {
         return getMockEntities(type, q, limit, offset);
       }
-      
+
       const session = driver.session();
       try {
-        let query = 'MATCH (n:Entity)';
+        let query = "MATCH (n:Entity)";
         const params: any = {};
 
         if (type) {
@@ -70,8 +83,8 @@ const entityResolvers = {
         params.offset = offset;
 
         const result = await session.run(query, params);
-        return result.records.map(record => {
-          const entity = record.get('n');
+        return result.records.map((record) => {
+          const entity = record.get("n");
           return {
             id: entity.properties.id,
             type: entity.labels[0],
@@ -81,100 +94,73 @@ const entityResolvers = {
           };
         });
       } catch (error) {
-        logger.error({ error, type, q, limit, offset }, 'Error fetching entities');
+        logger.error(
+          { error, type, q, limit, offset },
+          "Error fetching entities",
+        );
         throw new Error(`Failed to fetch entities: ${error.message}`);
       } finally {
         await session.close();
       }
     },
-    semanticSearch: async (_: any, { query, type, props, limit, offset }: { query: string, type?: string, props?: any, limit: number, offset: number }) => {
-      const pgPool = getPostgresPool();
-      const neo4jSession = driver.session();
-      let pgClient;
-
+    semanticSearch: async (
+      _: any,
+      {
+        query,
+        filters,
+        limit,
+        offset,
+      }: { query: string; filters?: any; limit: number; offset: number },
+    ) => {
+      const session = driver.session();
       try {
-        // 1. Get embedding for the query from ML service
-        const mlServiceUrl = process.env.ML_SERVICE_URL || 'http://localhost:8081';
-        const embeddingResponse = await axios.post(`${mlServiceUrl}/gnn/generate_embeddings`, {
-          graph_data: { nodes: [{ id: 'query', features: [] }] }, // Dummy graph for query embedding
-          node_features: { query: [0.0] }, // Placeholder for actual query features
-          model_name: 'text_embedding_model', // Assuming a text embedding model in ML service
-          job_id: `semantic-search-${Date.now()}`,
-        });
-        const queryEmbedding = embeddingResponse.data.node_embeddings.query;
+        const searchService = new (
+          await import("../../services/SemanticSearchService.js")
+        ).default();
+        const docs = await searchService.search(
+          query,
+          filters || {},
+          limit + offset,
+        );
+        const sliced = docs.slice(offset);
+        const ids = sliced.map((d) => d.metadata.graphId).filter(Boolean);
 
-        if (!queryEmbedding || queryEmbedding.length === 0) {
-          throw new Error('Failed to get embedding for query from ML service.');
-        }
+        if (ids.length === 0) return [];
 
-        // 2. Perform vector similarity search in PostgreSQL with filters
-        pgClient = await pgPool.connect();
-        const embeddingVectorString = `[${queryEmbedding.join(',')}]`;
-
-        let pgQuery = `SELECT ee.entity_id FROM entity_embeddings ee`;
-        let pgQueryParams: any[] = [embeddingVectorString];
-        let paramIndex = 2; // Start index for additional parameters
-
-        // Add filters for type and props
-        if (type || props) {
-          pgQuery += ` JOIN entities e ON ee.entity_id = e.id WHERE 1=1`; // Assuming 'entities' table exists with 'id' and 'type'
-          if (type) {
-            pgQuery += ` AND e.type = ${paramIndex}`;
-            pgQueryParams.push(type);
-            paramIndex++;
-          }
-          if (props) {
-            // This is a simplified example. Real JSONB querying would be more complex.
-            // Assuming props is a flat object and we're checking for existence of keys/values.
-            for (const key in props) {
-              pgQuery += ` AND e.props->>'${key}' = ${paramIndex}`;
-              pgQueryParams.push(props[key]);
-              paramIndex++;
-            }
-          }
-        }
-
-        pgQuery += ` ORDER BY ee.embedding <-> $1 LIMIT ${paramIndex} OFFSET ${paramIndex + 1}`;
-        pgQueryParams.push(limit);
-        pgQueryParams.push(offset);
-
-        const pgResult = await pgClient.query(pgQuery, pgQueryParams);
-
-        const entityIds = pgResult.rows.map(row => row.entity_id);
-
-        if (entityIds.length === 0) {
-          return [];
-        }
-
-        // 3. Fetch corresponding entities from Neo4j
-        const neo4jResult = await neo4jSession.run(
-          `MATCH (n:Entity) WHERE n.id IN $entityIds RETURN n`,
-          { entityIds }
+        const result = await session.run(
+          `MATCH (n:Entity) WHERE n.id IN $ids RETURN n`,
+          { ids },
         );
 
-        return neo4jResult.records.map(record => {
-          const entity = record.get('n');
-          return {
+        const entityMap = new Map();
+        result.records.forEach((record) => {
+          const entity = record.get("n");
+          entityMap.set(entity.properties.id, {
             id: entity.properties.id,
             type: entity.labels[0],
             props: entity.properties,
             createdAt: entity.properties.createdAt,
             updatedAt: entity.properties.updatedAt,
-          };
+          });
         });
+
+        return ids.map((id) => entityMap.get(id)).filter(Boolean);
       } catch (error) {
-        logger.error({ error, query, type, props }, 'Error performing semantic search with filters');
+        logger.error(
+          { error, query, filters },
+          "Error performing semantic search with filters",
+        );
         throw new Error(`Failed to perform semantic search: ${error.message}`);
       } finally {
-        if (pgClient) {
-          pgClient.release();
-        }
-        await neo4jSession.close();
+        await session.close();
       }
     },
   },
   Mutation: {
-    createEntity: async (_: any, { input }: { input: { type: string, props: any } }) => {
+    createEntity: async (
+      _: any,
+      { input }: { input: { type: string; props: any } },
+    ) => {
       const session = driver.session();
       try {
         const id = uuidv4();
@@ -184,9 +170,9 @@ const entityResolvers = {
 
         const result = await session.run(
           `CREATE (n:Entity:${type} $props) RETURN n`,
-          { props }
+          { props },
         );
-        const record = result.records[0].get('n');
+        const record = result.records[0].get("n");
         const entity = {
           id: record.properties.id,
           type: record.labels[0],
@@ -197,17 +183,20 @@ const entityResolvers = {
         pubsub.publish(ENTITY_CREATED, entity); // Publish event
         return entity;
       } catch (error) {
-        logger.error({ error, input }, 'Error creating entity');
+        logger.error({ error, input }, "Error creating entity");
         throw new Error(`Failed to create entity: ${error.message}`);
       } finally {
         await session.close();
       }
     },
-    updateEntity: async (_: any, { id, input }: { id: string, input: { type?: string, props?: any } }) => {
+    updateEntity: async (
+      _: any,
+      { id, input }: { id: string; input: { type?: string; props?: any } },
+    ) => {
       const session = driver.session();
       try {
         const updatedAt = new Date().toISOString();
-        let query = 'MATCH (n:Entity {id: $id})';
+        let query = "MATCH (n:Entity {id: $id})";
         const params: any = { id, updatedAt };
 
         if (input.type) {
@@ -228,7 +217,7 @@ const entityResolvers = {
         if (result.records.length === 0) {
           return null; // Or throw an error if entity not found
         }
-        const record = result.records[0].get('n');
+        const record = result.records[0].get("n");
         const entity = {
           id: record.properties.id,
           type: record.labels[0],
@@ -239,7 +228,7 @@ const entityResolvers = {
         pubsub.publish(ENTITY_UPDATED, entity); // Publish event
         return entity;
       } catch (error) {
-        logger.error({ error, id, input }, 'Error updating entity');
+        logger.error({ error, id, input }, "Error updating entity");
         throw new Error(`Failed to update entity: ${error.message}`);
       } finally {
         await session.close();
@@ -251,8 +240,8 @@ const entityResolvers = {
         // Soft delete: set a 'deletedAt' timestamp
         const deletedAt = new Date().toISOString();
         const result = await session.run(
-          'MATCH (n:Entity {id: $id}) SET n.deletedAt = $deletedAt RETURN n',
-          { id, deletedAt }
+          "MATCH (n:Entity {id: $id}) SET n.deletedAt = $deletedAt RETURN n",
+          { id, deletedAt },
         );
         if (result.records.length === 0) {
           return false; // Or throw an error if entity not found
@@ -260,7 +249,7 @@ const entityResolvers = {
         pubsub.publish(ENTITY_DELETED, id); // Publish event (just the ID)
         return true;
       } catch (error) {
-        logger.error({ error, id }, 'Error deleting entity');
+        logger.error({ error, id }, "Error deleting entity");
         throw new Error(`Failed to delete entity: ${error.message}`);
       } finally {
         await session.close();
@@ -268,11 +257,15 @@ const entityResolvers = {
     },
     linkEntities: async (_: any, { text }: { text: string }) => {
       try {
-        const mlServiceUrl = process.env.ML_SERVICE_URL || 'http://localhost:8081';
-        const response = await axios.post(`${mlServiceUrl}/nlp/entity_linking`, {
-          text: text,
-          job_id: `entity-linking-${Date.now()}`,
-        });
+        const mlServiceUrl =
+          process.env.ML_SERVICE_URL || "http://localhost:8081";
+        const response = await axios.post(
+          `${mlServiceUrl}/nlp/entity_linking`,
+          {
+            text: text,
+            job_id: `entity-linking-${Date.now()}`,
+          },
+        );
 
         // The ML service returns a queued response, so we need to poll or use a webhook
         // For simplicity, this resolver will assume the ML service returns the result directly
@@ -280,7 +273,7 @@ const entityResolvers = {
         // and having a separate subscription for job completion).
 
         // Assuming the ML service returns the linked entities directly for this demo
-        if (response.data.status === 'completed' && response.data.entities) {
+        if (response.data.status === "completed" && response.data.entities) {
           return response.data.entities.map((entity: any) => ({
             text: entity.text,
             label: entity.label,
@@ -289,31 +282,45 @@ const entityResolvers = {
             entityId: entity.entity_id,
           }));
         } else {
-          throw new Error(`ML service did not return completed entities: ${response.data.status}`);
+          throw new Error(
+            `ML service did not return completed entities: ${response.data.status}`,
+          );
         }
       } catch (error) {
-        logger.error({ error, text }, 'Error linking entities');
+        logger.error({ error, text }, "Error linking entities");
         throw new Error(`Failed to link entities: ${error.message}`);
       }
     },
-    extractRelationships: async (_: any, { text, entities }: { text: string, entities: any[] }) => {
+    extractRelationships: async (
+      _: any,
+      { text, entities }: { text: string; entities: any[] },
+    ) => {
       const neo4jSession = driver.session(); // Get Neo4j session
       try {
-        const mlServiceUrl = process.env.ML_SERVICE_URL || 'http://localhost:8081';
-        const response = await axios.post(`${mlServiceUrl}/nlp/relationship_extraction`, {
-          text: text,
-          entities: entities,
-          job_id: `relationship-extraction-${Date.now()}`,
-        });
+        const mlServiceUrl =
+          process.env.ML_SERVICE_URL || "http://localhost:8081";
+        const response = await axios.post(
+          `${mlServiceUrl}/nlp/relationship_extraction`,
+          {
+            text: text,
+            entities: entities,
+            job_id: `relationship-extraction-${Date.now()}`,
+          },
+        );
 
-        if (response.data.status === 'completed' && response.data.relationships) {
-          const extractedRelationships = response.data.relationships.map((rel: any) => ({
-            sourceEntityId: rel.source_entity_id,
-            targetEntityId: rel.target_entity_id,
-            type: rel.type,
-            confidence: rel.confidence,
-            textSpan: rel.text_span,
-          }));
+        if (
+          response.data.status === "completed" &&
+          response.data.relationships
+        ) {
+          const extractedRelationships = response.data.relationships.map(
+            (rel: any) => ({
+              sourceEntityId: rel.source_entity_id,
+              targetEntityId: rel.target_entity_id,
+              type: rel.type,
+              confidence: rel.confidence,
+              textSpan: rel.text_span,
+            }),
+          );
 
           // Create relationships in Neo4j
           for (const rel of extractedRelationships) {
@@ -331,17 +338,28 @@ const entityResolvers = {
               CREATE (source)-[r:${rel.type} $props]->(target)
               RETURN r
               `,
-              { sourceId: rel.sourceEntityId, targetId: rel.targetEntityId, props: props }
+              {
+                sourceId: rel.sourceEntityId,
+                targetId: rel.targetEntityId,
+                props: props,
+              },
             );
-            logger.info(`Created relationship: ${rel.sourceEntityId}-[${rel.type}]->${rel.targetEntityId}`);
+            logger.info(
+              `Created relationship: ${rel.sourceEntityId}-[${rel.type}]->${rel.targetEntityId}`,
+            );
           }
 
           return extractedRelationships;
         } else {
-          throw new Error(`ML service did not return completed relationships: ${response.data.status}`);
+          throw new Error(
+            `ML service did not return completed relationships: ${response.data.status}`,
+          );
         }
       } catch (error) {
-        logger.error({ error, text, entities }, 'Error extracting relationships');
+        logger.error(
+          { error, text, entities },
+          "Error extracting relationships",
+        );
         throw new Error(`Failed to extract relationships: ${error.message}`);
       } finally {
         await neo4jSession.close(); // Close Neo4j session
@@ -351,88 +369,94 @@ const entityResolvers = {
 };
 
 // Mock data for development when database is not available
-function getMockEntities(type?: string, q?: string, limit: number = 25, offset: number = 0) {
+function getMockEntities(
+  type?: string,
+  q?: string,
+  limit: number = 25,
+  offset: number = 0,
+) {
   const mockEntities = [
     {
-      id: 'mock-entity-1',
-      type: 'PERSON',
+      id: "mock-entity-1",
+      type: "PERSON",
       props: {
-        name: 'John Smith',
-        email: 'john.smith@example.com',
-        phone: '+1-555-0101',
-        location: 'New York, NY'
+        name: "John Smith",
+        email: "john.smith@example.com",
+        phone: "+1-555-0101",
+        location: "New York, NY",
       },
-      createdAt: '2024-08-15T12:00:00Z',
-      updatedAt: '2024-08-15T12:00:00Z'
+      createdAt: "2024-08-15T12:00:00Z",
+      updatedAt: "2024-08-15T12:00:00Z",
     },
     {
-      id: 'mock-entity-2',
-      type: 'ORGANIZATION',
+      id: "mock-entity-2",
+      type: "ORGANIZATION",
       props: {
-        name: 'Tech Corp Industries',
-        industry: 'Technology',
-        headquarters: 'San Francisco, CA',
-        website: 'https://techcorp.example.com'
+        name: "Tech Corp Industries",
+        industry: "Technology",
+        headquarters: "San Francisco, CA",
+        website: "https://techcorp.example.com",
       },
-      createdAt: '2024-08-15T12:00:00Z',
-      updatedAt: '2024-08-15T12:00:00Z'
+      createdAt: "2024-08-15T12:00:00Z",
+      updatedAt: "2024-08-15T12:00:00Z",
     },
     {
-      id: 'mock-entity-3',
-      type: 'EVENT',
+      id: "mock-entity-3",
+      type: "EVENT",
       props: {
-        name: 'Data Breach Incident',
-        date: '2024-08-01',
-        severity: 'HIGH',
-        status: 'INVESTIGATING'
+        name: "Data Breach Incident",
+        date: "2024-08-01",
+        severity: "HIGH",
+        status: "INVESTIGATING",
       },
-      createdAt: '2024-08-15T12:00:00Z',
-      updatedAt: '2024-08-15T12:00:00Z'
+      createdAt: "2024-08-15T12:00:00Z",
+      updatedAt: "2024-08-15T12:00:00Z",
     },
     {
-      id: 'mock-entity-4',
-      type: 'LOCATION',
+      id: "mock-entity-4",
+      type: "LOCATION",
       props: {
-        name: 'Corporate Headquarters',
-        address: '100 Market Street, San Francisco, CA 94105',
-        coordinates: { lat: 37.7749, lng: -122.4194 }
+        name: "Corporate Headquarters",
+        address: "100 Market Street, San Francisco, CA 94105",
+        coordinates: { lat: 37.7749, lng: -122.4194 },
       },
-      createdAt: '2024-08-15T12:00:00Z',
-      updatedAt: '2024-08-15T12:00:00Z'
+      createdAt: "2024-08-15T12:00:00Z",
+      updatedAt: "2024-08-15T12:00:00Z",
     },
     {
-      id: 'mock-entity-5',
-      type: 'ASSET',
+      id: "mock-entity-5",
+      type: "ASSET",
       props: {
-        name: 'Database Server DB-01',
-        type: 'SERVER',
-        ip_address: '192.168.1.100',
-        status: 'ACTIVE'
+        name: "Database Server DB-01",
+        type: "SERVER",
+        ip_address: "192.168.1.100",
+        status: "ACTIVE",
       },
-      createdAt: '2024-08-15T12:00:00Z',
-      updatedAt: '2024-08-15T12:00:00Z'
-    }
+      createdAt: "2024-08-15T12:00:00Z",
+      updatedAt: "2024-08-15T12:00:00Z",
+    },
   ];
 
   let filtered = mockEntities;
-  
+
   if (type) {
-    filtered = filtered.filter(entity => entity.type === type);
+    filtered = filtered.filter((entity) => entity.type === type);
   }
-  
+
   if (q) {
-    filtered = filtered.filter(entity => 
-      JSON.stringify(entity.props).toLowerCase().includes(q.toLowerCase()) ||
-      entity.type.toLowerCase().includes(q.toLowerCase())
+    filtered = filtered.filter(
+      (entity) =>
+        JSON.stringify(entity.props).toLowerCase().includes(q.toLowerCase()) ||
+        entity.type.toLowerCase().includes(q.toLowerCase()),
     );
   }
-  
+
   return filtered.slice(offset, offset + limit);
 }
 
 function getMockEntity(id: string) {
   const entities = getMockEntities();
-  return entities.find(entity => entity.id === id) || null;
+  return entities.find((entity) => entity.id === id) || null;
 }
 
 export default entityResolvers;

--- a/server/src/graphql/schema.ts
+++ b/server/src/graphql/schema.ts
@@ -270,9 +270,16 @@ Cache operation result
 type CacheOperationResult {
   """Whether the operation succeeded"""
   success: Boolean!
-  
+
   """Human readable message"""
   message: String!
+}
+
+input SemanticSearchFilter {
+  source: String
+  dateFrom: DateTime
+  dateTo: DateTime
+  threatLevel: Int
 }
 
   type Query {
@@ -284,7 +291,7 @@ type CacheOperationResult {
     users(limit: Int = 25, offset: Int = 0): [User!]!
     investigation(id: ID!): Investigation
     investigations(limit: Int = 25, offset: Int = 0): [Investigation!]!
-    semanticSearch(query: String!, type: String, props: JSON, limit: Int = 10, offset: Int = 0): [Entity!]! # Enhanced query
+    semanticSearch(query: String!, filters: SemanticSearchFilter, limit: Int = 10, offset: Int = 0): [Entity!]! # Enhanced query
     
     # AI Analysis Queries
     """

--- a/server/src/services/SemanticSearchService.ts
+++ b/server/src/services/SemanticSearchService.ts
@@ -1,0 +1,145 @@
+import EmbeddingService from "./EmbeddingService.js";
+import pino from "pino";
+
+export interface IndexDocumentInput {
+  id: string;
+  text: string;
+  graphId?: string;
+  source?: string;
+  date?: string;
+  threatLevel?: number;
+}
+
+export interface SemanticSearchFilters {
+  source?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  threatLevel?: number;
+}
+
+export interface SemanticSearchResult {
+  id: string;
+  text: string;
+  score: number;
+  metadata: Record<string, any>;
+}
+
+export default class SemanticSearchService {
+  private client: any;
+  private embeddingService: EmbeddingService;
+  private indexName: string;
+  private logger = pino({ name: "SemanticSearchService" });
+
+  constructor(client?: any, embeddingService?: EmbeddingService) {
+    this.client = client || null;
+    this.embeddingService = embeddingService || new EmbeddingService();
+    this.indexName = process.env.WEAVIATE_INDEX || "IngestedDocument";
+  }
+
+  private async getClient() {
+    if (this.client) return this.client;
+    try {
+      const weaviate = await import("weaviate-ts-client");
+      const apiKey = process.env.WEAVIATE_API_KEY
+        ? new weaviate.ApiKey(process.env.WEAVIATE_API_KEY)
+        : undefined;
+      this.client = weaviate.client({
+        scheme: process.env.WEAVIATE_SCHEME || "http",
+        host: process.env.WEAVIATE_HOST || "localhost:8080",
+        apiKey,
+      });
+      return this.client;
+    } catch (err: any) {
+      this.logger.error({ err }, "Failed to initialize Weaviate client");
+      throw new Error("Weaviate client not available");
+    }
+  }
+
+  async indexDocument(doc: IndexDocumentInput) {
+    const client = await this.getClient();
+    const vector = await this.embeddingService.generateEmbedding({
+      text: doc.text,
+    });
+    await client.data
+      .creator()
+      .withClassName(this.indexName)
+      .withId(doc.id)
+      .withVector(vector)
+      .withProperties({
+        text: doc.text,
+        graphId: doc.graphId,
+        source: doc.source,
+        date: doc.date,
+        threatLevel: doc.threatLevel,
+      })
+      .do();
+  }
+
+  async search(
+    query: string,
+    filters: SemanticSearchFilters = {},
+    limit = 10,
+  ): Promise<SemanticSearchResult[]> {
+    const client = await this.getClient();
+    const vector = await this.embeddingService.generateEmbedding({
+      text: query,
+    });
+
+    const operands: any[] = [];
+    if (filters.source) {
+      operands.push({
+        path: ["source"],
+        operator: "Equal",
+        valueString: filters.source,
+      });
+    }
+    if (filters.threatLevel !== undefined) {
+      operands.push({
+        path: ["threatLevel"],
+        operator: "Equal",
+        valueInt: filters.threatLevel,
+      });
+    }
+    if (filters.dateFrom) {
+      operands.push({
+        path: ["date"],
+        operator: "GreaterThanEqual",
+        valueDate: filters.dateFrom,
+      });
+    }
+    if (filters.dateTo) {
+      operands.push({
+        path: ["date"],
+        operator: "LessThanEqual",
+        valueDate: filters.dateTo,
+      });
+    }
+
+    const where =
+      operands.length > 0 ? { operator: "And", operands } : undefined;
+
+    const result = await client.graphql
+      .get()
+      .withClassName(this.indexName)
+      .withFields(
+        "id text source date threatLevel graphId _additional { distance }",
+      )
+      .withNearVector({ vector })
+      .withWhere(where)
+      .withLimit(limit)
+      .do();
+
+    const docs = result?.data?.Get?.[this.indexName] || [];
+    return docs.map((d: any) => ({
+      id: d.id,
+      text: d.text,
+      score: 1 - (d._additional?.distance ?? 0),
+      metadata: {
+        source: d.source,
+        date: d.date,
+        threatLevel: d.threatLevel,
+        graphId: d.graphId,
+      },
+    }));
+  }
+}

--- a/server/src/tests/semanticSearch.test.ts
+++ b/server/src/tests/semanticSearch.test.ts
@@ -1,0 +1,127 @@
+import SemanticSearchService from "../services/SemanticSearchService";
+
+describe("SemanticSearchService", () => {
+  class MockEmbeddingService {
+    async generateEmbedding({ text }: { text: string }): Promise<number[]> {
+      return [text.includes("threat") ? 1 : 0];
+    }
+  }
+
+  class MockWeaviateClient {
+    docs: any[] = [];
+    data = {
+      creator: () => {
+        const ctx = this;
+        const record: any = {};
+        return {
+          withClassName(name: string) {
+            record.className = name;
+            return this;
+          },
+          withId(id: string) {
+            record.id = id;
+            return this;
+          },
+          withVector(vector: number[]) {
+            record.vector = vector;
+            return this;
+          },
+          withProperties(props: any) {
+            record.props = props;
+            return this;
+          },
+          async do() {
+            ctx.docs.push(record);
+          },
+        };
+      },
+    };
+    graphql = {
+      get: () => {
+        const ctx = this;
+        const query: any = { limit: 10 };
+        return {
+          withClassName(name: string) {
+            query.className = name;
+            return this;
+          },
+          withFields(_f: string) {
+            return this;
+          },
+          withNearVector(nv: any) {
+            query.nearVector = nv;
+            return this;
+          },
+          withWhere(where: any) {
+            query.where = where;
+            return this;
+          },
+          withLimit(limit: number) {
+            query.limit = limit;
+            return this;
+          },
+          async do() {
+            let items = ctx.docs;
+            if (query.where?.operands) {
+              for (const op of query.where.operands) {
+                const field = op.path[0];
+                const val = op.valueString ?? op.valueInt ?? op.valueDate;
+                if (op.operator === "Equal") {
+                  items = items.filter((d) => d.props[field] === val);
+                } else if (op.operator === "GreaterThanEqual") {
+                  items = items.filter((d) => d.props[field] >= val);
+                } else if (op.operator === "LessThanEqual") {
+                  items = items.filter((d) => d.props[field] <= val);
+                }
+              }
+            }
+            items = items
+              .map((d) => ({
+                ...d.props,
+                _additional: {
+                  distance: Math.abs(d.vector[0] - query.nearVector.vector[0]),
+                },
+              }))
+              .sort((a, b) => a._additional.distance - b._additional.distance)
+              .slice(0, query.limit);
+            const data: any = {};
+            data[query.className] = items;
+            return { data: { Get: data } };
+          },
+        };
+      },
+    };
+  }
+
+  it("performs search with metadata filters", async () => {
+    const client = new MockWeaviateClient();
+    const service = new SemanticSearchService(
+      client as any,
+      new MockEmbeddingService() as any,
+    );
+
+    await service.indexDocument({
+      id: "1",
+      text: "threat report one",
+      source: "OSINT",
+      date: "2024-01-01",
+      threatLevel: 3,
+      graphId: "e1",
+    });
+    await service.indexDocument({
+      id: "2",
+      text: "benign report",
+      source: "OSINT",
+      date: "2024-01-02",
+      threatLevel: 1,
+      graphId: "e2",
+    });
+
+    const results = await service.search("threat", {
+      source: "OSINT",
+      threatLevel: 3,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].metadata.graphId).toBe("e1");
+  });
+});


### PR DESCRIPTION
## Summary
- add SemanticSearchService for vector-based document indexing and query using Weaviate
- wire semanticSearch GraphQL resolver to new service with metadata filters
- support filtering by source, date range, and threat level
- add unit test for semantic search filters

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in workflow YAML)*
- `npm test` *(fails: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a1824c57a883338207647e64a1cafd