### PR TITLE
feat: add counter-psyops detection agent

### DIFF
--- a/python/intelgraph_py/analytics/counter_psyops.py
+++ b/python/intelgraph_py/analytics/counter_psyops.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+RED = "\033[91m"
+RESET = "\033[0m"
+
+
+@dataclass(frozen=True)
+class SourceClaim:
+  source: str
+  entity: str
+  claim: str
+
+
+def detect_misleading_information(claims: Iterable[SourceClaim]) -> List[str]:
+  """Detect conflicting claims across sources.
+
+  Groups claims by entity and flags those where multiple distinct claims
+  exist. Each flagged source and entity is wrapped in ANSI red for review.
+  """
+  entity_map: Dict[str, Dict[str, List[str]]] = {}
+  for sc in claims:
+    entity_map.setdefault(sc.entity, {}).setdefault(sc.claim, []).append(sc.source)
+
+  flagged: List[str] = []
+  for entity, claim_map in entity_map.items():
+    if len(claim_map) > 1:
+      for claim, sources in claim_map.items():
+        for src in sources:
+          flagged.append(
+            f"{RED}{src}{RESET} reports '{claim}' about {RED}{entity}{RESET}"
+          )
+  return flagged

--- a/python/tests/test_counter_psyops.py
+++ b/python/tests/test_counter_psyops.py
@@ -1,0 +1,24 @@
+from intelgraph_py.analytics.counter_psyops import (
+  RED,
+  SourceClaim,
+  detect_misleading_information,
+)
+
+
+def test_detect_misleading_information_flags_conflicts():
+  claims = [
+    SourceClaim("source1", "entity", "claimA"),
+    SourceClaim("source2", "entity", "claimB"),
+  ]
+  flagged = detect_misleading_information(claims)
+  assert len(flagged) == 2
+  assert all(RED in line for line in flagged)
+
+
+def test_detect_misleading_information_no_conflicts():
+  claims = [
+    SourceClaim("source1", "entity", "claimA"),
+    SourceClaim("source2", "entity", "claimA"),
+  ]
+  flagged = detect_misleading_information(claims)
+  assert flagged == []


### PR DESCRIPTION
## Summary
- add counter-psyops detector to flag conflicting claims across sources
- test highlight behavior for misleading information

## Testing
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*
- `PYTHONPATH=. pytest` *(fails: SyntaxError in tests/test_explainability_engine.py)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: multiple syntax errors in project files)*

------
https://chatgpt.com/codex/tasks/task_e_68a188267db083339c2c0f569948aa1e