### PR TITLE
feat: add behavioral fingerprinting to identity resolution

### DIFF
--- a/server/src/services/BehavioralFingerprintService.ts
+++ b/server/src/services/BehavioralFingerprintService.ts
@@ -1,0 +1,64 @@
+export interface BehavioralTelemetry {
+  clicks: number;
+  timeInView: number; // seconds
+  editRate: number; // edits per minute
+}
+
+export interface BehavioralFingerprint {
+  clicksPerMinute: number;
+  attentionSpan: number;
+  editRate: number;
+}
+
+export class BehavioralFingerprintService {
+  computeFingerprint(events: BehavioralTelemetry[]): BehavioralFingerprint {
+    const totals = events.reduce(
+      (acc, e) => {
+        acc.clicks += e.clicks;
+        acc.time += e.timeInView;
+        acc.edit += e.editRate;
+        return acc;
+      },
+      { clicks: 0, time: 0, edit: 0 },
+    );
+    const minutes = totals.time / 60 || 1; // avoid divide by zero
+    return {
+      clicksPerMinute: totals.clicks / minutes,
+      attentionSpan: totals.time / events.length || 0,
+      editRate: totals.edit / events.length || 0,
+    };
+  }
+
+  scoreFingerprint(fp: BehavioralFingerprint): number {
+    return (
+      fp.clicksPerMinute * 0.4 + fp.attentionSpan * 0.2 + fp.editRate * 0.4
+    );
+  }
+
+  clusterFingerprints(
+    items: { id: string; fingerprint: BehavioralFingerprint }[],
+  ): Map<string, string[]> {
+    const clusters = new Map<string, string[]>();
+    let clusterIdx = 0;
+    for (const item of items) {
+      let assigned = false;
+      for (const [clusterId, members] of clusters.entries()) {
+        const rep = items.find((i) => i.id === members[0])!.fingerprint;
+        const dist =
+          Math.abs(rep.clicksPerMinute - item.fingerprint.clicksPerMinute) +
+          Math.abs(rep.attentionSpan - item.fingerprint.attentionSpan) +
+          Math.abs(rep.editRate - item.fingerprint.editRate);
+        if (dist < 50) {
+          members.push(item.id);
+          assigned = true;
+          break;
+        }
+      }
+      if (!assigned) {
+        clusterIdx += 1;
+        clusters.set(`cluster-${clusterIdx}`, [item.id]);
+      }
+    }
+    return clusters;
+  }
+}

--- a/server/src/tests/behavioralFingerprintWorker.test.ts
+++ b/server/src/tests/behavioralFingerprintWorker.test.ts
@@ -1,0 +1,35 @@
+import { runBehavioralFingerprintJob } from "../workers/behavioralFingerprintWorker";
+
+describe("behavioral fingerprint job", () => {
+  it("scores and clusters identities across projects", async () => {
+    const data = [
+      {
+        id: "alice",
+        projectId: "A",
+        telemetry: [
+          { clicks: 10, timeInView: 120, editRate: 2 },
+          { clicks: 5, timeInView: 60, editRate: 1 },
+        ],
+      },
+      {
+        id: "bob",
+        projectId: "B",
+        telemetry: [
+          { clicks: 11, timeInView: 118, editRate: 2 },
+          { clicks: 4, timeInView: 70, editRate: 1 },
+        ],
+      },
+      {
+        id: "charlie",
+        projectId: "C",
+        telemetry: [{ clicks: 1, timeInView: 10, editRate: 0.5 }],
+      },
+    ];
+    const result = await runBehavioralFingerprintJob(data);
+    expect(result.fingerprints.length).toBe(3);
+    const clusters = Array.from(result.clusters.values());
+    const clusterWithAlice = clusters.find((c) => c.includes("alice"));
+    expect(clusterWithAlice).toBeDefined();
+    expect(clusterWithAlice).toContain("bob");
+  });
+});

--- a/server/src/workers/behavioralFingerprintWorker.ts
+++ b/server/src/workers/behavioralFingerprintWorker.ts
@@ -1,0 +1,18 @@
+import { EntityResolutionService } from "../services/EntityResolutionService.js";
+import { BehavioralTelemetry } from "../services/BehavioralFingerprintService.js";
+
+interface IdentityInput {
+  id: string;
+  projectId: string;
+  telemetry: BehavioralTelemetry[];
+}
+
+export async function runBehavioralFingerprintJob(identities: IdentityInput[]) {
+  const er = new EntityResolutionService();
+  const fingerprints = identities.map((i) => {
+    const { fingerprint, score } = er.fuseBehavioralFingerprint(i.telemetry);
+    return { id: i.id, projectId: i.projectId, fingerprint, score };
+  });
+  const clusters = er.clusterIdentitiesAcrossProjects(identities);
+  return { fingerprints, clusters };
+}


### PR DESCRIPTION
## Summary
- compute behavioral fingerprints from telemetry traits
- integrate fingerprint scoring and clustering with entity resolution
- add job and tests for cross-project identity clustering

## Testing
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js')*
- `npm run lint` *(fails: thousands of lint errors across repo)*
- `npm run format` *(fails: YAML syntax errors in workflows)*
- `npm test` *(fails: client/src/components/graph/CytoscapeGraph.jsx syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68a187fafa84833395e579c18db0c5c0