### PR TITLE
feat: add investigation templates

### DIFF
--- a/client/src/components/dashboard/Dashboard.jsx
+++ b/client/src/components/dashboard/Dashboard.jsx
@@ -20,10 +20,12 @@ import { useNavigate } from 'react-router-dom';
 import OnboardingTour from '../onboarding/OnboardingTour';
 import ActivityWidget from '../activity/ActivityWidget';
 import ServiceHealthCard from './ServiceHealthCard';
+import TemplateModal from '../templates/TemplateModal';
 
 function Dashboard() {
   const navigate = useNavigate();
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const [showTemplateModal, setShowTemplateModal] = useState(false);
 
   const CREATE_ALERT = gql`
     mutation DemoAlert($title: String!, $message: String!) {
@@ -75,6 +77,9 @@ function Dashboard() {
           size="large"
         >
           New Investigation
+        </Button>
+        <Button sx={{ ml: 2 }} variant="outlined" onClick={() => setShowTemplateModal(true)} size="large">
+          Start from Template
         </Button>
         <Button sx={{ ml: 2 }} variant="outlined" onClick={() => createAlert({ variables: { title: 'Demo alert', message: 'This is a demo alert from Dashboard' } })}>
           Send Demo Alert
@@ -159,6 +164,13 @@ function Dashboard() {
 
       {showOnboarding && (
         <OnboardingTour open onClose={() => { localStorage.setItem('onboarding_seen', '1'); setShowOnboarding(false); }} />
+      )}
+      {showTemplateModal && (
+        <TemplateModal
+          open={showTemplateModal}
+          onClose={() => setShowTemplateModal(false)}
+          onSelect={(tpl) => navigate(`/investigations?template=${tpl.id}`)}
+        />
       )}
     </Box>
   );

--- a/client/src/components/templates/TemplateModal.jsx
+++ b/client/src/components/templates/TemplateModal.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  ToggleButton,
+  ToggleButtonGroup,
+} from "@mui/material";
+import { TemplatesAPI } from "../../services/api.js";
+
+const TemplateModal = ({ open, onClose, onSelect }) => {
+  const [templates, setTemplates] = useState([]);
+  const [scope, setScope] = useState("org");
+
+  useEffect(() => {
+    if (open) {
+      loadTemplates();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, scope]);
+
+  const loadTemplates = async () => {
+    try {
+      const data = await TemplatesAPI.list({ scope });
+      setTemplates(data.templates || []);
+    } catch (err) {
+      console.error("Failed to load templates", err);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Start from Template</DialogTitle>
+      <DialogContent>
+        <ToggleButtonGroup
+          value={scope}
+          exclusive
+          onChange={(_, v) => v && setScope(v)}
+          size="small"
+          sx={{ mb: 2 }}
+        >
+          <ToggleButton value="org">Shared</ToggleButton>
+          <ToggleButton value="personal">My Templates</ToggleButton>
+        </ToggleButtonGroup>
+        <List>
+          {templates.map((t) => (
+            <ListItem
+              button
+              key={t.id}
+              onClick={() => {
+                onSelect && onSelect(t);
+                onClose();
+              }}
+            >
+              <ListItemText
+                primary={t.name}
+                secondary={t.scope === "org" ? "Shared" : "Personal"}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default TemplateModal;

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -69,6 +69,19 @@ export const ActivityAPI = {
   },
 };
 
+export const TemplatesAPI = {
+  list: ({ scope } = {}) => {
+    const qs = new URLSearchParams();
+    if (scope) qs.set('scope', scope);
+    const query = qs.toString();
+    return apiFetch(`/api/templates${query ? `?${query}` : ''}`);
+  },
+  create: (payload) => apiFetch('/api/templates', { method: 'POST', body: JSON.stringify(payload) }),
+  get: (id) => apiFetch(`/api/templates/${encodeURIComponent(id)}`),
+  update: (id, payload) => apiFetch(`/api/templates/${encodeURIComponent(id)}`, { method: 'PUT', body: JSON.stringify(payload) }),
+  remove: (id) => apiFetch(`/api/templates/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+};
+
 export const AdminAPI = {
   users: () => apiFetch('/api/admin/users'),
   setRole: (id, role) => apiFetch(`/api/admin/users/${encodeURIComponent(id)}/role`, { method: 'PATCH', body: JSON.stringify({ role }) }),

--- a/server/server.js
+++ b/server/server.js
@@ -226,6 +226,7 @@ async function startServer() {
     app.use('/api/activity', require('./src/routes/activity'));
     app.use('/api/admin', require('./src/routes/admin'));
     app.use('/api/import', require('./src/routes/import'));
+    app.use('/api/templates', require('./src/routes/templateRoutes'));
 
     // Webhook endpoint to ingest completed GNN suggestions (production-safe)
     app.post('/api/ai/gnn/suggestions', async (req, res) => {

--- a/server/src/controllers/TemplateController.js
+++ b/server/src/controllers/TemplateController.js
@@ -1,0 +1,74 @@
+class TemplateController {
+  constructor(templateService) {
+    this.templates = templateService;
+  }
+
+  async create(req, res) {
+    try {
+      const { name, data, scope } = req.body;
+      if (!name || !data) {
+        return res.status(400).json({ error: "Name and data are required" });
+      }
+      const ownerId = req.user.id;
+      const template = this.templates.createTemplate({
+        name,
+        data,
+        scope,
+        ownerId,
+      });
+      res.status(201).json(template);
+    } catch (err) {
+      console.error("Error creating template", err);
+      res.status(500).json({ error: "Failed to create template" });
+    }
+  }
+
+  async list(req, res) {
+    try {
+      const scope = req.query.scope;
+      const userId = req.user.id;
+      const templates = this.templates.listTemplates({ scope, userId });
+      res.json({ templates });
+    } catch (err) {
+      console.error("Error listing templates", err);
+      res.status(500).json({ error: "Failed to list templates" });
+    }
+  }
+
+  async get(req, res) {
+    try {
+      const template = this.templates.getTemplate(req.params.id);
+      if (!template)
+        return res.status(404).json({ error: "Template not found" });
+      res.json(template);
+    } catch (err) {
+      console.error("Error getting template", err);
+      res.status(500).json({ error: "Failed to get template" });
+    }
+  }
+
+  async update(req, res) {
+    try {
+      const updated = this.templates.updateTemplate(req.params.id, req.body);
+      if (!updated)
+        return res.status(404).json({ error: "Template not found" });
+      res.json(updated);
+    } catch (err) {
+      console.error("Error updating template", err);
+      res.status(500).json({ error: "Failed to update template" });
+    }
+  }
+
+  async delete(req, res) {
+    try {
+      const ok = this.templates.deleteTemplate(req.params.id);
+      if (!ok) return res.status(404).json({ error: "Template not found" });
+      res.json({ success: true });
+    } catch (err) {
+      console.error("Error deleting template", err);
+      res.status(500).json({ error: "Failed to delete template" });
+    }
+  }
+}
+
+module.exports = TemplateController;

--- a/server/src/routes/templateRoutes.js
+++ b/server/src/routes/templateRoutes.js
@@ -1,0 +1,17 @@
+const express = require("express");
+const TemplateController = require("../controllers/TemplateController");
+const templateService = require("../services/TemplateService");
+const { ensureAuthenticated } = require("../middleware/auth");
+
+const router = express.Router();
+const controller = new TemplateController(templateService);
+
+router.use(ensureAuthenticated);
+
+router.get("/", (req, res) => controller.list(req, res));
+router.post("/", (req, res) => controller.create(req, res));
+router.get("/:id", (req, res) => controller.get(req, res));
+router.put("/:id", (req, res) => controller.update(req, res));
+router.delete("/:id", (req, res) => controller.delete(req, res));
+
+module.exports = router;

--- a/server/src/services/TemplateService.js
+++ b/server/src/services/TemplateService.js
@@ -1,0 +1,51 @@
+class TemplateService {
+  constructor() {
+    this.templates = new Map();
+  }
+
+  createTemplate({ name, data, scope = "org", ownerId }) {
+    const id = `tmpl_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    const now = new Date();
+    const template = {
+      id,
+      name,
+      data,
+      scope: scope === "personal" ? "personal" : "org",
+      ownerId: scope === "personal" ? ownerId : null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.templates.set(id, template);
+    return template;
+  }
+
+  listTemplates({ scope, userId } = {}) {
+    let result = Array.from(this.templates.values());
+    if (scope === "org") {
+      result = result.filter((t) => t.scope === "org");
+    } else if (scope === "personal") {
+      result = result.filter(
+        (t) => t.scope === "personal" && t.ownerId === userId,
+      );
+    }
+    return result;
+  }
+
+  getTemplate(id) {
+    return this.templates.get(id);
+  }
+
+  updateTemplate(id, updates) {
+    const existing = this.templates.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...updates, updatedAt: new Date() };
+    this.templates.set(id, updated);
+    return updated;
+  }
+
+  deleteTemplate(id) {
+    return this.templates.delete(id);
+  }
+}
+
+module.exports = new TemplateService();

--- a/server/tests/templateService.test.js
+++ b/server/tests/templateService.test.js
@@ -1,0 +1,40 @@
+const TemplateService = require("../src/services/TemplateService");
+
+describe("TemplateService", () => {
+  afterEach(() => {
+    TemplateService.templates.clear();
+  });
+
+  it("creates and retrieves templates", () => {
+    const tpl = TemplateService.createTemplate({
+      name: "Test",
+      data: { graph: {} },
+      scope: "personal",
+      ownerId: "u1",
+    });
+    expect(tpl.id).toBeDefined();
+    const fetched = TemplateService.getTemplate(tpl.id);
+    expect(fetched.name).toBe("Test");
+  });
+
+  it("lists templates by scope", () => {
+    const orgTpl = TemplateService.createTemplate({
+      name: "Org",
+      data: {},
+      scope: "org",
+    });
+    TemplateService.createTemplate({
+      name: "Mine",
+      data: {},
+      scope: "personal",
+      ownerId: "u2",
+    });
+    const orgList = TemplateService.listTemplates({ scope: "org" });
+    expect(orgList.find((t) => t.id === orgTpl.id)).toBeTruthy();
+    const personalList = TemplateService.listTemplates({
+      scope: "personal",
+      userId: "u2",
+    });
+    expect(personalList).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add backend CRUD endpoints for investigation templates
- expose template APIs in client with selection modal
- include basic template service tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Map keys must be unique in GitHub workflow files)*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a185c967688333bca51d85abd6813e