### PR TITLE
feat: add sentiment analysis for text nodes

### DIFF
--- a/client/src/components/graph/EnhancedGraphExplorer.jsx
+++ b/client/src/components/graph/EnhancedGraphExplorer.jsx
@@ -369,7 +369,7 @@ function EnhancedGraphExplorer() {
       selector: 'node',
       style: {
         'background-color': (ele) => getNodeColor(ele.data('type')),
-        'label': 'data(label)',
+        'label': (ele) => `${getSentimentIcon(ele.data('sentimentLabel'))}${ele.data('label')}`,
         'color': '#333',
         'font-size': '12px',
         'font-weight': 'bold',
@@ -1002,6 +1002,17 @@ function EnhancedGraphExplorer() {
       }
     });
 
+    cy.on('mouseover', 'node', (evt) => {
+      const node = evt.target;
+      const label = node.data('sentimentLabel');
+      const score = node.data('sentimentScore');
+      const tooltip = label ? `${label} (${(score || 0).toFixed(2)})` : '';
+      cy.container().setAttribute('title', tooltip);
+    });
+    cy.on('mouseout', 'node', () => {
+      cy.container().removeAttribute('title');
+    });
+
     // Double click to edit
     cy.on('dblclick', 'node, edge', (evt) => {
       handleEditElement(evt.target);
@@ -1147,6 +1158,19 @@ function EnhancedGraphExplorer() {
   const getNodeIcon = (type) => {
     // This would return actual icon URLs in a real implementation
     return null;
+  };
+
+  const getSentimentIcon = (label) => {
+    switch (label) {
+      case 'positive':
+        return '🟢 ';
+      case 'negative':
+        return '🔴 ';
+      case 'neutral':
+        return '⚪ ';
+      default:
+        return '';
+    }
   };
 
   const highlightConnectedElements = useCallback((node) => {

--- a/python/intelgraph_py/database.py
+++ b/python/intelgraph_py/database.py
@@ -20,3 +20,13 @@ Base = declarative_base()
 # Dependency to get a database session
 def create_db_tables(engine):
     Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    engine = get_engine()
+    SessionLocal = get_session_local(engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/python/intelgraph_py/schemas.py
+++ b/python/intelgraph_py/schemas.py
@@ -68,3 +68,11 @@ class AlertLogInDB(AlertLogBase):
 
     class Config:
         from_attributes = True
+
+
+# --- Sentiment Analysis Schema ---
+class SentimentRequest(BaseModel):
+    node_id: str
+    node_label: str
+    text: str
+

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,3 +9,5 @@ langchain-community
 ollama
 redis
 python-json-logger
+transformers
+torch

--- a/python/tests/test_sentiment_analysis.py
+++ b/python/tests/test_sentiment_analysis.py
@@ -1,0 +1,50 @@
+import os
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+# Ensure in-memory DB and Celery eager for tests
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from intelgraph_py.main import app
+from intelgraph_py.tasks import analyze_sentiment
+
+client = TestClient(app)
+
+
+def test_sentiment_endpoint_triggers_task(monkeypatch):
+    mock_task = MagicMock()
+    monkeypatch.setattr("intelgraph_py.tasks.analyze_sentiment.delay", lambda *a, **k: mock_task)
+    mock_task.id = "task123"
+    res = client.post("/analyze/sentiment", json={"node_id": "1", "node_label": "Report", "text": "good"})
+    assert res.status_code == 200
+    assert res.json()["task_id"] == "task123"
+    assert mock_task.id == "task123"
+
+
+def test_analyze_sentiment_task_updates_graph(monkeypatch):
+    mock_pipeline = MagicMock(return_value=[{"label": "LABEL_2", "score": 0.95}])
+    monkeypatch.setattr("intelgraph_py.tasks.get_sentiment_pipeline", lambda: mock_pipeline)
+
+    class DummySession:
+        def run(self, q, **p):
+            self.q = q
+            self.params = p
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    class DummyDriver:
+        def session(self):
+            return DummySession()
+        def close(self):
+            pass
+    monkeypatch.setattr("intelgraph_py.tasks.GraphDatabase", MagicMock(driver=lambda *a, **k: DummyDriver()))
+
+    result = analyze_sentiment("42", "Great job", "Report")
+    assert result["sentimentLabel"] == "positive"
+    assert result["sentimentScore"] == 0.95
+


### PR DESCRIPTION
## Summary
- queue sentiment analysis through Celery using HuggingFace model and update Neo4j node metadata
- expose `/analyze/sentiment` endpoint for submitting text for sentiment classification
- display color-coded sentiment icons with tooltips in graph explorer UI
- cover new sentiment task with unit tests

## Testing
- `pytest python/tests/test_sentiment_analysis.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: YAML syntax errors in workflow files)*
- `npm test` *(fails: Prettier syntax errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a1859d4f748333b10a660a3a86dc3b