### PR TITLE
feat: add GraphQL audit logging middleware

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,113 +1,49 @@
-import 'dotenv/config'
-import express from 'express'
-import { ApolloServer } from '@apollo/server'
-import { expressMiddleware } from '@as-integrations/express4'
-import { makeExecutableSchema } from '@graphql-tools/schema'
-import cors from 'cors'
-import helmet from 'helmet'
-import rateLimit from 'express-rate-limit'
-import pino from 'pino'
-import { pinoHttp } from 'pino-http'
-import monitoringRouter from './routes/monitoring.js'
-import aiRouter from './routes/ai.js'
-import { typeDefs } from './graphql/schema.js'
-import resolvers from './graphql/resolvers/index.js'
-import { getContext } from './lib/auth.js'
-import { getNeo4jDriver } from './db/neo4j.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const app = express()
-const logger: pino.Logger = pino();
-app.use(helmet())
-app.use(cors({ origin: process.env.CORS_ORIGIN?.split(',') ?? ['http://localhost:3000'], credentials: true }))
-app.use(pinoHttp({ logger, redact: ['req.headers.authorization'] }))
-
-// Rate limiting (exempt monitoring endpoints)
-app.use('/monitoring', monitoringRouter)
-app.use('/api/ai', aiRouter)
-app.use(rateLimit({
-  windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
-  max: Number(process.env.RATE_LIMIT_MAX || 600),
-  message: { error: 'Too many requests, please try again later' }
-}))
-
-app.get('/search/evidence', async (req, res) => {
-  const { q, skip = 0, limit = 10 } = req.query;
-
-  if (!q) {
-    return res.status(400).send({ error: "Query parameter 'q' is required" });
-  }
-
-  const driver = getNeo4jDriver();
-  const session = driver.session();
-
-  try {
-    const searchQuery = `
-      CALL db.index.fulltext.queryNodes("evidenceContentSearch", $query) YIELD node, score
-      RETURN node, score
-      SKIP $skip
-      LIMIT $limit
-    `;
-
-    const countQuery = `
-      CALL db.index.fulltext.queryNodes("evidenceContentSearch", $query) YIELD node
-      RETURN count(node) as total
-    `;
-
-    const [searchResult, countResult] = await Promise.all([
-      session.run(searchQuery, {
-        query: q,
-        skip: Number(skip),
-        limit: Number(limit),
-      }),
-      session.run(countQuery, { query: q }),
-    ]);
-
-    import 'dotenv/config'
-import express from 'express'
-import { ApolloServer } from '@apollo/server'
-import { expressMiddleware } from '@as-integrations/express4'
-import { makeExecutableSchema } from '@graphql-tools/schema'
-import cors from 'cors'
-import helmet from 'helmet'
-import rateLimit from 'express-rate-limit'
-import pino from 'pino'
-import { pinoHttp } from 'pino-http'
-import monitoringRouter from './routes/monitoring.js'
-import aiRouter from './routes/ai.js'
-import { typeDefs } from './graphql/schema.js'
-import resolvers from './graphql/resolvers/index.js'
-import { getContext } from './lib/auth.js'
-import { getNeo4jDriver } from './db/neo4j.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import WSPersistedQueriesMiddleware from './graphql/middleware/wsPersistedQueries.js';
+import "dotenv/config";
+import express from "express";
+import { ApolloServer } from "@apollo/server";
+import { expressMiddleware } from "@as-integrations/express4";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import cors from "cors";
+import helmet from "helmet";
+import rateLimit from "express-rate-limit";
+import pino from "pino";
+import { pinoHttp } from "pino-http";
+import monitoringRouter from "./routes/monitoring.js";
+import aiRouter from "./routes/ai.js";
+import { typeDefs } from "./graphql/schema.js";
+import resolvers from "./graphql/resolvers/index.js";
+import { getContext } from "./lib/auth.js";
+import { getNeo4jDriver } from "./db/neo4j.js";
+import path from "path";
+import { fileURLToPath } from "url";
 
 export const createApp = async () => {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = path.dirname(__filename);
 
-  const app = express()
+  const app = express();
   const logger: pino.Logger = pino();
-  app.use(helmet())
-  app.use(cors({ origin: process.env.CORS_ORIGIN?.split(',') ?? ['http://localhost:3000'], credentials: true }))
-  app.use(pinoHttp({ logger, redact: ['req.headers.authorization'] }))
+  app.use(helmet());
+  app.use(
+    cors({
+      origin: process.env.CORS_ORIGIN?.split(",") ?? ["http://localhost:3000"],
+      credentials: true,
+    }),
+  );
+  app.use(pinoHttp({ logger, redact: ["req.headers.authorization"] }));
 
   // Rate limiting (exempt monitoring endpoints)
-  app.use('/monitoring', monitoringRouter)
-  app.use('/api/ai', aiRouter)
-  app.use(rateLimit({
-    windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
-    max: Number(process.env.RATE_LIMIT_MAX || 600),
-    message: { error: 'Too many requests, please try again later' }
-  }))
+  app.use("/monitoring", monitoringRouter);
+  app.use("/api/ai", aiRouter);
+  app.use(
+    rateLimit({
+      windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
+      max: Number(process.env.RATE_LIMIT_MAX || 600),
+      message: { error: "Too many requests, please try again later" },
+    }),
+  );
 
-  app.get('/search/evidence', async (req, res) => {
+  app.get("/search/evidence", async (req, res) => {
     const { q, skip = 0, limit = 10 } = req.query;
 
     if (!q) {
@@ -157,8 +93,10 @@ export const createApp = async () => {
         },
       });
     } catch (error) {
-      logger.error(`Error in search/evidence: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      res.status(500).send({ error: 'Internal server error' });
+      logger.error(
+        `Error in search/evidence: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+      res.status(500).send({ error: "Internal server error" });
     } finally {
       await session.close();
     }
@@ -167,70 +105,40 @@ export const createApp = async () => {
   const schema = makeExecutableSchema({ typeDefs, resolvers });
 
   // GraphQL over HTTP
-  const { persistedQueriesPlugin } = await import('./graphql/plugins/persistedQueries.js');
-  const { default: pbacPlugin } = await import('./graphql/plugins/pbac.js');
-  const { default: resolverMetricsPlugin } = await import('./graphql/plugins/resolverMetrics.js');
-  const { depthLimit } = await import('./graphql/validation/depthLimit.js');
+  const { persistedQueriesPlugin } = await import(
+    "./graphql/plugins/persistedQueries.js"
+  );
+  const { default: pbacPlugin } = await import("./graphql/plugins/pbac.js");
+  const { default: resolverMetricsPlugin } = await import(
+    "./graphql/plugins/resolverMetrics.js"
+  );
+  const { default: auditLoggerPlugin } = await import(
+    "./graphql/plugins/auditLogger.js"
+  );
+  const { depthLimit } = await import("./graphql/validation/depthLimit.js");
 
   const apollo = new ApolloServer({
     schema,
     // Order matters: PBAC early in execution lifecycle
-    plugins: [persistedQueriesPlugin as any, resolverMetricsPlugin as any],
+    plugins: [
+      persistedQueriesPlugin as any,
+      resolverMetricsPlugin as any,
+      auditLoggerPlugin as any,
+    ],
     // TODO: Complete PBAC Apollo Server 5 compatibility in separate task
     // plugins: [persistedQueriesPlugin as any, pbacPlugin() as any],
     // Disable introspection and playground in production
-    introspection: process.env.NODE_ENV !== 'production',
+    introspection: process.env.NODE_ENV !== "production",
     // Note: ApolloServer 4+ doesn't have playground config, handled by Apollo Studio
     // GraphQL query validation rules
     validationRules: [depthLimit(8)],
-  })
-  await apollo.start()
-  app.use('/graphql', express.json(), expressMiddleware(apollo, { context: getContext }))
+  });
+  await apollo.start();
+  app.use(
+    "/graphql",
+    express.json(),
+    expressMiddleware(apollo, { context: getContext }),
+  );
 
   return app;
 };
-
-    const total = countResult.records[0].get("total").toNumber();
-
-    res.send({
-      data: evidence,
-      metadata: {
-        total,
-        skip: Number(skip),
-        limit: Number(limit),
-        pages: Math.ceil(total / Number(limit)),
-        currentPage: Math.floor(Number(skip) / Number(limit)) + 1,
-      },
-    });
-  } catch (error) {
-    logger.error(`Error in search/evidence: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    res.status(500).send({ error: 'Internal server error' });
-  } finally {
-    await session.close();
-  }
-});
-
-const schema = makeExecutableSchema({ typeDefs, resolvers });
-
-// GraphQL over HTTP
-import { persistedQueriesPlugin } from './graphql/plugins/persistedQueries.js';
-import pbacPlugin from './graphql/plugins/pbac.js';
-import resolverMetricsPlugin from './graphql/plugins/resolverMetrics.js';
-import { depthLimit } from './graphql/validation/depthLimit.js';
-
-const apollo = new ApolloServer({
-  schema,
-  // Order matters: PBAC early in execution lifecycle
-  plugins: [persistedQueriesPlugin as any, resolverMetricsPlugin as any],
-  // TODO: Complete PBAC Apollo Server 5 compatibility in separate task
-  // plugins: [persistedQueriesPlugin as any, pbacPlugin() as any],
-  // Disable introspection and playground in production
-  introspection: process.env.NODE_ENV !== 'production',
-  // Note: ApolloServer 4+ doesn't have playground config, handled by Apollo Studio
-  // GraphQL query validation rules
-  validationRules: [depthLimit(8)],
-})
-await apollo.start()
-app.use('/graphql', express.json(), expressMiddleware(apollo, { context: getContext }))
-
-export default app;

--- a/server/src/graphql/plugins/auditLogger.ts
+++ b/server/src/graphql/plugins/auditLogger.ts
@@ -1,0 +1,96 @@
+import type {
+  ApolloServerPlugin,
+  GraphQLRequestListener,
+} from "@apollo/server";
+import fs from "fs";
+import axios from "axios";
+import { isEqual } from "lodash";
+
+const ELASTIC_URL = process.env.ELASTICSEARCH_URL;
+const LOG_FILE = process.env.AUDIT_LOG_FILE || "audit-log.jsonl";
+const ANONYMIZE = process.env.AUDIT_LOG_ANONYMIZE === "true";
+
+const anonymize = (value: unknown): any => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "object") {
+    if (Array.isArray(value)) {
+      return value.map(() => "[redacted]");
+    }
+    return Object.keys(value as Record<string, unknown>).reduce(
+      (acc, key) => ({ ...acc, [key]: anonymize((value as any)[key]) }),
+      {},
+    );
+  }
+  return "[redacted]";
+};
+
+const auditLoggerPlugin: ApolloServerPlugin = {
+  async requestDidStart(): Promise<GraphQLRequestListener<any>> {
+    const start = new Date();
+    return {
+      async willSendResponse(ctx) {
+        const operation = ctx.operation;
+        if (!operation || operation.operation !== "mutation") {
+          return;
+        }
+
+        const entity =
+          (operation.selectionSet.selections[0] as any)?.name?.value ||
+          "unknown";
+        const userId = ctx.contextValue?.user?.id ?? null;
+
+        const before = ctx.contextValue?.audit?.before;
+        const after =
+          ctx.contextValue?.audit?.after ||
+          (ctx.response.body.kind === "single"
+            ? (ctx.response.body.singleResult?.data as any)?.[entity]
+            : undefined);
+
+        const diff: Record<string, { before: unknown; after: unknown }> = {};
+        if (
+          before &&
+          after &&
+          typeof before === "object" &&
+          typeof after === "object"
+        ) {
+          const keys = new Set([
+            ...Object.keys(before as Record<string, unknown>),
+            ...Object.keys(after as Record<string, unknown>),
+          ]);
+          for (const key of keys) {
+            const b = (before as any)[key];
+            const a = (after as any)[key];
+            if (!isEqual(b, a)) {
+              diff[key] = {
+                before: ANONYMIZE ? anonymize(b) : b,
+                after: ANONYMIZE ? anonymize(a) : a,
+              };
+            }
+          }
+        }
+
+        const logEntry = {
+          timestamp: start.toISOString(),
+          userId: ANONYMIZE ? anonymize(userId) : userId,
+          operation: operation.operation,
+          entity,
+          diff,
+        };
+
+        try {
+          if (ELASTIC_URL) {
+            await axios.post(`${ELASTIC_URL}/audit/_doc`, logEntry, {
+              timeout: 2000,
+            });
+          } else {
+            throw new Error("No Elasticsearch URL");
+          }
+        } catch (_err) {
+          fs.appendFileSync(LOG_FILE, JSON.stringify(logEntry) + "\n");
+        }
+      },
+    };
+  },
+};
+
+export default auditLoggerPlugin;


### PR DESCRIPTION
## Summary
- integrate audit logging plugin into Apollo server
- log GraphQL mutations with before/after diff and anonymization option

## Testing
- `npm run lint:server` *(fails: Cannot find package '@eslint/js')*
- `npx prettier server/src/app.ts server/src/graphql/plugins/auditLogger.ts --write`
- `cd server && npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a18511a4148333ae1a39d97078c81d