### PR TITLE
feat: add AI-assisted link suggestions

### DIFF
--- a/client/src/components/graph/CytoscapeGraph.jsx
+++ b/client/src/components/graph/CytoscapeGraph.jsx
@@ -1,10 +1,10 @@
-import React, { useRef, useEffect, useState, useCallback } from 'react';
-import { 
-  Box, 
-  Paper, 
-  Typography, 
-  IconButton, 
-  Tooltip, 
+import React, { useRef, useEffect, useState, useCallback } from "react";
+import {
+  Box,
+  Paper,
+  Typography,
+  IconButton,
+  Tooltip,
   Fab,
   Button,
   Alert,
@@ -25,12 +25,12 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  TextField
-} from '@mui/material';
-import { 
-  ZoomIn, 
-  ZoomOut, 
-  CenterFocusStrong, 
+  TextField,
+} from "@mui/material";
+import {
+  ZoomIn,
+  ZoomOut,
+  CenterFocusStrong,
   Add,
   Save,
   Refresh,
@@ -43,24 +43,30 @@ import {
   GroupWork,
   PlayArrow,
   Stop,
-  Download
-} from '@mui/icons-material';
-import { useParams } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
-import { setGraphData, addNode, addEdge, setSelectedNode, setSelectedEdge } from '../../store/slices/graphSlice';
-import { setCommunityData } from '../../store/slices/aiInsightsSlice';
-import { useSocket } from '../../hooks/useSocket';
-import { useAIOperations } from '../../ai/insightsHooks';
-import AIInsightsPanel from '../ai/AIInsightsPanel';
-import { useApolloClient } from '@apollo/client';
-import cytoscape from 'cytoscape';
-import cola from 'cytoscape-cola';
-import dagre from 'cytoscape-dagre';
-import fcose from 'cytoscape-fcose';
-import coseBilkent from 'cytoscape-cose-bilkent';
-import popper from 'cytoscape-popper';
-import ReactDOM from 'react-dom/client';
-import GraphPopover from './GraphPopover';
+  Download,
+} from "@mui/icons-material";
+import { useParams } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  setGraphData,
+  addNode,
+  addEdge,
+  setSelectedNode,
+  setSelectedEdge,
+} from "../../store/slices/graphSlice";
+import { setCommunityData } from "../../store/slices/aiInsightsSlice";
+import { useSocket } from "../../hooks/useSocket";
+import { useAIOperations } from "../../ai/insightsHooks";
+import AIInsightsPanel from "../ai/AIInsightsPanel";
+import { useApolloClient } from "@apollo/client";
+import cytoscape from "cytoscape";
+import cola from "cytoscape-cola";
+import dagre from "cytoscape-dagre";
+import fcose from "cytoscape-fcose";
+import coseBilkent from "cytoscape-cose-bilkent";
+import popper from "cytoscape-popper";
+import ReactDOM from "react-dom/client";
+import GraphPopover from "./GraphPopover";
 
 // Register extensions
 cytoscape.use(cola);
@@ -76,120 +82,146 @@ function CytoscapeGraph() {
   const cyRef = useRef(null);
   const containerRef = useRef(null);
   const [cy, setCy] = useState(null);
-  const { nodes, edges, selectedNode, selectedEdge } = useSelector(state => state.graph);
-  const { highlightEnabled, selectedInsightType, communityData, communityIdFilter } = useSelector(state => state.aiInsights);
+  const { nodes, edges, selectedNode, selectedEdge } = useSelector(
+    (state) => state.graph,
+  );
+  const {
+    highlightEnabled,
+    selectedInsightType,
+    communityData,
+    communityIdFilter,
+  } = useSelector((state) => state.aiInsights);
   const [loading, setLoading] = useState(false);
   const [layoutMenuAnchor, setLayoutMenuAnchor] = useState(null);
-  const [currentLayout, setCurrentLayout] = useState('fcose');
+  const [currentLayout, setCurrentLayout] = useState("fcose");
   const [settingsOpen, setSettingsOpen] = useState(false);
-  
+
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const [realTimeEnabled, setRealTimeEnabled] = useState(false);
   const [notification, setNotification] = useState(null);
-  const [aiJobDialog, setAiJobDialog] = useState({ open: false, type: '', loading: false });
+  const [aiJobDialog, setAiJobDialog] = useState({
+    open: false,
+    type: "",
+    loading: false,
+  });
   const [filterSettings, setFilterSettings] = useState({
     nodeTypes: [],
     relationshipTypes: [],
-    timeRange: [0, 100]
+    timeRange: [0, 100],
   });
+  const [suggestedEdges, setSuggestedEdges] = useState([]);
 
   // WebSocket connection for real-time updates
-  const socket = useSocket('ws://localhost:4000');
-  
+  const socket = useSocket("ws://localhost:4000");
+
   // AI operations hook
   const aiOps = useAIOperations();
 
   // Advanced styling configuration
   const cytoscapeStyle = [
     {
-      selector: 'node',
+      selector: "node",
       style: {
-        'background-color': (ele) => getNodeColor(ele.data('type'), ele.data('id')),
-        'label': 'data(label)',
-        'color': '#333',
-        'font-size': '12px',
-        'font-weight': 'bold',
-        'text-halign': 'center',
-        'text-valign': 'center',
-        'border-width': 2,
-        'border-color': '#fff',
-        'width': (ele) => Math.max(30, ele.data('importance') * 10 || 30),
-        'height': (ele) => Math.max(30, ele.data('importance') * 10 || 30),
-        'overlay-opacity': 0,
-        'transition-property': 'background-color, border-color, width, height',
-        'transition-duration': '0.3s'
-      }
+        "background-color": (ele) =>
+          getNodeColor(ele.data("type"), ele.data("id")),
+        label: "data(label)",
+        color: "#333",
+        "font-size": "12px",
+        "font-weight": "bold",
+        "text-halign": "center",
+        "text-valign": "center",
+        "border-width": 2,
+        "border-color": "#fff",
+        width: (ele) => Math.max(30, ele.data("importance") * 10 || 30),
+        height: (ele) => Math.max(30, ele.data("importance") * 10 || 30),
+        "overlay-opacity": 0,
+        "transition-property": "background-color, border-color, width, height",
+        "transition-duration": "0.3s",
+      },
     },
     {
-      selector: 'node:selected',
+      selector: "node:selected",
       style: {
-        'border-color': '#FF6B35',
-        'border-width': 4,
-        'background-color': '#FFE5DB'
-      }
+        "border-color": "#FF6B35",
+        "border-width": 4,
+        "background-color": "#FFE5DB",
+      },
     },
     {
-      selector: 'node:hover',
+      selector: "node:hover",
       style: {
-        'border-color': '#4CAF50',
-        'border-width': 3
-      }
+        "border-color": "#4CAF50",
+        "border-width": 3,
+      },
     },
     {
-      selector: 'edge',
+      selector: "edge",
       style: {
-        'width': (ele) => Math.max(2, ele.data('weight') * 5 || 2),
-        'line-color': (ele) => getEdgeColor(ele.data('type')),
-        'target-arrow-color': (ele) => getEdgeColor(ele.data('type')),
-        'target-arrow-shape': 'triangle',
-        'curve-style': 'bezier',
-        'label': 'data(label)',
-        'font-size': '10px',
-        'text-rotation': 'autorotate',
-        'text-margin-y': -10,
-        'edge-text-rotation': 'autorotate',
-        'overlay-opacity': 0,
-        'transition-property': 'line-color, width',
-        'transition-duration': '0.3s'
-      }
+        width: (ele) => Math.max(2, ele.data("weight") * 5 || 2),
+        "line-color": (ele) => getEdgeColor(ele.data("type")),
+        "target-arrow-color": (ele) => getEdgeColor(ele.data("type")),
+        "target-arrow-shape": "triangle",
+        "curve-style": "bezier",
+        label: "data(label)",
+        "font-size": "10px",
+        "text-rotation": "autorotate",
+        "text-margin-y": -10,
+        "edge-text-rotation": "autorotate",
+        "overlay-opacity": 0,
+        "transition-property": "line-color, width",
+        "transition-duration": "0.3s",
+      },
     },
     {
-      selector: 'edge:selected',
+      selector: "edge:selected",
       style: {
-        'line-color': '#FF6B35',
-        'target-arrow-color': '#FF6B35',
-        'width': 6
-      }
+        "line-color": "#FF6B35",
+        "target-arrow-color": "#FF6B35",
+        width: 6,
+      },
     },
     {
-      selector: 'edge:hover',
+      selector: "edge:hover",
       style: {
-        'line-color': '#4CAF50',
-        'target-arrow-color': '#4CAF50'
-      }
+        "line-color": "#4CAF50",
+        "target-arrow-color": "#4CAF50",
+      },
     },
     {
-      selector: '.highlighted',
+      selector: "edge[suggested]",
       style: {
-        'background-color': '#FFD700',
-        'line-color': '#FFD700',
-        'target-arrow-color': '#FFD700',
-        'transition-property': 'background-color, line-color, target-arrow-color',
-        'transition-duration': '0.3s'
-      }
+        "line-style": "dashed",
+        "line-color": "#999",
+        "target-arrow-color": "#999",
+        label: "data(scoreLabel)",
+        "font-size": "10px",
+        "text-rotation": "autorotate",
+        "text-margin-y": -10,
+      },
     },
     {
-      selector: '.dimmed',
+      selector: ".highlighted",
       style: {
-        'opacity': 0.3
-      }
-    }
+        "background-color": "#FFD700",
+        "line-color": "#FFD700",
+        "target-arrow-color": "#FFD700",
+        "transition-property":
+          "background-color, line-color, target-arrow-color",
+        "transition-duration": "0.3s",
+      },
+    },
+    {
+      selector: ".dimmed",
+      style: {
+        opacity: 0.3,
+      },
+    },
   ];
 
   // Layout configurations
   const layoutConfigs = {
     fcose: {
-      name: 'fcose',
+      name: "fcose",
       quality: "default",
       randomize: false,
       animate: true,
@@ -202,10 +234,10 @@ function CytoscapeGraph() {
       nodeRepulsion: 4500,
       idealEdgeLength: 50,
       edgeElasticity: 0.45,
-      nestingFactor: 0.1
+      nestingFactor: 0.1,
     },
     cola: {
-      name: 'cola',
+      name: "cola",
       animate: true,
       animationDuration: 1000,
       refresh: 1,
@@ -218,21 +250,21 @@ function CytoscapeGraph() {
       avoidOverlap: true,
       handleDisconnected: true,
       convergenceThreshold: 0.01,
-      nodeSpacing: 10
+      nodeSpacing: 10,
     },
     dagre: {
-      name: 'dagre',
-      rankDir: 'TB',
+      name: "dagre",
+      rankDir: "TB",
       animate: true,
       animationDuration: 1000,
       fit: true,
       padding: 30,
       spacingFactor: 1.25,
       nodeDimensionsIncludeLabels: true,
-      ranker: 'network-simplex'
+      ranker: "network-simplex",
     },
-    'cose-bilkent': {
-      name: 'cose-bilkent',
+    "cose-bilkent": {
+      name: "cose-bilkent",
       animate: true,
       animationDuration: 1000,
       refresh: 30,
@@ -248,10 +280,10 @@ function CytoscapeGraph() {
       numIter: 2500,
       tile: true,
       tilingPaddingVertical: 10,
-      tilingPaddingHorizontal: 10
+      tilingPaddingHorizontal: 10,
     },
     circle: {
-      name: 'circle',
+      name: "circle",
       animate: true,
       animationDuration: 1000,
       fit: true,
@@ -260,10 +292,10 @@ function CytoscapeGraph() {
       startAngle: -Math.PI / 2,
       sweep: 2 * Math.PI,
       clockwise: true,
-      sort: undefined
+      sort: undefined,
     },
     grid: {
-      name: 'grid',
+      name: "grid",
       animate: true,
       animationDuration: 1000,
       fit: true,
@@ -274,88 +306,128 @@ function CytoscapeGraph() {
       spacingFactor: 1.25,
       condense: false,
       rows: undefined,
-      cols: undefined
-    }
+      cols: undefined,
+    },
   };
 
   const sampleNodes = [
-    { 
-      data: { 
-        id: '1', 
-        label: 'John Doe', 
-        type: 'PERSON', 
+    {
+      data: {
+        id: "1",
+        label: "John Doe",
+        type: "PERSON",
         importance: 3,
-        properties: { age: 35, occupation: 'Engineer' }
-      } 
+        properties: { age: 35, occupation: "Engineer" },
+      },
     },
-    { 
-      data: { 
-        id: '2', 
-        label: 'Acme Corp', 
-        type: 'ORGANIZATION', 
+    {
+      data: {
+        id: "2",
+        label: "Acme Corp",
+        type: "ORGANIZATION",
         importance: 4,
-        properties: { industry: 'Technology', employees: 1000 }
-      } 
+        properties: { industry: "Technology", employees: 1000 },
+      },
     },
-    { 
-      data: { 
-        id: '3', 
-        label: 'New York', 
-        type: 'LOCATION', 
+    {
+      data: {
+        id: "3",
+        label: "New York",
+        type: "LOCATION",
         importance: 2,
-        properties: { country: 'USA', population: 8000000 }
-      } 
+        properties: { country: "USA", population: 8000000 },
+      },
     },
-    { 
-      data: { 
-        id: '4', 
-        label: 'Document A', 
-        type: 'DOCUMENT', 
+    {
+      data: {
+        id: "4",
+        label: "Document A",
+        type: "DOCUMENT",
         importance: 1,
-        properties: { classification: 'Confidential', pages: 50 }
-      } 
+        properties: { classification: "Confidential", pages: 50 },
+      },
     },
   ];
 
   const sampleEdges = [
-    { 
-      data: { 
-        id: 'e1', 
-        source: '1', 
-        target: '2', 
-        label: 'WORKS_FOR', 
-        type: 'EMPLOYMENT',
+    {
+      data: {
+        id: "e1",
+        source: "1",
+        target: "2",
+        label: "WORKS_FOR",
+        type: "EMPLOYMENT",
         weight: 0.8,
-        properties: { since: '2020-01-01', role: 'Senior Engineer' }
-      } 
+        properties: { since: "2020-01-01", role: "Senior Engineer" },
+      },
     },
-    { 
-      data: { 
-        id: 'e2', 
-        source: '1', 
-        target: '3', 
-        label: 'LOCATED_AT', 
-        type: 'LOCATION',
+    {
+      data: {
+        id: "e2",
+        source: "1",
+        target: "3",
+        label: "LOCATED_AT",
+        type: "LOCATION",
         weight: 0.6,
-        properties: { address: '123 Main St' }
-      } 
+        properties: { address: "123 Main St" },
+      },
     },
-    { 
-      data: { 
-        id: 'e3', 
-        source: '2', 
-        target: '4', 
-        label: 'OWNS', 
-        type: 'OWNERSHIP',
+    {
+      data: {
+        id: "e3",
+        source: "2",
+        target: "4",
+        label: "OWNS",
+        type: "OWNERSHIP",
         weight: 0.9,
-        properties: { acquired: '2019-05-15' }
-      } 
+        properties: { acquired: "2019-05-15" },
+      },
     },
   ];
 
   useEffect(() => {
     dispatch(setGraphData({ nodes: sampleNodes, edges: sampleEdges }));
   }, [dispatch]);
+
+  useEffect(() => {
+    if (!selectedNode) return;
+    const fetchSuggestions = async () => {
+      try {
+        const res = await fetch("/ai/suggest-links", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            graph: { nodes, edges },
+            node_id: selectedNode.id,
+            top_k: 5,
+          }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setSuggestedEdges(data.suggestions || []);
+        }
+      } catch (err) {
+        console.error("Error fetching suggestions", err);
+      }
+    };
+    fetchSuggestions();
+  }, [selectedNode, nodes, edges]);
+
+  useEffect(() => {
+    if (!cy) return;
+    cy.edges("[suggested]").remove();
+    suggestedEdges.forEach((e) => {
+      cy.add({
+        data: {
+          id: `suggested-${e.source}-${e.target}`,
+          source: e.source,
+          target: e.target,
+          scoreLabel: e.score.toFixed(2),
+          suggested: true,
+        },
+      });
+    });
+  }, [cy, suggestedEdges]);
 
   useEffect(() => {
     if (containerRef.current && !cy) {
@@ -368,14 +440,14 @@ function CytoscapeGraph() {
         maxZoom: 10,
         wheelSensitivity: 0.1,
         boxSelectionEnabled: true,
-        selectionType: 'single'
+        selectionType: "single",
       });
 
       // Store popover instances
       const popovers = new Map();
 
       const showPopover = (ele) => {
-        const popperDiv = document.createElement('div');
+        const popperDiv = document.createElement("div");
         document.body.appendChild(popperDiv);
         const root = ReactDOM.createRoot(popperDiv);
         root.render(<GraphPopover data={ele.data()} />);
@@ -383,8 +455,8 @@ function CytoscapeGraph() {
         const popper = ele.popper({
           content: () => popperDiv,
           popper: {
-            placement: 'top',
-            strategy: 'fixed',
+            placement: "top",
+            strategy: "fixed",
           },
         });
 
@@ -402,19 +474,19 @@ function CytoscapeGraph() {
       };
 
       // Event handlers
-      cytoscapeInstance.on('tap', 'node', (evt) => {
+      cytoscapeInstance.on("tap", "node", (evt) => {
         const node = evt.target;
         dispatch(setSelectedNode(node.data()));
         highlightConnectedElements(node);
       });
 
-      cytoscapeInstance.on('tap', 'edge', (evt) => {
+      cytoscapeInstance.on("tap", "edge", (evt) => {
         const edge = evt.target;
         dispatch(setSelectedEdge(edge.data()));
         highlightEdge(edge);
       });
 
-      cytoscapeInstance.on('tap', (evt) => {
+      cytoscapeInstance.on("tap", (evt) => {
         if (evt.target === cytoscapeInstance) {
           dispatch(setSelectedNode(null));
           dispatch(setSelectedEdge(null));
@@ -423,16 +495,16 @@ function CytoscapeGraph() {
       });
 
       // Mouseover/mouseout for popovers
-      cytoscapeInstance.on('mouseover', 'node, edge', (evt) => {
+      cytoscapeInstance.on("mouseover", "node, edge", (evt) => {
         showPopover(evt.target);
       });
 
-      cytoscapeInstance.on('mouseout', 'node, edge', (evt) => {
+      cytoscapeInstance.on("mouseout", "node, edge", (evt) => {
         hidePopover(evt.target);
       });
 
       // Context menu setup
-      cytoscapeInstance.on('cxttap', 'node', (evt) => {
+      cytoscapeInstance.on("cxttap", "node", (evt) => {
         const node = evt.target;
         showContextMenu(evt, node);
       });
@@ -459,8 +531,8 @@ function CytoscapeGraph() {
   useEffect(() => {
     if (cy && (nodes.length > 0 || edges.length > 0)) {
       const elements = [
-        ...nodes.map(node => ({ data: node.data || node })),
-        ...edges.map(edge => ({ data: edge.data || edge }))
+        ...nodes.map((node) => ({ data: node.data || node })),
+        ...edges.map((edge) => ({ data: edge.data || edge })),
       ];
 
       cy.elements().remove();
@@ -474,13 +546,17 @@ function CytoscapeGraph() {
     if (!cy) return;
     let socket;
     try {
-      const url = (import.meta?.env?.VITE_WS_URL) || undefined;
-      const token = (typeof localStorage !== 'undefined' && (localStorage.getItem('auth_token') || localStorage.getItem('token'))) || undefined;
+      const url = import.meta?.env?.VITE_WS_URL || undefined;
+      const token =
+        (typeof localStorage !== "undefined" &&
+          (localStorage.getItem("auth_token") ||
+            localStorage.getItem("token"))) ||
+        undefined;
       // Connect to analytics namespace
-      const { io } = require('socket.io-client');
-      socket = io(url ? `${url}/graph-analytics` : '/graph-analytics', {
+      const { io } = require("socket.io-client");
+      socket = io(url ? `${url}/graph-analytics` : "/graph-analytics", {
         autoConnect: true,
-        transports: ['websocket'],
+        transports: ["websocket"],
         auth: token ? { token } : undefined,
       });
       const getHeat = (v) => {
@@ -489,125 +565,177 @@ function CytoscapeGraph() {
         const g = Math.floor(180 * (1 - x));
         return `rgb(${r},${g},80)`;
       };
-      socket.on('result', (ev) => {
+      socket.on("result", (ev) => {
         const updates = ev?.activity?.nodes || [];
         updates.forEach(({ id, activityScore }) => {
           const node = cy.getElementById(String(id));
           if (node && node.length) {
-            node.data('activityScore', activityScore);
-            node.style('background-color', getHeat(activityScore));
+            node.data("activityScore", activityScore);
+            node.style("background-color", getHeat(activityScore));
           }
         });
       });
-      socket.on('complete', () => {/* no-op */});
-    } catch (_) { /* ignore */ }
-    return () => { try { socket && socket.close(); } catch (_) {} };
+      socket.on("complete", () => {
+        /* no-op */
+      });
+    } catch (_) {
+      /* ignore */
+    }
+    return () => {
+      try {
+        socket && socket.close();
+      } catch (_) {}
+    };
   }, [cy]);
 
   const getCommunityColor = (communityId) => {
     const colors = [
-      '#FF6B35', '#6BFF35', '#356BFF', '#FF356B', '#35FF6B', '#6B35FF',
-      '#FFD700', '#ADFF2F', '#8A2BE2', '#00CED1', '#FF4500', '#7FFF00',
-      '#DC143C', '#00BFFF', '#FF1493', '#20B2AA', '#BA55D3', '#7B68EE'
+      "#FF6B35",
+      "#6BFF35",
+      "#356BFF",
+      "#FF356B",
+      "#35FF6B",
+      "#6B35FF",
+      "#FFD700",
+      "#ADFF2F",
+      "#8A2BE2",
+      "#00CED1",
+      "#FF4500",
+      "#7FFF00",
+      "#DC143C",
+      "#00BFFF",
+      "#FF1493",
+      "#20B2AA",
+      "#BA55D3",
+      "#7B68EE",
     ];
     return colors[communityId % colors.length];
   };
-
-  }, [cy]);
 
   // Apply AI Insights highlighting
   useEffect(() => {
     if (!cy) return;
 
-    if (highlightEnabled && selectedInsightType === 'community_detection' && Object.keys(communityData).length > 0) {
-      cy.nodes().forEach(node => {
-        const nodeId = node.data('id');
+    if (
+      highlightEnabled &&
+      selectedInsightType === "community_detection" &&
+      Object.keys(communityData).length > 0
+    ) {
+      cy.nodes().forEach((node) => {
+        const nodeId = node.data("id");
         const communityId = communityData[nodeId];
         const [min, max] = communityIdFilter;
 
         if (communityId !== undefined) {
           if (communityId >= min && communityId <= max) {
-            node.style('background-color', getCommunityColor(communityId));
-            node.removeClass('dimmed');
+            node.style("background-color", getCommunityColor(communityId));
+            node.removeClass("dimmed");
           } else {
-            node.style('background-color', getNodeColor(node.data('type'), node.data('id'))); // Revert to default color
-            node.addClass('dimmed');
+            node.style(
+              "background-color",
+              getNodeColor(node.data("type"), node.data("id")),
+            ); // Revert to default color
+            node.addClass("dimmed");
           }
         } else {
           // If node has no community data, revert to default and dim
-          node.style('background-color', getNodeColor(node.data('type'), node.data('id')));
-          node.addClass('dimmed');
+          node.style(
+            "background-color",
+            getNodeColor(node.data("type"), node.data("id")),
+          );
+          node.addClass("dimmed");
         }
       });
     } else {
       // Reset node colors to default based on type and remove dimming
-      cy.nodes().forEach(node => {
-        node.style('background-color', getNodeColor(node.data('type'), node.data('id')));
-        node.removeClass('dimmed');
+      cy.nodes().forEach((node) => {
+        node.style(
+          "background-color",
+          getNodeColor(node.data("type"), node.data("id")),
+        );
+        node.removeClass("dimmed");
       });
     }
-  }, [cy, highlightEnabled, selectedInsightType, communityData, communityIdFilter]);
+  }, [
+    cy,
+    highlightEnabled,
+    selectedInsightType,
+    communityData,
+    communityIdFilter,
+  ]);
 
   const getNodeColor = (type, nodeId) => {
-    if (highlightEnabled && selectedInsightType === 'community_detection' && communityData[nodeId] !== undefined) {
+    if (
+      highlightEnabled &&
+      selectedInsightType === "community_detection" &&
+      communityData[nodeId] !== undefined
+    ) {
       return getCommunityColor(communityData[nodeId]);
     }
     const colors = {
-      PERSON: '#4caf50',
-      ORGANIZATION: '#2196f3',
-      LOCATION: '#ff9800',
-      DOCUMENT: '#9c27b0',
-      EVENT: '#f44336',
-      ASSET: '#795548',
-      COMMUNICATION: '#607d8b'
+      PERSON: "#4caf50",
+      ORGANIZATION: "#2196f3",
+      LOCATION: "#ff9800",
+      DOCUMENT: "#9c27b0",
+      EVENT: "#f44336",
+      ASSET: "#795548",
+      COMMUNICATION: "#607d8b",
     };
-    return colors[type] || '#9e9e9e';
+    return colors[type] || "#9e9e9e";
   };
 
   const getEdgeColor = (type) => {
     const colors = {
-      EMPLOYMENT: '#4caf50',
-      LOCATION: '#ff9800',
-      OWNERSHIP: '#2196f3',
-      COMMUNICATION: '#607d8b',
-      FINANCIAL: '#795548',
-      FAMILY: '#e91e63',
-      ASSOCIATION: '#9c27b0'
+      EMPLOYMENT: "#4caf50",
+      LOCATION: "#ff9800",
+      OWNERSHIP: "#2196f3",
+      COMMUNICATION: "#607d8b",
+      FINANCIAL: "#795548",
+      FAMILY: "#e91e63",
+      ASSOCIATION: "#9c27b0",
     };
-    return colors[type] || '#666';
+    return colors[type] || "#666";
   };
 
-  const highlightConnectedElements = useCallback((node) => {
-    if (!cy) return;
-    
-    cy.elements().removeClass('highlighted dimmed');
-    
-    const connectedEdges = node.connectedEdges();
-    const connectedNodes = connectedEdges.connectedNodes();
-    
-    node.addClass('highlighted');
-    connectedEdges.addClass('highlighted');
-    connectedNodes.addClass('highlighted');
-    
-    cy.elements().difference(node.union(connectedEdges).union(connectedNodes)).addClass('dimmed');
-  }, [cy]);
+  const highlightConnectedElements = useCallback(
+    (node) => {
+      if (!cy) return;
 
-  const highlightEdge = useCallback((edge) => {
-    if (!cy) return;
-    
-    cy.elements().removeClass('highlighted dimmed');
-    
-    const connectedNodes = edge.connectedNodes();
-    
-    edge.addClass('highlighted');
-    connectedNodes.addClass('highlighted');
-    
-    cy.elements().difference(edge.union(connectedNodes)).addClass('dimmed');
-  }, [cy]);
+      cy.elements().removeClass("highlighted dimmed");
+
+      const connectedEdges = node.connectedEdges();
+      const connectedNodes = connectedEdges.connectedNodes();
+
+      node.addClass("highlighted");
+      connectedEdges.addClass("highlighted");
+      connectedNodes.addClass("highlighted");
+
+      cy.elements()
+        .difference(node.union(connectedEdges).union(connectedNodes))
+        .addClass("dimmed");
+    },
+    [cy],
+  );
+
+  const highlightEdge = useCallback(
+    (edge) => {
+      if (!cy) return;
+
+      cy.elements().removeClass("highlighted dimmed");
+
+      const connectedNodes = edge.connectedNodes();
+
+      edge.addClass("highlighted");
+      connectedNodes.addClass("highlighted");
+
+      cy.elements().difference(edge.union(connectedNodes)).addClass("dimmed");
+    },
+    [cy],
+  );
 
   const clearHighlights = useCallback(() => {
     if (!cy) return;
-    cy.elements().removeClass('highlighted dimmed');
+    cy.elements().removeClass("highlighted dimmed");
   }, [cy]);
 
   const applyLayout = (layoutName) => {
@@ -635,10 +763,10 @@ function CytoscapeGraph() {
       data: {
         id: `node_${Date.now()}`,
         label: `New Entity ${nodes.length + 1}`,
-        type: 'PERSON',
+        type: "PERSON",
         importance: Math.random() * 5,
-        properties: {}
-      }
+        properties: {},
+      },
     };
     dispatch(addNode(newNode));
   };
@@ -653,41 +781,47 @@ function CytoscapeGraph() {
 
   const showContextMenu = (evt, element) => {
     // Placeholder for context menu functionality
-    console.log('Context menu for:', element.data());
+    console.log("Context menu for:", element.data());
   };
 
   // WebSocket event handlers
   useEffect(() => {
     if (socket && realTimeEnabled) {
-      socket.on('graph:node:added', (nodeData) => {
+      socket.on("graph:node:added", (nodeData) => {
         dispatch(addNode(nodeData));
-        setNotification({ message: 'New node added to graph', severity: 'info' });
+        setNotification({
+          message: "New node added to graph",
+          severity: "info",
+        });
       });
 
-      socket.on('graph:edge:added', (edgeData) => {
+      socket.on("graph:edge:added", (edgeData) => {
         dispatch(addEdge(edgeData));
-        setNotification({ message: 'New relationship added', severity: 'info' });
+        setNotification({
+          message: "New relationship added",
+          severity: "info",
+        });
       });
 
-      socket.on('graph:node:updated', (nodeData) => {
+      socket.on("graph:node:updated", (nodeData) => {
         // Update existing node
         if (cy) {
           const node = cy.getElementById(nodeData.id);
           if (node.length) {
             node.data(nodeData);
-            setNotification({ message: 'Node updated', severity: 'info' });
+            setNotification({ message: "Node updated", severity: "info" });
           }
         }
       });
 
-      socket.on('ai:insight:created', (insight) => {
-        setNotification({ 
-          message: `New AI insight: ${insight.kind}`, 
-          severity: 'success' 
+      socket.on("ai:insight:created", (insight) => {
+        setNotification({
+          message: `New AI insight: ${insight.kind}`,
+          severity: "success",
         });
-        if (insight.kind === 'community_detection' && insight.data) {
+        if (insight.kind === "community_detection" && insight.data) {
           const newCommunityData = {};
-          insight.data.forEach(item => {
+          insight.data.forEach((item) => {
             if (item.nodeId && item.communityId !== undefined) {
               newCommunityData[item.nodeId] = item.communityId;
             }
@@ -697,59 +831,68 @@ function CytoscapeGraph() {
       });
 
       return () => {
-        socket.off('graph:node:added');
-        socket.off('graph:edge:added');
-        socket.off('graph:node:updated');
-        socket.off('ai:insight:created');
+        socket.off("graph:node:added");
+        socket.off("graph:edge:added");
+        socket.off("graph:node:updated");
+        socket.off("ai:insight:created");
       };
     }
   }, [socket, realTimeEnabled, cy, dispatch]);
 
   // AI Operations
   const handleAILinkPrediction = async () => {
-    setAiJobDialog({ open: true, type: 'link_prediction', loading: true });
+    setAiJobDialog({ open: true, type: "link_prediction", loading: true });
     try {
-      const result = await aiOps.predictLinks(apollo, id || 'current', 50);
-      setNotification({ 
-        message: `Link prediction job queued: ${result.data.aiLinkPredict.id}`, 
-        severity: 'success' 
+      const result = await aiOps.predictLinks(apollo, id || "current", 50);
+      setNotification({
+        message: `Link prediction job queued: ${result.data.aiLinkPredict.id}`,
+        severity: "success",
       });
     } catch (error) {
-      setNotification({ message: 'Failed to start link prediction', severity: 'error' });
+      setNotification({
+        message: "Failed to start link prediction",
+        severity: "error",
+      });
     } finally {
-      setAiJobDialog({ open: false, type: '', loading: false });
+      setAiJobDialog({ open: false, type: "", loading: false });
     }
   };
 
   const handleAICommunityDetection = async () => {
-    setAiJobDialog({ open: true, type: 'community_detection', loading: true });
+    setAiJobDialog({ open: true, type: "community_detection", loading: true });
     try {
-      const result = await aiOps.detectCommunities(apollo, id || 'current');
-      setNotification({ 
-        message: `Community detection job queued: ${result.data.aiCommunityDetect.id}`, 
-        severity: 'success' 
+      const result = await aiOps.detectCommunities(apollo, id || "current");
+      setNotification({
+        message: `Community detection job queued: ${result.data.aiCommunityDetect.id}`,
+        severity: "success",
       });
     } catch (error) {
-      setNotification({ message: 'Failed to start community detection', severity: 'error' });
+      setNotification({
+        message: "Failed to start community detection",
+        severity: "error",
+      });
     } finally {
-      setAiJobDialog({ open: false, type: '', loading: false });
+      setAiJobDialog({ open: false, type: "", loading: false });
     }
   };
 
   const handleAIEntityExtraction = async () => {
     if (selectedNode && selectedNode.text) {
-      setAiJobDialog({ open: true, type: 'entity_extraction', loading: true });
+      setAiJobDialog({ open: true, type: "entity_extraction", loading: true });
       try {
         const docs = [{ id: selectedNode.id, text: selectedNode.text }];
         const result = await aiOps.extractEntities(apollo, docs);
-        setNotification({ 
-          message: `Entity extraction job queued: ${result.data.aiExtractEntities.id}`, 
-          severity: 'success' 
+        setNotification({
+          message: `Entity extraction job queued: ${result.data.aiExtractEntities.id}`,
+          severity: "success",
         });
       } catch (error) {
-        setNotification({ message: 'Failed to start entity extraction', severity: 'error' });
+        setNotification({
+          message: "Failed to start entity extraction",
+          severity: "error",
+        });
       } finally {
-        setAiJobDialog({ open: false, type: '', loading: false });
+        setAiJobDialog({ open: false, type: "", loading: false });
       }
     }
   };
@@ -757,7 +900,7 @@ function CytoscapeGraph() {
   const handleExport = () => {
     if (cy) {
       const png = cy.png({ scale: 2, full: true });
-      const link = document.createElement('a');
+      const link = document.createElement("a");
       link.download = `graph-${Date.now()}.png`;
       link.href = png;
       link.click();
@@ -766,30 +909,40 @@ function CytoscapeGraph() {
 
   const handleExportData = (format) => {
     const data = {
-      nodes: nodes.map(n => n.data || n),
-      edges: edges.map(e => e.data || e),
+      nodes: nodes.map((n) => n.data || n),
+      edges: edges.map((e) => e.data || e),
       meta: {
         layout: currentLayout,
         exportedAt: new Date().toISOString(),
-        investigationId: id
-      }
+        investigationId: id,
+      },
     };
 
     let content, filename, type;
-    
+
     switch (format) {
-      case 'json':
+      case "json":
         content = JSON.stringify(data, null, 2);
         filename = `graph-export-${Date.now()}.json`;
-        type = 'application/json';
+        type = "application/json";
         break;
-      case 'csv':
+      case "csv":
         // Convert to CSV format
-        const csvNodes = nodes.map(n => `"${n.data?.id || n.id}","${n.data?.label || n.label}","${n.data?.type || n.type}"`).join('\n');
-        const csvEdges = edges.map(e => `"${e.data?.source || e.source}","${e.data?.target || e.target}","${e.data?.label || e.label}"`).join('\n');
+        const csvNodes = nodes
+          .map(
+            (n) =>
+              `"${n.data?.id || n.id}","${n.data?.label || n.label}","${n.data?.type || n.type}"`,
+          )
+          .join("\n");
+        const csvEdges = edges
+          .map(
+            (e) =>
+              `"${e.data?.source || e.source}","${e.data?.target || e.target}","${e.data?.label || e.label}"`,
+          )
+          .join("\n");
         content = `Nodes\nid,label,type\n${csvNodes}\n\nEdges\nsource,target,label\n${csvEdges}`;
         filename = `graph-export-${Date.now()}.csv`;
-        type = 'text/csv';
+        type = "text/csv";
         break;
       default:
         return;
@@ -797,7 +950,7 @@ function CytoscapeGraph() {
 
     const blob = new Blob([content], { type });
     const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
+    const link = document.createElement("a");
     link.href = url;
     link.download = filename;
     link.click();
@@ -805,12 +958,19 @@ function CytoscapeGraph() {
   };
 
   return (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 2,
+        }}
+      >
         <Typography variant="h5" component="h1" fontWeight="bold">
           Advanced Graph Explorer {id && `- Investigation ${id}`}
         </Typography>
-        <Box sx={{ display: 'flex', gap: 1 }}>
+        <Box sx={{ display: "flex", gap: 1 }}>
           <Button
             variant="outlined"
             startIcon={<AccountTree />}
@@ -831,7 +991,7 @@ function CytoscapeGraph() {
             onClick={() => setRealTimeEnabled(!realTimeEnabled)}
             color={realTimeEnabled ? "success" : "primary"}
           >
-            Real-time: {realTimeEnabled ? 'ON' : 'OFF'}
+            Real-time: {realTimeEnabled ? "ON" : "OFF"}
           </Button>
           <Button
             variant="outlined"
@@ -848,37 +1008,50 @@ function CytoscapeGraph() {
           >
             Filters
           </Button>
-          <Button variant="contained" startIcon={<Download />} onClick={() => handleExportData('json')}>
+          <Button
+            variant="contained"
+            startIcon={<Download />}
+            onClick={() => handleExportData("json")}
+          >
             Export
           </Button>
         </Box>
       </Box>
 
-      <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
-        <Chip label={`Nodes: ${nodes.length}`} color="primary" variant="outlined" />
-        <Chip label={`Edges: ${edges.length}`} color="secondary" variant="outlined" />
-        <Chip 
-          label={`Layout: ${currentLayout}`} 
-          color={loading ? "default" : "success"} 
-          variant="outlined" 
+      <Box sx={{ display: "flex", gap: 1, mb: 2, flexWrap: "wrap" }}>
+        <Chip
+          label={`Nodes: ${nodes.length}`}
+          color="primary"
+          variant="outlined"
         />
-        <Chip 
-          label={`Status: ${loading ? 'Loading...' : 'Ready'}`}
+        <Chip
+          label={`Edges: ${edges.length}`}
+          color="secondary"
+          variant="outlined"
+        />
+        <Chip
+          label={`Layout: ${currentLayout}`}
+          color={loading ? "default" : "success"}
+          variant="outlined"
+        />
+        <Chip
+          label={`Status: ${loading ? "Loading..." : "Ready"}`}
           color={loading ? "warning" : "success"}
           variant="outlined"
         />
       </Box>
 
       <Alert severity="info" sx={{ mb: 2 }}>
-        Advanced graph visualization with Cytoscape.js. Select nodes/edges to see details, right-click for context menu.
+        Advanced graph visualization with Cytoscape.js. Select nodes/edges to
+        see details, right-click for context menu.
       </Alert>
 
-      <Paper 
-        sx={{ 
-          flexGrow: 1, 
-          position: 'relative', 
-          overflow: 'hidden',
-          minHeight: 500
+      <Paper
+        sx={{
+          flexGrow: 1,
+          position: "relative",
+          overflow: "hidden",
+          minHeight: 500,
         }}
         elevation={2}
       >
@@ -886,37 +1059,55 @@ function CytoscapeGraph() {
           ref={containerRef}
           data-testid="cytoscape-graph-container"
           style={{
-            width: '100%',
-            height: '100%',
-            background: '#fafafa'
+            width: "100%",
+            height: "100%",
+            background: "#fafafa",
           }}
         />
-        
-        <Box sx={{ 
-          position: 'absolute', 
-          top: 16, 
-          right: 16, 
-          display: 'flex', 
-          flexDirection: 'column',
-          gap: 1
-        }}>
+
+        <Box
+          sx={{
+            position: "absolute",
+            top: 16,
+            right: 16,
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+          }}
+        >
           <Tooltip title="Zoom In">
-            <IconButton size="small" sx={{ bgcolor: 'white' }} onClick={handleZoomIn}>
+            <IconButton
+              size="small"
+              sx={{ bgcolor: "white" }}
+              onClick={handleZoomIn}
+            >
               <ZoomIn />
             </IconButton>
           </Tooltip>
           <Tooltip title="Zoom Out">
-            <IconButton size="small" sx={{ bgcolor: 'white' }} onClick={handleZoomOut}>
+            <IconButton
+              size="small"
+              sx={{ bgcolor: "white" }}
+              onClick={handleZoomOut}
+            >
               <ZoomOut />
             </IconButton>
           </Tooltip>
           <Tooltip title="Fit to View">
-            <IconButton size="small" sx={{ bgcolor: 'white' }} onClick={handleCenter}>
+            <IconButton
+              size="small"
+              sx={{ bgcolor: "white" }}
+              onClick={handleCenter}
+            >
               <CenterFocusStrong />
             </IconButton>
           </Tooltip>
           <Tooltip title="Settings">
-            <IconButton size="small" sx={{ bgcolor: 'white' }} onClick={() => setSettingsOpen(true)}>
+            <IconButton
+              size="small"
+              sx={{ bgcolor: "white" }}
+              onClick={() => setSettingsOpen(true)}
+            >
               <Settings />
             </IconButton>
           </Tooltip>
@@ -924,7 +1115,7 @@ function CytoscapeGraph() {
 
         <Fab
           color="primary"
-          sx={{ position: 'absolute', bottom: 16, right: 16 }}
+          sx={{ position: "absolute", bottom: 16, right: 16 }}
           onClick={handleAddNode}
         >
           <Add />
@@ -938,8 +1129,8 @@ function CytoscapeGraph() {
         onClose={() => setLayoutMenuAnchor(null)}
       >
         {Object.keys(layoutConfigs).map((layout) => (
-          <MenuItem 
-            key={layout} 
+          <MenuItem
+            key={layout}
             onClick={() => applyLayout(layout)}
             selected={layout === currentLayout}
           >
@@ -948,25 +1139,28 @@ function CytoscapeGraph() {
         ))}
       </Menu>
 
-      
-
       {/* Settings Drawer */}
       <Drawer
         anchor="right"
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}
-        sx={{ '& .MuiDrawer-paper': { width: 350, p: 2 } }}
+        sx={{ "& .MuiDrawer-paper": { width: 350, p: 2 } }}
       >
         <Typography variant="h6" sx={{ mb: 2 }}>
           Graph Settings
         </Typography>
-        
+
         <FormControl fullWidth sx={{ mb: 2 }}>
           <InputLabel>Node Type Filter</InputLabel>
           <Select
             multiple
             value={filterSettings.nodeTypes}
-            onChange={(e) => setFilterSettings(prev => ({ ...prev, nodeTypes: e.target.value }))}
+            onChange={(e) =>
+              setFilterSettings((prev) => ({
+                ...prev,
+                nodeTypes: e.target.value,
+              }))
+            }
           >
             <MenuItem value="PERSON">Person</MenuItem>
             <MenuItem value="ORGANIZATION">Organization</MenuItem>
@@ -979,7 +1173,9 @@ function CytoscapeGraph() {
         <Typography gutterBottom>Time Range</Typography>
         <Slider
           value={filterSettings.timeRange}
-          onChange={(e, value) => setFilterSettings(prev => ({ ...prev, timeRange: value }))}
+          onChange={(e, value) =>
+            setFilterSettings((prev) => ({ ...prev, timeRange: value }))
+          }
           valueLabelDisplay="auto"
           sx={{ mb: 2 }}
         />
@@ -993,9 +1189,9 @@ function CytoscapeGraph() {
       {(selectedNode || selectedEdge) && (
         <Paper sx={{ mt: 2, p: 2 }}>
           <Typography variant="h6" sx={{ mb: 1 }}>
-            {selectedNode ? 'Selected Node' : 'Selected Edge'}
+            {selectedNode ? "Selected Node" : "Selected Edge"}
           </Typography>
-          <pre style={{ fontSize: '12px', overflow: 'auto' }}>
+          <pre style={{ fontSize: "12px", overflow: "auto" }}>
             {JSON.stringify(selectedNode || selectedEdge, null, 2)}
           </pre>
         </Paper>
@@ -1004,13 +1200,18 @@ function CytoscapeGraph() {
       {/* AI Job Dialog */}
       <Dialog
         open={aiJobDialog.open}
-        onClose={() => !aiJobDialog.loading && setAiJobDialog({ open: false, type: '', loading: false })}
+        onClose={() =>
+          !aiJobDialog.loading &&
+          setAiJobDialog({ open: false, type: "", loading: false })
+        }
       >
         <DialogTitle>AI Analysis in Progress</DialogTitle>
-        <DialogContent sx={{ display: 'flex', alignItems: 'center', gap: 2, minWidth: 300 }}>
+        <DialogContent
+          sx={{ display: "flex", alignItems: "center", gap: 2, minWidth: 300 }}
+        >
           <CircularProgress size={24} />
           <Typography>
-            Running {aiJobDialog.type.replace('_', ' ')} analysis...
+            Running {aiJobDialog.type.replace("_", " ")} analysis...
           </Typography>
         </DialogContent>
       </Dialog>
@@ -1020,19 +1221,19 @@ function CytoscapeGraph() {
         open={!!notification}
         autoHideDuration={4000}
         onClose={() => setNotification(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
       >
-        <Alert 
-          onClose={() => setNotification(null)} 
-          severity={notification?.severity || 'info'}
+        <Alert
+          onClose={() => setNotification(null)}
+          severity={notification?.severity || "info"}
         >
           {notification?.message}
         </Alert>
       </Snackbar>
 
-      <AIInsightsPanel 
-        open={aiPanelOpen} 
-        onClose={() => setAiPanelOpen(false)} 
+      <AIInsightsPanel
+        open={aiPanelOpen}
+        onClose={() => setAiPanelOpen(false)}
         onExportData={handleExportData}
       />
     </Box>

--- a/ml/app/link_prediction.py
+++ b/ml/app/link_prediction.py
@@ -1,0 +1,59 @@
+import torch
+from torch import nn
+from typing import List, Tuple
+
+
+class LinkPredictor:
+    """Simple Node2Vec-style link predictor using embeddings."""
+
+    def __init__(self, embedding_dim: int = 32):
+        self.embedding_dim = embedding_dim
+        self.model: nn.Embedding | None = None
+        self.node_index: dict[str, int] = {}
+
+    def fit(self, edges: List[Tuple[str, str]]) -> None:
+        """Train embeddings from known edges."""
+        nodes = set([u for u, v in edges] + [v for u, v in edges])
+        self.node_index = {node: idx for idx, node in enumerate(nodes)}
+        self.model = nn.Embedding(len(self.node_index), self.embedding_dim)
+        optimizer = torch.optim.SGD(self.model.parameters(), lr=0.05)
+        edge_idx = torch.tensor(
+            [[self.node_index[u], self.node_index[v]] for u, v in edges],
+            dtype=torch.long,
+        )
+        for _ in range(50):
+            optimizer.zero_grad()
+            u_emb = self.model(edge_idx[:, 0])
+            v_emb = self.model(edge_idx[:, 1])
+            score = (u_emb * v_emb).sum(dim=1)
+            loss = -torch.log(torch.sigmoid(score)).mean()
+            loss.backward()
+            optimizer.step()
+
+    def predict(self, source: str, candidates: List[str]) -> List[Tuple[str, float]]:
+        if not self.model or source not in self.node_index:
+            return []
+        src_idx = self.node_index[source]
+        src_emb = self.model(torch.tensor([src_idx]))[0]
+        preds: List[Tuple[str, float]] = []
+        for c in candidates:
+            if c not in self.node_index or c == source:
+                continue
+            dst_idx = self.node_index[c]
+            dst_emb = self.model(torch.tensor([dst_idx]))[0]
+            score = torch.sigmoid((src_emb * dst_emb).sum()).item()
+            preds.append((c, float(score)))
+        preds.sort(key=lambda x: x[1], reverse=True)
+        return preds
+
+    def suggest_links(
+        self,
+        nodes: List[str],
+        edges: List[Tuple[str, str]],
+        source: str,
+        top_k: int = 5,
+    ) -> List[Tuple[str, float]]:
+        self.fit(edges)
+        existing = {(u, v) for u, v in edges} | {(v, u) for u, v in edges}
+        candidates = [n for n in nodes if (source, n) not in existing and n != source]
+        return self.predict(source, candidates)[:top_k]

--- a/ml/app/main.py
+++ b/ml/app/main.py
@@ -3,56 +3,86 @@ from fastapi import FastAPI, Depends, HTTPException, Header, Request, Response
 from fastapi.responses import PlainTextResponse
 from jose import jwt
 import httpx
-from .schemas import NLPRequest, ERRequest, LinkPredRequest, CommunityRequest, SuggestLinksRequest, SuggestLinksQueuedResponse, DetectAnomaliesRequest, DetectAnomaliesQueuedResponse, EntityLinkRequest, LinkedEntity, EntityLinkResponse, RelationshipExtractionRequest, ExtractedRelationship, RelationshipExtractionResponse # Added RelationshipExtractionRequest, ExtractedRelationship, RelationshipExtractionResponse
-from .tasks import task_nlp_entities, task_entity_resolution, task_link_prediction, task_community_detect
+from .schemas import (
+    NLPRequest,
+    ERRequest,
+    LinkPredRequest,
+    CommunityRequest,
+    SuggestLinksRequest,
+    SuggestLinksQueuedResponse,
+    DetectAnomaliesRequest,
+    DetectAnomaliesQueuedResponse,
+    EntityLinkRequest,
+    LinkedEntity,
+    EntityLinkResponse,
+    RelationshipExtractionRequest,
+    ExtractedRelationship,
+    RelationshipExtractionResponse,
+    AISuggestLinksRequest,
+    AISuggestLinksResponse,
+    AISuggestedLink,
+)  # Added RelationshipExtractionRequest, ExtractedRelationship, RelationshipExtractionResponse
+from .link_prediction import LinkPredictor
+from .tasks import (
+    task_nlp_entities,
+    task_entity_resolution,
+    task_link_prediction,
+    task_community_detect,
+)
 from .tasks.gnn_tasks import (
     task_gnn_node_classification,
     task_gnn_link_prediction,
     task_gnn_graph_classification,
     task_gnn_anomaly_detection,
-    task_gnn_generate_embeddings
+    task_gnn_generate_embeddings,
 )
-from .tasks.nlp_tasks import task_entity_linking, task_relationship_extraction # Added task_relationship_extraction
+from .tasks.nlp_tasks import (
+    task_entity_linking,
+    task_relationship_extraction,
+)  # Added task_relationship_extraction
 from .security import sign_payload
 from .monitoring import (
-    track_http_request, 
-    track_ml_prediction, 
-    get_metrics, 
+    track_http_request,
+    track_ml_prediction,
+    get_metrics,
     get_content_type,
-    health_checker
+    health_checker,
 )
 
 JWT_PUBLIC_KEY = os.getenv("JWT_PUBLIC_KEY", "")
 JWT_ALGO = "RS256"
+
 
 def verify_token(authorization: str = Header(...)):
     try:
         scheme, token = authorization.split(" ")
         if scheme.lower() != "bearer":
             raise ValueError("invalid scheme")
-        
+
         # Use enhanced security validation
         from .security import validate_jwt_token, audit_security_event
+
         payload = validate_jwt_token(token)
-        
+
         # Audit token usage
         audit_security_event(
             "TOKEN_VALIDATION_SUCCESS",
             {"user_id": payload.get("sub"), "roles": payload.get("roles", [])},
-            "low"
+            "low",
         )
-        
+
         return payload
     except Exception as e:
         from .security import audit_security_event
-        audit_security_event(
-            "TOKEN_VALIDATION_FAILED",
-            {"error": str(e)},
-            "medium"
-        )
+
+        audit_security_event("TOKEN_VALIDATION_FAILED", {"error": str(e)}, "medium")
         raise HTTPException(status_code=401, detail=f"Unauthorized: {e}")
 
+
+link_predictor = LinkPredictor()
+
 api = FastAPI(title="IntelGraph ML Service", version="0.2.0")
+
 
 # Middleware for tracking HTTP requests
 @api.middleware("http")
@@ -60,48 +90,49 @@ async def track_requests(request: Request, call_next):
     start_time = time.time()
     response = await call_next(request)
     duration = time.time() - start_time
-    
+
     # Track metrics
     track_http_request(
         method=request.method,
         endpoint=request.url.path,
         status_code=response.status_code,
-        duration=duration
+        duration=duration,
     )
-    
+
     return response
+
 
 # Monitoring endpoints
 @api.get("/metrics")
 async def metrics():
     """Prometheus metrics endpoint"""
     metrics_data = get_metrics()
-    return PlainTextResponse(
-        content=metrics_data,
-        media_type=get_content_type()
-    )
+    return PlainTextResponse(content=metrics_data, media_type=get_content_type())
+
 
 @api.get("/health")
 async def health():
     """Comprehensive health check"""
     health_status = await health_checker.perform_comprehensive_health_check()
-    status_code = 200 if health_status['status'] == 'healthy' else 503
+    status_code = 200 if health_status["status"] == "healthy" else 503
     return Response(
         content=json.dumps(health_status),
         status_code=status_code,
-        media_type="application/json"
+        media_type="application/json",
     )
+
 
 @api.get("/health/quick")
 async def health_quick():
     """Quick health check (cached)"""
     health_status = health_checker.get_cached_health_status()
-    status_code = 200 if health_status['status'] == 'healthy' else 503
+    status_code = 200 if health_status["status"] == "healthy" else 503
     return Response(
         content=json.dumps(health_status),
         status_code=status_code,
-        media_type="application/json"
+        media_type="application/json",
     )
+
 
 @api.get("/health/live")
 async def health_live():
@@ -109,38 +140,41 @@ async def health_live():
     liveness_status = health_checker.liveness_probe()
     return liveness_status
 
+
 @api.get("/health/ready")
 async def health_ready():
     """Kubernetes readiness probe"""
     readiness_status = await health_checker.readiness_probe()
-    status_code = 200 if readiness_status['status'] == 'ready' else 503
+    status_code = 200 if readiness_status["status"] == "ready" else 503
     return Response(
         content=json.dumps(readiness_status),
         status_code=status_code,
-        media_type="application/json"
+        media_type="application/json",
     )
+
 
 @api.get("/health/info")
 async def health_info():
     """Service information"""
     import platform
     import psutil
-    
+
     process = psutil.Process()
-    
+
     info = {
-        'service': 'intelgraph-ml',
-        'version': '0.2.0',
-        'environment': os.getenv('ENVIRONMENT', 'development'),
-        'python_version': platform.python_version(),
-        'platform': platform.platform(),
-        'uptime_seconds': round(time.time() - process.create_time()),
-        'timestamp': time.time(),
-        'pid': process.pid,
-        'memory_mb': round(process.memory_info().rss / 1024 / 1024),
+        "service": "intelgraph-ml",
+        "version": "0.2.0",
+        "environment": os.getenv("ENVIRONMENT", "development"),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "uptime_seconds": round(time.time() - process.create_time()),
+        "timestamp": time.time(),
+        "pid": process.pid,
+        "memory_mb": round(process.memory_info().rss / 1024 / 1024),
     }
-    
+
     return info
+
 
 async def _maybe_webhook(callback_url: str, result: dict):
     if not callback_url:
@@ -148,42 +182,51 @@ async def _maybe_webhook(callback_url: str, result: dict):
     body = json.dumps(result).encode()
     sig = sign_payload(body)
     async with httpx.AsyncClient(timeout=10.0) as client:
-        await client.post(callback_url, content=body, headers={"X-IntelGraph-Signature": sig, "Content-Type": "application/json"})
+        await client.post(
+            callback_url,
+            content=body,
+            headers={"X-IntelGraph-Signature": sig, "Content-Type": "application/json"},
+        )
+
 
 @api.post("/nlp/entities")
 async def nlp_entities(req: NLPRequest, request: Request, user=Depends(verify_token)):
     from .security import security_middleware, sanitize_input, SecurityConfig
-    
+
     # Apply security checks
     security_middleware(lambda: None)()
-    
+
     # Validate and sanitize input
     docs = sanitize_input(req.docs)
     if req.job_id:
         SecurityConfig.validate_job_id(req.job_id)
     if req.callback_url:
         SecurityConfig.validate_callback_url(req.callback_url)
-    
+
     # Track ML prediction
     track_ml_prediction("nlp_entities", len(docs))
-    
+
     t = task_nlp_entities.delay(req.model_dump())
     return {"queued": True, "task_id": t.id}
+
 
 @api.post("/er/resolve")
 async def entity_resolution(req: ERRequest, _=Depends(verify_token)):
     t = task_entity_resolution.delay(req.model_dump())
     return {"queued": True, "task_id": t.id}
 
+
 @api.post("/graph/link_predict")
 async def link_predict(req: LinkPredRequest, _=Depends(verify_token)):
     t = task_link_prediction.delay(req.model_dump())
     return {"queued": True, "task_id": t.id}
 
+
 @api.post("/graph/community_detect")
 async def community_detect(req: CommunityRequest, _=Depends(verify_token)):
     t = task_community_detect.delay(req.model_dump())
     return {"queued": True, "task_id": t.id}
+
 
 # GNN Endpoints
 @api.post("/gnn/node_classification")
@@ -192,11 +235,13 @@ async def gnn_node_classification(request: dict, _=Depends(verify_token)):
     t = task_gnn_node_classification.delay(request)
     return {"queued": True, "task_id": t.id}
 
+
 @api.post("/gnn/link_prediction")
 async def gnn_link_prediction(request: dict, _=Depends(verify_token)):
     """Queue GNN link prediction task"""
     t = task_gnn_link_prediction.delay(request)
     return {"queued": True, "task_id": t.id}
+
 
 @api.post("/gnn/graph_classification")
 async def gnn_graph_classification(request: dict, _=Depends(verify_token)):
@@ -204,17 +249,20 @@ async def gnn_graph_classification(request: dict, _=Depends(verify_token)):
     t = task_gnn_graph_classification.delay(request)
     return {"queued": True, "task_id": t.id}
 
+
 @api.post("/gnn/anomaly_detection")
 async def gnn_anomaly_detection(request: dict, _=Depends(verify_token)):
     """Queue GNN anomaly detection task"""
     t = task_gnn_anomaly_detection.delay(request)
     return {"queued": True, "task_id": t.id}
 
+
 @api.post("/gnn/generate_embeddings")
 async def gnn_generate_embeddings(request: dict, _=Depends(verify_token)):
     """Queue GNN embedding generation task"""
     t = task_gnn_generate_embeddings.delay(request)
     return {"queued": True, "task_id": t.id}
+
 
 @api.post("/nlp/entity_linking", response_model=EntityLinkResponse)
 async def nlp_entity_linking(req: EntityLinkRequest, _=Depends(verify_token)):
@@ -224,92 +272,118 @@ async def nlp_entity_linking(req: EntityLinkRequest, _=Depends(verify_token)):
     t = task_entity_linking.delay(req.model_dump())
     return EntityLinkResponse(
         job_id=t.id,
-        entities=[], # Entities will be populated by the Celery task
+        entities=[],  # Entities will be populated by the Celery task
         status="queued",
-        completed_at=datetime.utcnow().isoformat()
+        completed_at=datetime.utcnow().isoformat(),
     )
 
+
 @api.post("/nlp/relationship_extraction", response_model=RelationshipExtractionResponse)
-async def nlp_relationship_extraction(req: RelationshipExtractionRequest, _=Depends(verify_token)):
+async def nlp_relationship_extraction(
+    req: RelationshipExtractionRequest, _=Depends(verify_token)
+):
     """
     Perform relationship extraction on text given identified entities.
     """
     t = task_relationship_extraction.delay(req.model_dump())
     return RelationshipExtractionResponse(
         job_id=t.id,
-        relationships=[], # Relationships will be populated by the Celery task
+        relationships=[],  # Relationships will be populated by the Celery task
         status="queued",
-        completed_at=datetime.utcnow().isoformat()
+        completed_at=datetime.utcnow().isoformat(),
     )
+
+
+@api.post("/ai/suggest-links", response_model=AISuggestLinksResponse)
+async def ai_suggest_links(req: AISuggestLinksRequest, _=Depends(verify_token)):
+    nodes = [n.get("id") for n in req.graph.get("nodes", [])]
+    edges = [(e.get("source"), e.get("target")) for e in req.graph.get("edges", [])]
+    preds = link_predictor.suggest_links(nodes, edges, req.node_id, req.top_k)
+    return AISuggestLinksResponse(
+        suggestions=[
+            AISuggestedLink(source=req.node_id, target=tgt, score=score)
+            for tgt, score in preds
+        ]
+    )
+
 
 # High-level JSON contracts
 @api.post("/suggestLinks", response_model=SuggestLinksQueuedResponse)
 async def suggest_links(req: SuggestLinksRequest, _=Depends(verify_token)):
     payload = {
-        'graph_data': req.graph,
-        'node_features': req.node_features or {},
-        'candidate_edges': req.candidate_edges or [],
-        'focus_entity_id': req.focus_entity_id,
-        'model_name': req.model_name if not req.model_version else f"{req.model_name}:{req.model_version}",
-        'model_config': req.model_config or {},
-        'task_mode': req.task_mode,
-        'top_k': req.top_k,
-        'job_id': req.job_id,
+        "graph_data": req.graph,
+        "node_features": req.node_features or {},
+        "candidate_edges": req.candidate_edges or [],
+        "focus_entity_id": req.focus_entity_id,
+        "model_name": (
+            req.model_name
+            if not req.model_version
+            else f"{req.model_name}:{req.model_version}"
+        ),
+        "model_config": req.model_config or {},
+        "task_mode": req.task_mode,
+        "top_k": req.top_k,
+        "job_id": req.job_id,
     }
     t = task_gnn_link_prediction.delay(payload)
     return SuggestLinksQueuedResponse(queued=True, task_id=t.id)
 
+
 @api.post("/detectAnomalies", response_model=DetectAnomaliesQueuedResponse)
 async def detect_anomalies(req: DetectAnomaliesRequest, _=Depends(verify_token)):
     payload = {
-        'graph_data': req.graph,
-        'node_features': req.node_features or {},
-        'normal_nodes': req.normal_nodes or [],
-        'model_name': req.model_name if not req.model_version else f"{req.model_name}:{req.model_version}",
-        'model_config': req.model_config or {},
-        'task_mode': req.task_mode,
-        'anomaly_threshold': req.anomaly_threshold,
-        'job_id': req.job_id,
+        "graph_data": req.graph,
+        "node_features": req.node_features or {},
+        "normal_nodes": req.normal_nodes or [],
+        "model_name": (
+            req.model_name
+            if not req.model_version
+            else f"{req.model_name}:{req.model_version}"
+        ),
+        "model_config": req.model_config or {},
+        "task_mode": req.task_mode,
+        "anomaly_threshold": req.anomaly_threshold,
+        "job_id": req.job_id,
     }
     t = task_gnn_anomaly_detection.delay(payload)
     return DetectAnomaliesQueuedResponse(queued=True, task_id=t.id)
+
 
 @api.get("/gnn/models")
 async def list_gnn_models(_=Depends(verify_token)):
     """List available GNN models"""
     from .models.gnn import gnn_manager
-    
+
     models = gnn_manager.list_models()
     model_info = {}
-    
+
     for model_name in models:
         info = gnn_manager.get_model_info(model_name)
         if info:
             model_info[model_name] = info
-    
-    return {
-        "models": model_info,
-        "count": len(models)
-    }
+
+    return {"models": model_info, "count": len(models)}
+
 
 @api.get("/gnn/models/{model_name}")
 async def get_gnn_model_info(model_name: str, _=Depends(verify_token)):
     """Get information about a specific GNN model"""
     from .models.gnn import gnn_manager
-    
+
     info = gnn_manager.get_model_info(model_name)
     if info is None:
         raise HTTPException(status_code=404, detail=f"Model {model_name} not found")
-    
+
     return info
+
 
 @api.delete("/gnn/models/{model_name}")
 async def delete_gnn_model(model_name: str, _=Depends(verify_token)):
     """Delete a GNN model"""
     from .models.gnn import gnn_manager
-    
+
     if model_name not in gnn_manager.list_models():
         raise HTTPException(status_code=404, detail=f"Model {model_name} not found")
-    
+
     gnn_manager.delete_model(model_name)
     return {"deleted": True, "model_name": model_name}

--- a/ml/app/schemas.py
+++ b/ml/app/schemas.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 
+
 class TextDoc(BaseModel):
     id: str
     text: str
+
 
 class NLPRequest(BaseModel):
     docs: List[TextDoc]
@@ -11,16 +13,19 @@ class NLPRequest(BaseModel):
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
 
+
 class ERRecord(BaseModel):
     id: str
     name: Optional[str] = None
     attrs: Dict[str, Any] = Field(default_factory=dict)
+
 
 class ERRequest(BaseModel):
     records: List[ERRecord]
     threshold: float = 0.82
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
+
 
 class LinkPredRequest(BaseModel):
     graph_snapshot_id: str
@@ -29,6 +34,7 @@ class LinkPredRequest(BaseModel):
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
 
+
 class CommunityRequest(BaseModel):
     graph_snapshot_id: str
     edges: Optional[list] = None
@@ -36,51 +42,72 @@ class CommunityRequest(BaseModel):
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
 
+
 # GNN JSON contracts
 class SuggestLinksRequest(BaseModel):
-    graph: Dict[str, Any] = Field(..., description="Graph data: {edges: [[u,v],...]} or NetworkX-like")
-    node_features: Optional[Dict[str, Dict[str, float]]] = Field(default=None, description="Per-node feature dict")
-    candidate_edges: Optional[List[List[str]]] = Field(default=None, description="Optional candidate edges [u,v]")
+    graph: Dict[str, Any] = Field(
+        ..., description="Graph data: {edges: [[u,v],...]} or NetworkX-like"
+    )
+    node_features: Optional[Dict[str, Dict[str, float]]] = Field(
+        default=None, description="Per-node feature dict"
+    )
+    candidate_edges: Optional[List[List[str]]] = Field(
+        default=None, description="Optional candidate edges [u,v]"
+    )
     focus_entity_id: Optional[str] = None
     model_name: str = Field(..., description="Registered GNN model name")
-    model_version: Optional[str] = Field(default=None, description="Model version label, e.g., v1")
-    model_config: Optional[Dict[str, Any]] = Field(default=None, description="Config if creating/training model")
-    task_mode: str = Field(default='predict', description="'train' or 'predict'")
+    model_version: Optional[str] = Field(
+        default=None, description="Model version label, e.g., v1"
+    )
+    model_config: Optional[Dict[str, Any]] = Field(
+        default=None, description="Config if creating/training model"
+    )
+    task_mode: str = Field(default="predict", description="'train' or 'predict'")
     top_k: int = 50
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
+
 
 class SuggestLinksQueuedResponse(BaseModel):
     queued: bool
     task_id: str
 
+
 class DetectAnomaliesRequest(BaseModel):
-    graph: Dict[str, Any] = Field(..., description="Graph data: {edges: [[u,v],...]} or NetworkX-like")
+    graph: Dict[str, Any] = Field(
+        ..., description="Graph data: {edges: [[u,v],...]} or NetworkX-like"
+    )
     node_features: Optional[Dict[str, Dict[str, float]]] = None
-    normal_nodes: Optional[List[str]] = Field(default=None, description="Known normal nodes for training")
+    normal_nodes: Optional[List[str]] = Field(
+        default=None, description="Known normal nodes for training"
+    )
     model_name: str
     model_version: Optional[str] = None
     model_config: Optional[Dict[str, Any]] = None
-    task_mode: str = Field(default='predict')
+    task_mode: str = Field(default="predict")
     anomaly_threshold: float = 0.5
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
 
+
 class DetectAnomaliesQueuedResponse(BaseModel):
     queued: bool
     task_id: str
+
 
 class EntityLinkRequest(BaseModel):
     text: str = Field(..., description="Text to perform entity linking on.")
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
 
+
 class LinkedEntity(BaseModel):
     text: str
     label: str
     start_char: int
     end_char: int
-    entity_id: Optional[str] = None # ID of the linked entity in the graph
+    entity_id: Optional[str] = None  # ID of the linked entity in the graph
+
 
 class EntityLinkResponse(BaseModel):
     job_id: str
@@ -88,21 +115,42 @@ class EntityLinkResponse(BaseModel):
     status: str
     completed_at: str
 
+
 class RelationshipExtractionRequest(BaseModel):
     text: str = Field(..., description="Text to perform relationship extraction on.")
-    entities: List[LinkedEntity] = Field(..., description="List of entities identified in the text.")
+    entities: List[LinkedEntity] = Field(
+        ..., description="List of entities identified in the text."
+    )
     job_id: Optional[str] = None
     callback_url: Optional[str] = None
+
 
 class ExtractedRelationship(BaseModel):
     source_entity_id: str
     target_entity_id: str
     type: str
     confidence: float
-    text_span: str # The part of the text that describes the relationship
+    text_span: str  # The part of the text that describes the relationship
+
 
 class RelationshipExtractionResponse(BaseModel):
     job_id: str
     relationships: List[ExtractedRelationship]
     status: str
     completed_at: str
+
+
+class AISuggestedLink(BaseModel):
+    source: str
+    target: str
+    score: float
+
+
+class AISuggestLinksRequest(BaseModel):
+    graph: Dict[str, Any]
+    node_id: str = Field(..., description="Source node for suggestions")
+    top_k: int = 5
+
+
+class AISuggestLinksResponse(BaseModel):
+    suggestions: List[AISuggestedLink]

--- a/ml/tests/test_api.py
+++ b/ml/tests/test_api.py
@@ -1,6 +1,7 @@
 """
 Test cases for the FastAPI ML service endpoints
 """
+
 import pytest
 import json
 from fastapi.testclient import TestClient
@@ -12,7 +13,7 @@ client = TestClient(api)
 
 class TestHealthEndpoint:
     """Test health check endpoint"""
-    
+
     def test_health_endpoint(self):
         """Test the health endpoint returns OK"""
         response = client.get("/health")
@@ -22,212 +23,228 @@ class TestHealthEndpoint:
 
 class TestMLEndpoints:
     """Test ML processing endpoints"""
-    
+
     def setUp(self):
         """Setup test environment"""
         self.jwt_token = "Bearer test-token"
         self.valid_headers = {"Authorization": self.jwt_token}
-    
-    @patch('ml.app.main.verify_token')
-    @patch('ml.app.tasks.task_nlp_entities.delay')
+
+    @patch("ml.app.main.verify_token")
+    @patch("ml.app.tasks.task_nlp_entities.delay")
     def test_nlp_entities_endpoint(self, mock_task, mock_verify):
         """Test NLP entity extraction endpoint"""
         mock_verify.return_value = {"sub": "test-user"}
         mock_task.return_value = MagicMock(id="test-task-id")
-        
+
         payload = {
             "docs": [
                 {"id": "doc1", "text": "John Doe works at Acme Corp"},
-                {"id": "doc2", "text": "Contact info: john@example.com"}
+                {"id": "doc2", "text": "Contact info: john@example.com"},
             ],
             "language": "en",
-            "job_id": "test-job-1"
+            "job_id": "test-job-1",
         }
-        
+
         response = client.post(
-            "/nlp/entities",
-            json=payload,
-            headers=self.valid_headers
+            "/nlp/entities", json=payload, headers=self.valid_headers
         )
-        
+
         assert response.status_code == 200
         assert response.json() == {"queued": True, "task_id": "test-task-id"}
         mock_task.assert_called_once()
-    
-    @patch('ml.app.main.verify_token')
-    @patch('ml.app.tasks.task_entity_resolution.delay')
+
+    @patch("ml.app.main.verify_token")
+    @patch("ml.app.tasks.task_entity_resolution.delay")
     def test_entity_resolution_endpoint(self, mock_task, mock_verify):
         """Test entity resolution endpoint"""
         mock_verify.return_value = {"sub": "test-user"}
         mock_task.return_value = MagicMock(id="test-task-id")
-        
+
         payload = {
             "records": [
-                {"id": "1", "name": "John Smith", "attrs": {"email": "john@example.com"}},
-                {"id": "2", "name": "J. Smith", "attrs": {"phone": "555-1234"}}
+                {
+                    "id": "1",
+                    "name": "John Smith",
+                    "attrs": {"email": "john@example.com"},
+                },
+                {"id": "2", "name": "J. Smith", "attrs": {"phone": "555-1234"}},
             ],
             "threshold": 0.85,
-            "job_id": "test-job-2"
+            "job_id": "test-job-2",
         }
-        
-        response = client.post(
-            "/er/resolve",
-            json=payload,
-            headers=self.valid_headers
-        )
-        
+
+        response = client.post("/er/resolve", json=payload, headers=self.valid_headers)
+
         assert response.status_code == 200
         assert response.json() == {"queued": True, "task_id": "test-task-id"}
         mock_task.assert_called_once()
-    
-    @patch('ml.app.main.verify_token')
-    @patch('ml.app.tasks.task_link_prediction.delay')
+
+    @patch("ml.app.main.verify_token")
+    @patch("ml.app.tasks.task_link_prediction.delay")
     def test_link_prediction_endpoint(self, mock_task, mock_verify):
         """Test link prediction endpoint"""
         mock_verify.return_value = {"sub": "test-user"}
         mock_task.return_value = MagicMock(id="test-task-id")
-        
+
         payload = {
             "graph_snapshot_id": "snapshot-123",
             "top_k": 25,
-            "job_id": "test-job-3"
+            "job_id": "test-job-3",
         }
-        
+
         response = client.post(
-            "/graph/link_predict",
-            json=payload,
-            headers=self.valid_headers
+            "/graph/link_predict", json=payload, headers=self.valid_headers
         )
-        
+
         assert response.status_code == 200
         assert response.json() == {"queued": True, "task_id": "test-task-id"}
         mock_task.assert_called_once()
-    
-    @patch('ml.app.main.verify_token')
-    @patch('ml.app.tasks.task_community_detect.delay')
+
+    @patch("ml.app.main.verify_token")
+    @patch("ml.app.tasks.task_community_detect.delay")
     def test_community_detection_endpoint(self, mock_task, mock_verify):
         """Test community detection endpoint"""
         mock_verify.return_value = {"sub": "test-user"}
         mock_task.return_value = MagicMock(id="test-task-id")
-        
-        payload = {
-            "graph_snapshot_id": "snapshot-123",
-            "job_id": "test-job-4"
-        }
-        
+
+        payload = {"graph_snapshot_id": "snapshot-123", "job_id": "test-job-4"}
+
         response = client.post(
-            "/graph/community_detect",
-            json=payload,
-            headers=self.valid_headers
+            "/graph/community_detect", json=payload, headers=self.valid_headers
         )
-        
+
         assert response.status_code == 200
         assert response.json() == {"queued": True, "task_id": "test-task-id"}
         mock_task.assert_called_once()
-    
+
     def test_unauthorized_access(self):
         """Test endpoints require authentication"""
         payload = {"docs": [{"id": "1", "text": "test"}]}
-        
+
         # No authorization header
         response = client.post("/nlp/entities", json=payload)
         assert response.status_code == 422  # Missing header
-        
+
         # Invalid authorization header
         response = client.post(
-            "/nlp/entities", 
-            json=payload,
-            headers={"Authorization": "InvalidToken"}
+            "/nlp/entities", json=payload, headers={"Authorization": "InvalidToken"}
         )
         assert response.status_code == 401
-    
+
     def test_invalid_payload(self):
         """Test endpoints validate input"""
         # Missing required fields
-        response = client.post(
-            "/nlp/entities",
-            json={},
-            headers=self.valid_headers
-        )
+        response = client.post("/nlp/entities", json={}, headers=self.valid_headers)
         assert response.status_code == 422
 
+
 class TestContracts:
-    @patch('ml.app.main.verify_token')
-    @patch('ml.app.tasks.gnn_tasks.task_gnn_link_prediction.delay')
+    @patch("ml.app.main.verify_token")
+    @patch("ml.app.tasks.gnn_tasks.task_gnn_link_prediction.delay")
     def test_suggest_links_contract(self, mock_task, mock_verify):
         mock_verify.return_value = {"sub": "tester"}
         mock_task.return_value = MagicMock(id="gnn-task-1")
         payload = {
-            "graph": {"edges": [["1","2"],["2","3"]]},
+            "graph": {"edges": [["1", "2"], ["2", "3"]]},
             "model_name": "lp-model",
             "model_version": "v1",
-            "top_k": 10
+            "top_k": 10,
         }
-        r = client.post('/suggestLinks', json=payload, headers={"Authorization":"Bearer t"})
+        r = client.post(
+            "/suggestLinks", json=payload, headers={"Authorization": "Bearer t"}
+        )
         assert r.status_code == 200
         assert r.json()["queued"] is True
         assert r.json()["task_id"] == "gnn-task-1"
 
-    @patch('ml.app.main.verify_token')
-    @patch('ml.app.tasks.gnn_tasks.task_gnn_anomaly_detection.delay')
+    @patch("ml.app.main.verify_token")
+    @patch("ml.app.tasks.gnn_tasks.task_gnn_anomaly_detection.delay")
     def test_detect_anomalies_contract(self, mock_task, mock_verify):
         mock_verify.return_value = {"sub": "tester"}
         mock_task.return_value = MagicMock(id="gnn-task-2")
         payload = {
-            "graph": {"edges": [["1","2"],["2","3"]]},
+            "graph": {"edges": [["1", "2"], ["2", "3"]]},
             "model_name": "ad-model",
-            "anomaly_threshold": 0.6
+            "anomaly_threshold": 0.6,
         }
-        r = client.post('/detectAnomalies', json=payload, headers={"Authorization":"Bearer t"})
+        r = client.post(
+            "/detectAnomalies", json=payload, headers={"Authorization": "Bearer t"}
+        )
         assert r.status_code == 200
         assert r.json()["queued"] is True
         assert r.json()["task_id"] == "gnn-task-2"
-        
+
         # Invalid field types
         response = client.post(
             "/er/resolve",
             json={"records": "not-a-list", "threshold": "not-a-number"},
-            headers=self.valid_headers
+            headers=self.valid_headers,
         )
         assert response.status_code == 422
 
 
+class TestAISuggestLinksEndpoint:
+    @patch("ml.app.main.verify_token")
+    @patch("ml.app.main.link_predictor.suggest_links")
+    def test_ai_suggest_links(self, mock_suggest, mock_verify):
+        mock_verify.return_value = {"sub": "tester"}
+        mock_suggest.return_value = [("nodeB", 0.9)]
+        payload = {
+            "graph": {
+                "nodes": [{"id": "nodeA"}, {"id": "nodeB"}],
+                "edges": [{"source": "nodeA", "target": "nodeC"}],
+            },
+            "node_id": "nodeA",
+            "top_k": 1,
+        }
+        r = client.post(
+            "/ai/suggest-links", json=payload, headers={"Authorization": "Bearer t"}
+        )
+        assert r.status_code == 200
+        assert r.json() == {
+            "suggestions": [{"source": "nodeA", "target": "nodeB", "score": 0.9}]
+        }
+        mock_suggest.assert_called_once()
+
+
 class TestAuthenticationFlow:
     """Test JWT authentication and security"""
-    
-    @patch('app.main.jwt.decode')
+
+    @patch("app.main.jwt.decode")
     def test_valid_jwt_token(self, mock_decode):
         """Test valid JWT token processing"""
         mock_decode.return_value = {"sub": "user123", "roles": ["analyst"]}
-        
+
         from ml.app.main import verify_token
+
         result = verify_token("Bearer valid-token")
-        
+
         assert result["sub"] == "user123"
         assert result["roles"] == ["analyst"]
-    
-    @patch('app.main.jwt.decode')
+
+    @patch("app.main.jwt.decode")
     def test_invalid_jwt_token(self, mock_decode):
         """Test invalid JWT token handling"""
         from jose import JWTError
+
         mock_decode.side_effect = JWTError("Invalid token")
-        
+
         from ml.app.main import verify_token
         from fastapi import HTTPException
-        
+
         with pytest.raises(HTTPException) as exc_info:
             verify_token("Bearer invalid-token")
-        
+
         assert exc_info.value.status_code == 401
-    
+
     def test_malformed_authorization_header(self):
         """Test malformed authorization header"""
         from ml.app.main import verify_token
         from fastapi import HTTPException
-        
+
         with pytest.raises(HTTPException):
             verify_token("InvalidFormat")
-        
+
         with pytest.raises(HTTPException):
             verify_token("NotBearer token")
 


### PR DESCRIPTION
## Summary
- add simple Node2Vec-style link predictor
- expose `/ai/suggest-links` FastAPI endpoint returning ranked edges
- visualize suggested links with dashed edges and score labels in Cytoscape graph

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in workflow files)*
- `npm test` *(fails: Invalid or unexpected token)*
- `PYTHONPATH=. pytest ml/tests/test_api.py::TestAISuggestLinksEndpoint::test_ai_suggest_links -q` *(fails: found no collectors)*


------
https://chatgpt.com/codex/tasks/task_e_68a18504aa448333bb17f370316315b1