### PR TITLE
refactor(graphql): modularize schema with federation

### DIFF
--- a/client/src/generated/graphql.json
+++ b/client/src/generated/graphql.json
@@ -10,5 +10,7 @@
   "1i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x": "query GetInvestigations($limit: Int, $offset: Int) {\n  investigations(limit: $limit, offset: $offset) {\n    id\n    title\n    description\n    status\n    sensitivity\n    createdBy\n    createdAt\n    updatedAt\n  }\n}",
   "0j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y": "query GetInvestigation($id: ID!) {\n  investigation(id: $id) {\n    id\n    title\n    description\n    status\n    sensitivity\n    createdBy\n    updatedBy\n    createdAt\n    updatedAt\n    entityCount\n    relationshipCount\n  }\n}",
   "9k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z": "mutation CreateInvestigation($input: CreateInvestigationInput!) {\n  createInvestigation(input: $input) {\n    id\n    title\n    description\n    status\n    sensitivity\n    createdBy\n    createdAt\n  }\n}",
-  "8l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a": "mutation UpdateInvestigation($id: ID!, $input: UpdateInvestigationInput!) {\n  updateInvestigation(id: $id, input: $input) {\n    id\n    title\n    description\n    status\n    sensitivity\n    updatedAt\n  }\n}"
+  "8l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a": "mutation UpdateInvestigation($id: ID!, $input: UpdateInvestigationInput!) {\n  updateInvestigation(id: $id, input: $input) {\n    id\n    title\n    description\n    status\n    sensitivity\n    updatedAt\n  }\n}",
+  "7z8y9x0w1v2u3t4s5r6q7p8o9n0m1l2": "query ListInsights {\n  insights {\n    id\n    message\n  }\n}",
+  "6y7x8w9v0u1t2s3r4q5p6o7n8m9l0k1": "query ListAlerts {\n  alerts {\n    id\n    level\n    message\n  }\n}"
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,7 +2,6 @@ import "dotenv/config";
 import express from "express";
 import { ApolloServer } from "@apollo/server";
 import { expressMiddleware } from "@as-integrations/express4";
-import { makeExecutableSchema } from "@graphql-tools/schema";
 import cors from "cors";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
@@ -10,8 +9,7 @@ import pino from "pino";
 import { pinoHttp } from "pino-http";
 import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
-import { typeDefs } from "./graphql/schema.js";
-import resolvers from "./graphql/resolvers/index.js";
+import { supergraphSchema } from "./graphql/federation/index.js";
 import { getContext } from "./lib/auth.js";
 import { getNeo4jDriver } from "./db/neo4j.js";
 import path from "path";
@@ -102,7 +100,7 @@ export const createApp = async () => {
     }
   });
 
-  const schema = makeExecutableSchema({ typeDefs, resolvers });
+  const schema = supergraphSchema;
 
   // GraphQL over HTTP
   const { persistedQueriesPlugin } = await import(

--- a/server/src/graphql/federation/alerts.ts
+++ b/server/src/graphql/federation/alerts.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+import { alertsResolvers } from '../../resolvers/alerts.js';
+
+export const typeDefs = gql`
+  type Alert @key(fields: "id") {
+    id: ID!
+    level: String!
+    message: String!
+  }
+
+  extend type Query {
+    alerts: [Alert!]!
+  }
+`;
+
+export const resolvers = alertsResolvers;

--- a/server/src/graphql/federation/collaboration.ts
+++ b/server/src/graphql/federation/collaboration.ts
@@ -1,0 +1,21 @@
+import gql from 'graphql-tag';
+import { collaborationResolvers } from '../../resolvers/collaboration.js';
+
+export const typeDefs = gql`
+  type Investigation @key(fields: "id") {
+    id: ID!
+    title: String!
+    description: String
+  }
+
+  extend type Query {
+    investigations(limit: Int, offset: Int): [Investigation!]!
+    investigation(id: ID!): Investigation
+  }
+
+  extend type Mutation {
+    createInvestigation(title: String!, description: String): Investigation
+  }
+`;
+
+export const resolvers = collaborationResolvers;

--- a/server/src/graphql/federation/entities.ts
+++ b/server/src/graphql/federation/entities.ts
@@ -1,0 +1,23 @@
+import gql from 'graphql-tag';
+import { entityResolvers } from '../../resolvers/entities.js';
+
+export const typeDefs = gql`
+  type Entity @key(fields: "id") {
+    id: ID!
+    type: String!
+    props: JSON
+    createdAt: DateTime!
+    updatedAt: DateTime
+  }
+
+  extend type Query {
+    entity(id: ID!): Entity
+    entities(type: String, q: String, limit: Int!, offset: Int!): [Entity!]!
+  }
+
+  extend type Mutation {
+    createEntity(id: ID!, type: String!, props: JSON): Entity
+  }
+`;
+
+export const resolvers = entityResolvers;

--- a/server/src/graphql/federation/index.ts
+++ b/server/src/graphql/federation/index.ts
@@ -1,0 +1,77 @@
+import { buildFederatedSchema } from '@apollo/federation';
+import gql from 'graphql-tag';
+import { GraphQLScalarType, Kind } from 'graphql';
+import { typeDefs as insightsTypeDefs, resolvers as insightsResolvers } from './insights.js';
+import { typeDefs as alertsTypeDefs, resolvers as alertsResolvers } from './alerts.js';
+import { typeDefs as entitiesTypeDefs, resolvers as entitiesResolvers } from './entities.js';
+import { typeDefs as collaborationTypeDefs, resolvers as collaborationResolvers } from './collaboration.js';
+
+const baseTypeDefs = gql`
+  scalar JSON
+  scalar DateTime
+  type Query { _empty: String }
+  type Mutation { _empty: String }
+`;
+
+const JSONScalar = new GraphQLScalarType({
+  name: 'JSON',
+  description: 'Arbitrary JSON value',
+  parseValue: (value) => value,
+  serialize: (value) => value,
+  parseLiteral(ast): any {
+    switch (ast.kind) {
+      case Kind.STRING:
+      case Kind.BOOLEAN:
+        return ast.value;
+      case Kind.INT:
+      case Kind.FLOAT:
+        return Number(ast.value);
+      case Kind.OBJECT: {
+        const value: any = {};
+        ast.fields.forEach((f) => {
+          value[f.name.value] = (JSONScalar.parseLiteral as any)(f.value);
+        });
+        return value;
+      }
+      case Kind.LIST:
+        return ast.values.map((v) => (JSONScalar.parseLiteral as any)(v));
+      default:
+        return null;
+    }
+  },
+});
+
+const DateTimeScalar = new GraphQLScalarType({
+  name: 'DateTime',
+  description: 'ISO date string',
+  parseValue: (value) => (value ? new Date(value) : null),
+  serialize: (value) => (value instanceof Date ? value.toISOString() : new Date(value).toISOString()),
+  parseLiteral: (ast) => (ast.kind === Kind.STRING ? new Date(ast.value) : null),
+});
+
+const baseResolvers = {
+  JSON: JSONScalar,
+  DateTime: DateTimeScalar,
+  Query: { _empty: () => 'ok' },
+  Mutation: { _empty: () => 'ok' },
+};
+
+export const mlSubgraphSchema = buildFederatedSchema([
+  { typeDefs: baseTypeDefs, resolvers: baseResolvers },
+  { typeDefs: insightsTypeDefs, resolvers: insightsResolvers },
+  { typeDefs: alertsTypeDefs, resolvers: alertsResolvers },
+]);
+
+export const ingestSubgraphSchema = buildFederatedSchema([
+  { typeDefs: baseTypeDefs, resolvers: baseResolvers },
+  { typeDefs: entitiesTypeDefs, resolvers: entitiesResolvers },
+  { typeDefs: collaborationTypeDefs, resolvers: collaborationResolvers },
+]);
+
+export const supergraphSchema = buildFederatedSchema([
+  { typeDefs: baseTypeDefs, resolvers: baseResolvers },
+  { typeDefs: insightsTypeDefs, resolvers: insightsResolvers },
+  { typeDefs: alertsTypeDefs, resolvers: alertsResolvers },
+  { typeDefs: entitiesTypeDefs, resolvers: entitiesResolvers },
+  { typeDefs: collaborationTypeDefs, resolvers: collaborationResolvers },
+]);

--- a/server/src/graphql/federation/insights.ts
+++ b/server/src/graphql/federation/insights.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+import { insightsResolvers } from '../../resolvers/insights.js';
+
+export const typeDefs = gql`
+  type Insight @key(fields: "id") {
+    id: ID!
+    message: String!
+  }
+
+  extend type Query {
+    insights: [Insight!]!
+  }
+`;
+
+export const resolvers = insightsResolvers;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,9 +7,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import WSPersistedQueriesMiddleware from "./graphql/middleware/wsPersistedQueries.js";
 import { createApp } from "./app.js";
-import { makeExecutableSchema } from "@graphql-tools/schema";
-import { typeDefs } from "./graphql/schema.js";
-import resolvers from "./graphql/resolvers/index.js";
+import { supergraphSchema } from "./graphql/federation/index.js";
 import { DataRetentionService } from './services/DataRetentionService.js';
 import { getNeo4jDriver } from './db/neo4j.js';
 
@@ -19,7 +17,7 @@ const logger: pino.Logger = pino();
 
 const startServer = async () => {
   const app = await createApp();
-  const schema = makeExecutableSchema({ typeDefs, resolvers });
+  const schema = supergraphSchema;
   const httpServer = http.createServer(app);
 
   // Subscriptions with Persisted Query validation

--- a/server/src/resolvers/alerts.ts
+++ b/server/src/resolvers/alerts.ts
@@ -1,0 +1,7 @@
+export const alertsResolvers = {
+  Query: {
+    alerts: async () => [
+      { id: '1', level: 'INFO', message: 'Sample alert' },
+    ],
+  },
+};

--- a/server/src/resolvers/collaboration.ts
+++ b/server/src/resolvers/collaboration.ts
@@ -1,0 +1,3 @@
+import investigationResolvers from '../graphql/resolvers/investigation.js';
+
+export const collaborationResolvers = investigationResolvers;

--- a/server/src/resolvers/entities.ts
+++ b/server/src/resolvers/entities.ts
@@ -1,0 +1,3 @@
+import entityResolvers from '../graphql/resolvers/entity.js';
+
+export { entityResolvers };

--- a/server/src/resolvers/insights.ts
+++ b/server/src/resolvers/insights.ts
@@ -1,0 +1,3 @@
+import { AIResolvers } from './ai.js';
+
+export const insightsResolvers = AIResolvers;


### PR DESCRIPTION
## Summary
- add Apollo Federation subgraphs for insights, alerts, entities, and collaboration
- expose federated supergraph and subgraph schemas for ML and ingest services
- wire server to federated schema and update client generated queries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a21bea4f848333ba45da6628dd0ae5