### PR TITLE
feat: add request sanitization middleware

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,3 +4,9 @@
 - Do not include sensitive data in issues. We will coordinate a private disclosure.
 - We run secret scanning and gitleaks in CI; please keep secrets out of code.
 
+## Application Hardening
+
+- User input is sanitized at API boundaries to reduce injection risk.
+- RBAC and OPA policies enforce least-privilege access across services.
+- Secrets are stored in encrypted form via [`sops`](.sops.yaml) and loaded from environment variables.
+

--- a/docs/THREAT_MODEL_STRIDE.md
+++ b/docs/THREAT_MODEL_STRIDE.md
@@ -1,8 +1,14 @@
 # Threat Model (STRIDE)
 
-- **Spoofing:** token theft → short‑lived JWT + rotation; mTLS between services.
-- **Tampering:** signed evidence refs; WORM bucket option; audit trail in Neo4j.
-- **Repudiation:** immutable runbook logs; user/action timestamps.
-- **Information Disclosure:** ABAC policies; row‑level filters in resolvers.
-- **DoS:** rate limits per connector; query guards (max depth, node/rel caps).
-- **Elevation of Privilege:** admin‑only schema mutations; least‑privilege service accounts.
+## STRIDE Threat Matrix
+
+| Category | Example Threat | Severity (Low/Med/High) | Mitigation |
+| --- | --- | --- | --- |
+| Spoofing | Stolen JWT used to impersonate user | High | Short‑lived tokens, rotation, mTLS between services |
+| Tampering | Graph data modified by unauthorized actor | High | Signed evidence references, immutable audit logs |
+| Repudiation | User denies executing mutation | Medium | Append‑only runbook logs with user/time metadata |
+| Information Disclosure | Leakage of investigation data | High | ABAC policies, row‑level resolver filters |
+| Denial of Service | Massive query causing resource exhaustion | Medium | Rate limits, query depth/size guards |
+| Elevation of Privilege | Bypassing RBAC to gain admin rights | High | RBAC enforcement, least‑privilege service accounts |
+
+Regular reviews update severity based on exploit likelihood and impact.

--- a/server/src/middleware/sanitize.js
+++ b/server/src/middleware/sanitize.js
@@ -1,0 +1,29 @@
+function escape(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
+function sanitize(value) {
+  if (typeof value === 'string') return escape(value);
+  if (Array.isArray(value)) return value.map(sanitize);
+  if (value && typeof value === 'object') {
+    const result = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = sanitize(val);
+    }
+    return result;
+  }
+  return value;
+}
+
+function sanitizeRequest(req, res, next) {
+  if (req.body) req.body = sanitize(req.body);
+  if (req.query) req.query = sanitize(req.query);
+  next();
+}
+
+module.exports = sanitizeRequest;

--- a/server/src/routes/entities.js
+++ b/server/src/routes/entities.js
@@ -2,11 +2,13 @@ const express = require("express");
 const { v4: uuidv4 } = require("uuid");
 const { getNeo4jDriver, getPostgresPool } = require("../config/database");
 const { ensureAuthenticated, requirePermission } = require("../middleware/auth");
+const sanitize = require("../middleware/sanitize");
 
 const router = express.Router();
 
-// Authn for all, RBAC for write
+// Authn for all, RBAC for write, sanitize inputs
 router.use(ensureAuthenticated);
+router.use(sanitize);
 
 async function logAudit(req, action, resourceId, details) {
   try {


### PR DESCRIPTION
## Summary
- sanitize request query and body using middleware to prevent injection
- document STRIDE threat matrix with severity scoring
- expand security policy around RBAC and encrypted secrets

## Testing
- `npm audit --production`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a21fd8197883339be96d869c410bec