### PR TITLE
feat: add browser extension for psyops monitoring

### DIFF
--- a/client/browser-extension/README.md
+++ b/client/browser-extension/README.md
@@ -1,0 +1,11 @@
+# PsyOps Resilience Monitor Extension
+
+This experimental browser extension scans page content and highlights text that may contain emotional or biased language.
+
+## Modes
+
+- **Passive** – scores content without alerting.
+- **Alert** – highlights suspicious passages.
+- **Educational** – highlights and adds tooltip explanations.
+
+Click the extension icon to cycle through modes. Flagged text can optionally be sent to a central dashboard for review.

--- a/client/browser-extension/background.js
+++ b/client/browser-extension/background.js
@@ -1,0 +1,24 @@
+const MODES = ["passive", "alert", "educational"];
+
+chrome.action.onClicked.addListener(async () => {
+  const { psyopsMode = "alert" } = await chrome.storage.sync.get("psyopsMode");
+  const next = MODES[(MODES.indexOf(psyopsMode) + 1) % MODES.length];
+  await chrome.storage.sync.set({ psyopsMode: next });
+  const tabs = await chrome.tabs.query({});
+  for (const tab of tabs) {
+    if (tab.id) {
+      chrome.tabs.sendMessage(tab.id, { type: "SET_MODE", mode: next });
+    }
+  }
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === "FLAG") {
+    // Optional: send flagged content to a central service
+    fetch("https://example.com/flags", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(msg),
+    }).catch(() => {});
+  }
+});

--- a/client/browser-extension/content-script.js
+++ b/client/browser-extension/content-script.js
@@ -1,0 +1,45 @@
+import { analyzeText } from "./detector.js";
+
+const MODES = {
+  PASSIVE: "passive",
+  ALERT: "alert",
+  EDUCATIONAL: "educational",
+};
+
+let mode = MODES.ALERT;
+
+chrome.storage?.sync.get(["psyopsMode"], (data) => {
+  if (data.psyopsMode) mode = data.psyopsMode;
+  monitor();
+});
+
+chrome.runtime?.onMessage.addListener((msg) => {
+  if (msg.type === "SET_MODE") {
+    mode = msg.mode;
+    monitor();
+  }
+});
+
+function monitor() {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  while (walker.nextNode()) nodes.push(walker.currentNode);
+  nodes.forEach((n) => processNode(n));
+}
+
+function processNode(textNode) {
+  const text = textNode.textContent || "";
+  const result = analyzeText(text);
+  if (result.score > 0.5 && mode !== MODES.PASSIVE) {
+    const span = document.createElement("span");
+    span.textContent = text;
+    span.style.backgroundColor = "rgba(255,0,0,0.2)";
+    if (mode === MODES.EDUCATIONAL) {
+      span.title = `Potential manipulation: ${result.tags.join(", ")}`;
+    }
+    span.addEventListener("click", () => {
+      chrome.runtime.sendMessage({ type: "FLAG", text, tags: result.tags });
+    });
+    textNode.parentNode?.replaceChild(span, textNode);
+  }
+}

--- a/client/browser-extension/detector.js
+++ b/client/browser-extension/detector.js
@@ -1,0 +1,39 @@
+const EMOTION_KEYWORDS = {
+  anger: ["hate", "furious", "rage"],
+  fear: ["fear", "terror", "panic"],
+  disgust: ["disgust", "vile", "gross"],
+  joy: ["happy", "joy", "delight"],
+  sadness: ["sad", "depress", "gloom"],
+};
+
+const BIAS_PHRASES = [
+  "everyone knows",
+  "no one can deny",
+  "fake news",
+  "the truth is",
+  "always",
+  "never",
+];
+
+export function analyzeText(text) {
+  const lower = (text || "").toLowerCase();
+  let score = 0;
+  const tags = [];
+
+  Object.entries(EMOTION_KEYWORDS).forEach(([emotion, words]) => {
+    if (words.some((w) => lower.includes(w))) {
+      score += 0.2;
+      tags.push(`emotion:${emotion}`);
+    }
+  });
+
+  if (BIAS_PHRASES.some((p) => lower.includes(p))) {
+    score += 0.2;
+    tags.push("bias");
+  }
+
+  return {
+    score: Math.min(1, score),
+    tags,
+  };
+}

--- a/client/browser-extension/manifest.json
+++ b/client/browser-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "PsyOps Resilience Monitor",
+  "version": "0.1.0",
+  "description": "Highlights potential cognitive manipulation in web content.",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Toggle PsyOps Monitor"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/client/src/psyops-monitor/detector.js
+++ b/client/src/psyops-monitor/detector.js
@@ -1,0 +1,39 @@
+const EMOTION_KEYWORDS = {
+  anger: ["hate", "furious", "rage"],
+  fear: ["fear", "terror", "panic"],
+  disgust: ["disgust", "vile", "gross"],
+  joy: ["happy", "joy", "delight"],
+  sadness: ["sad", "depress", "gloom"],
+};
+
+const BIAS_PHRASES = [
+  "everyone knows",
+  "no one can deny",
+  "fake news",
+  "the truth is",
+  "always",
+  "never",
+];
+
+export function analyzeText(text) {
+  const lower = (text || "").toLowerCase();
+  let score = 0;
+  const tags = [];
+
+  Object.entries(EMOTION_KEYWORDS).forEach(([emotion, words]) => {
+    if (words.some((w) => lower.includes(w))) {
+      score += 0.2;
+      tags.push(`emotion:${emotion}`);
+    }
+  });
+
+  if (BIAS_PHRASES.some((p) => lower.includes(p))) {
+    score += 0.2;
+    tags.push("bias");
+  }
+
+  return {
+    score: Math.min(1, score),
+    tags,
+  };
+}

--- a/client/src/psyops-monitor/detector.test.js
+++ b/client/src/psyops-monitor/detector.test.js
@@ -1,0 +1,14 @@
+import { analyzeText } from "./detector";
+
+describe("analyzeText", () => {
+  test("detects emotional language", () => {
+    const res = analyzeText("I am furious and full of rage");
+    expect(res.score).toBeGreaterThan(0);
+    expect(res.tags).toContain("emotion:anger");
+  });
+
+  test("detects bias phrases", () => {
+    const res = analyzeText("Everyone knows this is fake news");
+    expect(res.tags).toContain("bias");
+  });
+});


### PR DESCRIPTION
## Summary
- add initial PsyOps Resilience Monitor extension with background, manifest and content script
- introduce emotion and bias detection utility with unit tests

## Testing
- `npx prettier client/browser-extension/* client/src/psyops-monitor/* --write`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Invalid or unexpected token)*
- `cd client && npx jest src/psyops-monitor/detector.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a21f5a57a8833385c54280167d3caa