### PR TITLE
feat: add tamper-evident audit trail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # IntelGraph Platform Makefile
 # MVP-0 Ship Plan Implementation
 
-.PHONY: help up down build logs clean seed smoke test lint typecheck format install deps health status restart backup
+.PHONY: help up down build logs clean seed smoke test lint typecheck format install deps health status restart backup audit-verify
 
 # Default target
 help: ## Show this help message
@@ -86,7 +86,11 @@ test-integration: ## Run integration tests only
 	@npm run test:integration
 
 test-e2e: ## Run end-to-end tests
-	@npm run test:e2e
+        @npm run test:e2e
+
+audit-verify: ## Verify integrity of audit log
+	@node scripts/audit_verify.mjs
+
 
 ## Code Quality
 lint: ## Run linting

--- a/docs/monitoring/AUDIT_TRAIL.md
+++ b/docs/monitoring/AUDIT_TRAIL.md
@@ -1,0 +1,26 @@
+# Audit Trail
+
+IntelGraph provides a tamper-evident audit trail for all mutating GraphQL operations and admin actions.
+
+## Features
+- Append-only JSON log with SHA-256 hash chaining (`prevHash`) and per-entry HMAC.
+- `@audited` GraphQL directive marks resolvers for automatic logging.
+- Entries capture user, action, resource, before/after (redacted), decision, reason, and request id.
+- OpenTelemetry span exported per entry for SIEM correlation.
+- Verification CLI: `node scripts/audit_verify.mjs`.
+
+## Environment
+- `AUDIT_LOG_FILE` – path to log file (default `server/audit.log`).
+- `AUDIT_HMAC_KEY` – secret for HMAC signing.
+- `AUDIT_HMAC_KEY_ID` – identifier for key rotation.
+
+## SIEM Mapping
+| Audit Field | OTel Attribute | Description |
+|-------------|----------------|-------------|
+| `user` | `audit.user` | Authenticated user id |
+| `action` | `audit.action` | Mutation name |
+| `resource` | `audit.resource` | GraphQL parent type |
+| `decision` | `audit.decision` | allow/deny |
+| `requestId` | `audit.request_id` | Correlates to request span |
+
+Run `make audit-verify` to validate log integrity.

--- a/scripts/audit_verify.mjs
+++ b/scripts/audit_verify.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import crypto from 'crypto';
+import path from 'path';
+
+const file = process.argv[2] || process.env.AUDIT_LOG_FILE || path.join('server', 'audit.log');
+const secret = process.env.AUDIT_HMAC_KEY || 'dev_audit_key';
+
+if (!fs.existsSync(file)) {
+  console.error(`Audit log file not found: ${file}`);
+  process.exit(1);
+}
+
+const lines = fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean);
+let prevHash = null;
+for (const [i, line] of lines.entries()) {
+  const entry = JSON.parse(line);
+  const base = {
+    timestamp: entry.timestamp,
+    user: entry.user,
+    action: entry.action,
+    resource: entry.resource,
+    before: entry.before,
+    after: entry.after,
+    decision: entry.decision,
+    reason: entry.reason,
+    requestId: entry.requestId,
+    prevHash: entry.prevHash,
+    keyId: entry.keyId,
+  };
+  const hash = crypto.createHash('sha256').update(JSON.stringify(base)).digest('hex');
+  const hmac = crypto.createHmac('sha256', secret).update(hash).digest('hex');
+  if (entry.prevHash !== prevHash || entry.hash !== hash || entry.hmac !== hmac) {
+    console.error(`Tamper detected at line ${i + 1}`);
+    process.exit(1);
+  }
+  prevHash = entry.hash;
+}
+console.log(`Audit log verified: ${lines.length} entries`);

--- a/server/src/audit/auditLogger.ts
+++ b/server/src/audit/auditLogger.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { trace, SpanKind } from '@opentelemetry/api';
+
+export interface AuditLogEntry {
+  timestamp: string;
+  user: string | null;
+  action: string;
+  resource: string;
+  before?: unknown;
+  after?: unknown;
+  decision: 'allow' | 'deny';
+  reason?: string;
+  requestId?: string;
+  prevHash: string | null;
+  hash: string;
+  hmac: string;
+  keyId: string;
+}
+
+const logFile =
+  process.env.AUDIT_LOG_FILE || path.join(process.cwd(), 'server', 'audit.log');
+const hmacKey = process.env.AUDIT_HMAC_KEY || 'dev_audit_key';
+const keyId = process.env.AUDIT_HMAC_KEY_ID || 'dev';
+
+let lastHash: string | null = null;
+
+if (fs.existsSync(logFile)) {
+  const lines = fs.readFileSync(logFile, 'utf8').trim().split('\n');
+  if (lines.length) {
+    try {
+      const last = JSON.parse(lines[lines.length - 1]);
+      lastHash = last.hash;
+    } catch {
+      lastHash = null;
+    }
+  }
+}
+
+const redact = (value: unknown): unknown => {
+  if (!value || typeof value !== 'object') return value;
+  const clone: any = Array.isArray(value) ? [...value] : { ...value };
+  for (const k of Object.keys(clone)) {
+    if (k.toLowerCase().includes('password') || k.toLowerCase().includes('secret')) {
+      clone[k] = '[REDACTED]';
+    }
+  }
+  return clone;
+};
+
+export async function writeAuditLog(entry: {
+  user: string | null;
+  action: string;
+  resource: string;
+  before?: unknown;
+  after?: unknown;
+  decision: 'allow' | 'deny';
+  reason?: string;
+  requestId?: string;
+}): Promise<void> {
+  const timestamp = new Date().toISOString();
+  const base = {
+    timestamp,
+    user: entry.user,
+    action: entry.action,
+    resource: entry.resource,
+    before: redact(entry.before),
+    after: redact(entry.after),
+    decision: entry.decision,
+    reason: entry.reason,
+    requestId: entry.requestId,
+    prevHash: lastHash,
+    keyId,
+  };
+  const hash = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(base))
+    .digest('hex');
+  const hmac = crypto.createHmac('sha256', hmacKey).update(hash).digest('hex');
+  const fullEntry: AuditLogEntry = { ...base, hash, hmac };
+  fs.appendFileSync(logFile, JSON.stringify(fullEntry) + '\n');
+  lastHash = hash;
+
+  const tracer = trace.getTracer('audit');
+  const span = tracer.startSpan(`audit.${entry.action}`, {
+    kind: SpanKind.INTERNAL,
+  });
+  span.setAttributes({
+    'audit.user': entry.user || 'anonymous',
+    'audit.action': entry.action,
+    'audit.resource': entry.resource,
+    'audit.decision': entry.decision,
+    'audit.request_id': entry.requestId || '',
+  });
+  span.end();
+}
+
+export function resetAuditState() {
+  lastHash = null;
+}

--- a/server/src/graphql/directives/auditDirective.ts
+++ b/server/src/graphql/directives/auditDirective.ts
@@ -1,0 +1,47 @@
+import { mapSchema, MapperKind, getDirective } from '@graphql-tools/utils';
+import { defaultFieldResolver, GraphQLSchema } from 'graphql';
+import { writeAuditLog } from '../../audit/auditLogger.js';
+import { v4 as uuidv4 } from 'uuid';
+
+export function auditDirectiveTransformer(schema: GraphQLSchema): GraphQLSchema {
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+      const directive = getDirective(schema, fieldConfig, 'audited')?.[0];
+      if (directive) {
+        const { resolve = defaultFieldResolver } = fieldConfig;
+        fieldConfig.resolve = async function (source, args, context, info) {
+          const requestId =
+            context.req?.id || context.requestId || uuidv4();
+          const user = context.user?.id || null;
+          try {
+            const result = await resolve.call(this, source, args, context, info);
+            await writeAuditLog({
+              user,
+              action: info.fieldName,
+              resource: info.parentType.name,
+              before: context.audit?.before,
+              after: result,
+              decision: 'allow',
+              reason: 'ok',
+              requestId,
+            });
+            return result;
+          } catch (err) {
+            await writeAuditLog({
+              user,
+              action: info.fieldName,
+              resource: info.parentType.name,
+              before: context.audit?.before,
+              after: undefined,
+              decision: 'deny',
+              reason: err instanceof Error ? err.message : 'error',
+              requestId,
+            });
+            throw err;
+          }
+        };
+        return fieldConfig;
+      }
+    },
+  });
+}

--- a/server/src/graphql/schema.ts
+++ b/server/src/graphql/schema.ts
@@ -1,6 +1,7 @@
 export const typeDefs = `
   scalar JSON
   scalar DateTime
+  directive @audited on FIELD_DEFINITION
   type Entity { id: ID!, type: String!, props: JSON, createdAt: DateTime!, updatedAt: DateTime, canonicalId: ID }
   type Relationship { id: ID!, from: ID!, to: ID!, type: String!, props: JSON, createdAt: DateTime! }
 
@@ -356,18 +357,18 @@ input SemanticSearchFilter {
   input RelationshipInput { from: ID!, to: ID!, type: String!, props: JSON }
   
   type Mutation {
-    createEntity(input: EntityInput!): Entity!
-    updateEntity(id: ID!, input: EntityInput!): Entity!
-    deleteEntity(id: ID!): Boolean!
-    createRelationship(input: RelationshipInput!): Relationship!
-    updateRelationship(id: ID!, input: RelationshipInput!): Relationship!
-    deleteRelationship(id: ID!): Boolean!
-    createUser(input: UserInput!): User!
-    updateUser(id: ID!, input: UserInput!): User!
-    deleteUser(id: ID!): Boolean!
-    createInvestigation(input: InvestigationInput!): Investigation!
-    updateInvestigation(id: ID!, input: InvestigationInput!): Investigation!
-    deleteInvestigation(id: ID!): Boolean!
+    createEntity(input: EntityInput!): Entity! @audited
+    updateEntity(id: ID!, input: EntityInput!): Entity! @audited
+    deleteEntity(id: ID!): Boolean! @audited
+    createRelationship(input: RelationshipInput!): Relationship! @audited
+    updateRelationship(id: ID!, input: RelationshipInput!): Relationship! @audited
+    deleteRelationship(id: ID!): Boolean! @audited
+    createUser(input: UserInput!): User! @audited
+    updateUser(id: ID!, input: UserInput!): User! @audited
+    deleteUser(id: ID!): Boolean! @audited
+    createInvestigation(input: InvestigationInput!): Investigation! @audited
+    updateInvestigation(id: ID!, input: InvestigationInput!): Investigation! @audited
+    deleteInvestigation(id: ID!): Boolean! @audited
     linkEntities(text: String!): [LinkedEntity!]!
     extractRelationships(text: String!, entities: [LinkedEntityInput!]!): [ExtractedRelationship!]!
     

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,7 @@ import { createApp } from "./app.js";
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
+import { auditDirectiveTransformer } from "./graphql/directives/auditDirective.js";
 import { DataRetentionService } from './services/DataRetentionService.js';
 import { getNeo4jDriver } from './db/neo4j.js';
 
@@ -19,7 +20,8 @@ const logger: pino.Logger = pino();
 
 const startServer = async () => {
   const app = await createApp();
-  const schema = makeExecutableSchema({ typeDefs, resolvers });
+  let schema = makeExecutableSchema({ typeDefs, resolvers });
+  schema = auditDirectiveTransformer(schema);
   const httpServer = http.createServer(app);
 
   // Subscriptions with Persisted Query validation

--- a/server/tests/audit-logger.test.ts
+++ b/server/tests/audit-logger.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { writeAuditLog, resetAuditState } from '../src/audit/auditLogger.js';
+
+describe('audit logger', () => {
+  const file = path.join(__dirname, 'audit-test.log');
+  beforeEach(() => {
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+    process.env.AUDIT_LOG_FILE = file;
+    resetAuditState();
+  });
+  afterEach(() => {
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  });
+
+  it('chains hashes and validates hmac', async () => {
+    await writeAuditLog({
+      user: 'u1',
+      action: 'create',
+      resource: 'Entity',
+      decision: 'allow',
+    });
+    await writeAuditLog({
+      user: 'u1',
+      action: 'update',
+      resource: 'Entity',
+      decision: 'allow',
+    });
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    const first = JSON.parse(lines[0]);
+    const second = JSON.parse(lines[1]);
+    expect(second.prevHash).toBe(first.hash);
+    const hmac = crypto
+      .createHmac('sha256', process.env.AUDIT_HMAC_KEY || 'dev_audit_key')
+      .update(first.hash)
+      .digest('hex');
+    expect(first.hmac).toBe(hmac);
+  });
+});

--- a/server/tests/audit-verify.test.ts
+++ b/server/tests/audit-verify.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { writeAuditLog, resetAuditState } from '../src/audit/auditLogger.js';
+
+describe('audit verify', () => {
+  const file = path.join(__dirname, 'audit-test.log');
+  beforeEach(() => {
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+    process.env.AUDIT_LOG_FILE = file;
+    resetAuditState();
+  });
+  afterEach(() => {
+    if (fs.existsSync(file)) fs.unlinkSync(file);
+  });
+
+  it('detects tampering', async () => {
+    await writeAuditLog({ user: 'u1', action: 'create', resource: 'Entity', decision: 'allow' });
+    await writeAuditLog({ user: 'u1', action: 'update', resource: 'Entity', decision: 'allow' });
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    const tampered = JSON.parse(lines[0]);
+    tampered.user = 'evil';
+    fs.writeFileSync(file, [JSON.stringify(tampered), lines[1]].join('\n') + '\n');
+    let failed = false;
+    try {
+      execSync(`node ../../scripts/audit_verify.mjs ${file}`);
+    } catch {
+      failed = true;
+    }
+    expect(failed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add append-only audit logger with hash chaining and HMAC
- introduce @audited GraphQL directive and middleware
- provide audit verification CLI and docs

## Testing
- `npm test` *(fails: Invalid or unexpected token)*
- `make smoke` *(fails: missing script `test:smoke`)*
- `make audit-verify`


------
https://chatgpt.com/codex/tasks/task_e_68a21e76d21c8333b004094942c08600