### PR TITLE
feat: add neural influence map dashboard

### DIFF
--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -52,12 +52,15 @@ import InvestigationTimeline from "./components/timeline/InvestigationTimeline";
 import ThreatAssessmentEngine from "./components/threat/ThreatAssessmentEngine";
 import OsintFeedConfig from "./components/admin/OSINTFeedConfig";
 
+import NIMDashboard from "./features/nim/nim-dashboard";
+
 // Navigation items
 const navigationItems = [
   { path: "/dashboard", label: "Dashboard", icon: <DashboardIcon /> },
   { path: "/investigations", label: "Timeline", icon: <Search /> },
   { path: "/graph", label: "Graph Explorer", icon: <Timeline /> },
   { path: "/copilot", label: "AI Copilot", icon: <Psychology /> },
+  { path: "/nim", label: "Influence Map", icon: <Map /> },
   { path: "/threats", label: "Threat Assessment", icon: <Assessment /> },
   { path: "/geoint", label: "GeoInt Map", icon: <Map /> },
   { path: "/reports", label: "Reports", icon: <Assessment /> },
@@ -528,6 +531,14 @@ function CopilotPage() {
   );
 }
 
+function NIMPage() {
+  return (
+    <Container maxWidth="xl" sx={{ height: "100vh", py: 2 }}>
+      <NIMDashboard />
+    </Container>
+  );
+}
+
 function ThreatsPage() {
   return (
     <Container maxWidth="xl" sx={{ height: "100vh", py: 2 }}>
@@ -577,6 +588,7 @@ function MainLayout() {
           <Route path="/investigations" element={<InvestigationsPage />} />
           <Route path="/graph" element={<GraphExplorerPage />} />
           <Route path="/copilot" element={<CopilotPage />} />
+          <Route path="/nim" element={<NIMPage />} />
           <Route path="/threats" element={<ThreatsPage />} />
           <Route path="/geoint" element={<InvestigationsPage />} />
           <Route path="/reports" element={<InvestigationsPage />} />

--- a/client/src/features/nim/nim-dashboard.jsx
+++ b/client/src/features/nim/nim-dashboard.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react";
+import { Box, Typography } from "@mui/material";
+import NIMGraph from "./nim-graph";
+import RiskHeatmap from "./risk-heatmap";
+
+export default function NIMDashboard() {
+  const [graph, setGraph] = useState(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const res = await fetch("/api/nim");
+        const json = await res.json();
+        setGraph(json.graph);
+      } catch (e) {
+        console.error("Failed to load NIM data", e);
+      }
+    };
+    loadData();
+  }, []);
+
+  if (!graph) {
+    return <Typography>Loading...</Typography>;
+  }
+
+  const points = graph.nodes
+    .filter((n) => n.lat && n.lon)
+    .map((n) => ({ lat: n.lat, lon: n.lon, risk: n.riskScore }));
+
+  return (
+    <Box sx={{ display: "flex", height: "100%" }}>
+      <Box sx={{ flex: 2 }}>
+        <NIMGraph data={graph} />
+      </Box>
+      <Box sx={{ flex: 1 }}>
+        <RiskHeatmap points={points} />
+      </Box>
+    </Box>
+  );
+}

--- a/client/src/features/nim/nim-graph.jsx
+++ b/client/src/features/nim/nim-graph.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef } from "react";
+import * as d3 from "d3";
+
+export default function NIMGraph({ data }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!data) return;
+    const element = ref.current;
+    const width = element.clientWidth;
+    const height = element.clientHeight;
+
+    const svg = d3
+      .select(element)
+      .append("svg")
+      .attr("width", width)
+      .attr("height", height);
+
+    const simulation = d3
+      .forceSimulation(data.nodes)
+      .force(
+        "link",
+        d3.forceLink(data.links).id((d) => d.id),
+      )
+      .force("charge", d3.forceManyBody().strength(-100))
+      .force("center", d3.forceCenter(width / 2, height / 2));
+
+    const link = svg
+      .append("g")
+      .selectAll("line")
+      .data(data.links)
+      .enter()
+      .append("line")
+      .attr("stroke", "#999")
+      .attr("stroke-opacity", 0.6);
+
+    const node = svg
+      .append("g")
+      .selectAll("circle")
+      .data(data.nodes)
+      .enter()
+      .append("circle")
+      .attr("r", 5)
+      .attr("fill", (d) =>
+        d.riskScore > 0.6 ? "red" : d.riskScore > 0.3 ? "orange" : "green",
+      )
+      .call(
+        d3
+          .drag()
+          .on("start", dragstarted)
+          .on("drag", dragged)
+          .on("end", dragended),
+      );
+
+    node.append("title").text((d) => d.id);
+
+    simulation.on("tick", () => {
+      link
+        .attr("x1", (d) => d.source.x)
+        .attr("y1", (d) => d.source.y)
+        .attr("x2", (d) => d.target.x)
+        .attr("y2", (d) => d.target.y);
+
+      node.attr("cx", (d) => d.x).attr("cy", (d) => d.y);
+    });
+
+    function dragstarted(event) {
+      if (!event.active) simulation.alphaTarget(0.3).restart();
+      event.subject.fx = event.subject.x;
+      event.subject.fy = event.subject.y;
+    }
+
+    function dragged(event) {
+      event.subject.fx = event.x;
+      event.subject.fy = event.y;
+    }
+
+    function dragended(event) {
+      if (!event.active) simulation.alphaTarget(0);
+      event.subject.fx = null;
+      event.subject.fy = null;
+    }
+
+    return () => {
+      svg.remove();
+    };
+  }, [data]);
+
+  return <div ref={ref} style={{ width: "100%", height: "100%" }} />;
+}

--- a/client/src/features/nim/risk-heatmap.jsx
+++ b/client/src/features/nim/risk-heatmap.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { MapContainer, TileLayer, CircleMarker } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+
+export default function RiskHeatmap({ points }) {
+  return (
+    <MapContainer
+      style={{ height: "100%", width: "100%" }}
+      center={[0, 0]}
+      zoom={2}
+    >
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      {points.map((p, idx) => (
+        <CircleMarker
+          key={idx}
+          center={[p.lat, p.lon]}
+          radius={10}
+          pathOptions={{
+            color: p.risk > 0.6 ? "red" : p.risk > 0.3 ? "orange" : "green",
+            fillOpacity: 0.5,
+          }}
+        />
+      ))}
+    </MapContainer>
+  );
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import pino from "pino";
 import { pinoHttp } from "pino-http";
 import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
+import nimRouter from "./routes/nim.js";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
 import { getContext } from "./lib/auth.js";
@@ -35,6 +36,7 @@ export const createApp = async () => {
   // Rate limiting (exempt monitoring endpoints)
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
+  app.use("/api/nim", nimRouter);
   app.use(
     rateLimit({
       windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),

--- a/server/src/routes/nim.ts
+++ b/server/src/routes/nim.ts
@@ -1,0 +1,35 @@
+import express from "express";
+
+const router = express.Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    graph: {
+      nodes: [
+        {
+          id: "reddit:r/worldnews",
+          community: "Reddit",
+          riskScore: 0.3,
+          lat: 34.05,
+          lon: -118.25,
+        },
+        {
+          id: "telegram:group123",
+          community: "Telegram",
+          riskScore: 0.8,
+          lat: 51.51,
+          lon: -0.13,
+        },
+      ],
+      links: [
+        {
+          source: "reddit:r/worldnews",
+          target: "telegram:group123",
+          weight: 0.5,
+        },
+      ],
+    },
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `/api/nim` endpoint returning sample influence graph data
- display Neural Influence Map with D3 graph and Leaflet risk heatmap
- wire Influence Map page into client routing

## Testing
- `npm run lint` *(fails: eslint: not found)*
- `npm run format` *(fails: syntax errors in repository files)*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a21f67caf48333b0086d8d22728968