### PR TITLE
feat: integrate forecast alerts with auto-retraining

### DIFF
--- a/ml/tests/test_intelligence_pipeline.py
+++ b/ml/tests/test_intelligence_pipeline.py
@@ -29,3 +29,16 @@ def test_pipeline_end_to_end():
     probs = pipe.analyse_image(image)
     assert probs.shape == (1, 1000)
     assert torch.isclose(probs.sum(), torch.tensor(1.0), atol=1e-5)
+
+
+def test_forecast_alert_and_retraining():
+    pipe = IntelligencePipeline()
+    triggered: list[float] = []
+
+    pipe.add_alert_callback(lambda x: triggered.append(x))
+    pred = pipe.forecast_and_alert([1, 2, 3, 4, 5], threshold=4)
+    assert triggered and isinstance(pred, float)
+
+    version = pipe._model_version
+    pipe.update_forecast_performance(actual=100.0, window=1, degrade_threshold=10.0)
+    assert pipe._model_version == version + 1


### PR DESCRIPTION
## Summary
- use ridge regression with hyperparameter search for threat forecasting
- trigger callbacks when forecasted threats exceed a threshold
- auto-retrain forecast model when prediction error worsens

## Testing
- `PYTHONPATH=. pytest tests/test_intelligence_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a21ec8a230833386213b5715729da9