### PR TITLE
feat: adaptive summary feedback with export options

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import pino from "pino";
 import { pinoHttp } from "pino-http";
 import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
+import summariesRouter from "./routes/summaries.js";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
 import { getContext } from "./lib/auth.js";
@@ -35,6 +36,7 @@ export const createApp = async () => {
   // Rate limiting (exempt monitoring endpoints)
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
+  app.use("/api/summaries", summariesRouter);
   app.use(
     rateLimit({
       windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),

--- a/server/src/routes/summaries.ts
+++ b/server/src/routes/summaries.ts
@@ -1,0 +1,76 @@
+import { Router, Request, Response } from "express";
+import puppeteer from "puppeteer";
+import { llmAnalystService } from "../services/LLMAnalystService.js";
+
+const router = Router();
+
+// Record user feedback for a summary
+router.post("/:id/feedback", async (req: Request, res: Response) => {
+  try {
+    await llmAnalystService.recordFeedback(req.params.id, req.body || {});
+    res.json({ success: true });
+  } catch (error) {
+    res.status(404).json({ error: "Summary not found" });
+  }
+});
+
+// Retrieve a summary, optionally translated
+router.get("/:id", async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const lang = (req.query.lang as string) || undefined;
+  const product = llmAnalystService.getProduct(id);
+  if (!product) {
+    return res.status(404).json({ error: "Summary not found" });
+  }
+  try {
+    let content = product.content;
+    let language = product.language;
+    if (lang && lang !== product.language) {
+      content = await llmAnalystService.translateContent(content, lang);
+      language = lang;
+    }
+    res.json({ id: product.id, content, language, score: product.score });
+  } catch {
+    res.status(500).json({ error: "Translation failed" });
+  }
+});
+
+// Export summary as PDF or Markdown
+router.get("/:id/export", async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const format = (req.query.format as string) || "markdown";
+  const lang = (req.query.lang as string) || undefined;
+  const product = llmAnalystService.getProduct(id);
+  if (!product) {
+    return res.status(404).json({ error: "Summary not found" });
+  }
+  try {
+    let content = product.content;
+    if (lang && lang !== product.language) {
+      content = await llmAnalystService.translateContent(content, lang);
+    }
+    if (format === "pdf") {
+      const browser = await puppeteer.launch();
+      const page = await browser.newPage();
+      await page.setContent(`<pre>${content}</pre>`);
+      const pdfBuffer = await page.pdf();
+      await browser.close();
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename=summary-${id}.pdf`,
+      );
+      res.setHeader("Content-Type", "application/pdf");
+      res.send(pdfBuffer);
+    } else {
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename=summary-${id}.md`,
+      );
+      res.type("text/markdown").send(content);
+    }
+  } catch {
+    res.status(500).json({ error: "Export failed" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- track user feedback on summaries and adjust scores
- support multilingual summary translation and export to Markdown/PDF
- add UI rating, bookmarking, copy, and export controls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: repository YAML syntax errors)*
- `npm test` *(fails: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a21eb8de748333882022c37632d628