### PR TITLE
feat(obs): client traceparent, Grafana JSON, alert rules

### DIFF
--- a/client/src/services/apollo.js
+++ b/client/src/services/apollo.js
@@ -1,51 +1,74 @@
-import { ApolloClient, InMemoryCache, createHttpLink, split } from '@apollo/client';
-import { getMainDefinition } from '@apollo/client/utilities';
-import { setContext } from '@apollo/client/link/context';
-import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
-import { createClient } from 'graphql-ws';
+import {
+  ApolloClient,
+  InMemoryCache,
+  createHttpLink,
+  split,
+} from "@apollo/client";
+import { getMainDefinition } from "@apollo/client/utilities";
+import { setContext } from "@apollo/client/link/context";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
+import { createClient } from "graphql-ws";
 
 const httpLink = createHttpLink({
-  uri: import.meta.env.VITE_API_URL || 'http://localhost:4000/graphql',
+  uri: import.meta.env.VITE_API_URL || "http://localhost:4000/graphql",
 });
 
 const authLink = setContext((_, { headers }) => {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem("token");
+
+  // Generate a W3C traceparent header for end-to-end tracing
+  const traceId = crypto.randomUUID().replace(/-/g, "");
+  const spanIdArray = new Uint8Array(8);
+  crypto.getRandomValues(spanIdArray);
+  const spanId = Array.from(spanIdArray, (b) =>
+    b.toString(16).padStart(2, "0"),
+  ).join("");
+  const traceparent = `00-${traceId}-${spanId}-01`;
+
   return {
     headers: {
       ...headers,
       authorization: token ? `Bearer ${token}` : "",
-    }
-  }
+      traceparent,
+    },
+  };
 });
 
 // Set up WebSocket link for subscriptions
 let link = authLink.concat(httpLink);
 
 try {
-  const wsUrl = (import.meta.env.VITE_API_URL || 'http://localhost:4000/graphql')
-    .replace('http://', 'ws://')
-    .replace('https://', 'wss://');
+  const wsUrl = (
+    import.meta.env.VITE_API_URL || "http://localhost:4000/graphql"
+  )
+    .replace("http://", "ws://")
+    .replace("https://", "wss://");
 
-  const token = typeof localStorage !== 'undefined' ? localStorage.getItem('token') : '';
-  const wsLink = new GraphQLWsLink(createClient({
-    url: wsUrl,
-    connectionParams: {
-      authorization: token ? `Bearer ${token}` : '',
-    },
-    retryAttempts: 5,
-  }));
+  const token =
+    typeof localStorage !== "undefined" ? localStorage.getItem("token") : "";
+  const wsLink = new GraphQLWsLink(
+    createClient({
+      url: wsUrl,
+      connectionParams: {
+        authorization: token ? `Bearer ${token}` : "",
+      },
+      retryAttempts: 5,
+    }),
+  );
 
   link = split(
     ({ query }) => {
       const def = getMainDefinition(query);
-      return def.kind === 'OperationDefinition' && def.operation === 'subscription';
+      return (
+        def.kind === "OperationDefinition" && def.operation === "subscription"
+      );
     },
     wsLink,
-    authLink.concat(httpLink)
+    authLink.concat(httpLink),
   );
 } catch (e) {
   // graphql-ws not installed or failed to initialize; subscriptions disabled
-  console.warn('WebSocket subscriptions disabled:', e.message);
+  console.warn("WebSocket subscriptions disabled:", e.message);
 }
 
 export const apolloClient = new ApolloClient({
@@ -53,10 +76,10 @@ export const apolloClient = new ApolloClient({
   cache: new InMemoryCache(),
   defaultOptions: {
     watchQuery: {
-      errorPolicy: 'all',
+      errorPolicy: "all",
     },
     query: {
-      errorPolicy: 'all',
+      errorPolicy: "all",
     },
   },
 });

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -151,6 +151,66 @@ groups:
           summary: "Neo4j connection failure"
           description: "Neo4j is down at {{ $labels.instance }}"
 
+      # GraphQL resolver latency
+      - alert: HighResolverLatency
+        expr: histogram_quantile(0.95, rate(graphql_resolver_duration_seconds_bucket[5m])) > 0.5
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High GraphQL resolver latency"
+          description: "95th percentile resolver duration is {{ $value }}s"
+
+      # Slow Neo4j queries
+      - alert: SlowNeo4jQueries
+        expr: histogram_quantile(0.95, rate(neo4j_query_duration_seconds_bucket[5m])) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow Neo4j queries detected"
+          description: "95th percentile Neo4j query duration is {{ $value }}s"
+
+      # Low cache hit ratio
+      - alert: LowCacheHitRatio
+        expr: (rate(cache_hits_total[5m]) / (rate(cache_hits_total[5m]) + rate(cache_misses_total[5m]))) < 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Cache hit ratio below 80%"
+          description: "Cache hit ratio is {{ $value | humanizePercentage }}"
+
+      # Slow LLM responses
+      - alert: SlowLLMResponses
+        expr: histogram_quantile(0.95, rate(llm_request_duration_seconds_bucket[5m])) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "LLM response time high"
+          description: "95th percentile LLM call duration is {{ $value }}s"
+
+      # High HTTP round-trip time
+      - alert: HighRTT
+        expr: histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High HTTP round-trip time"
+          description: "95th percentile HTTP RTT is {{ $value }}s"
+
+      # Data refresh lag
+      - alert: DataRefreshLag
+        expr: data_refresh_lag_seconds > 60
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Data refresh lag exceeds 60s"
+          description: "Data refresh lag is {{ $value }} seconds"
+
   - name: intelgraph.ml.rules
     rules:
       # ML model loading failures

--- a/monitoring/dashboards/observability.json
+++ b/monitoring/dashboards/observability.json
@@ -1,0 +1,66 @@
+{
+  "id": null,
+  "uid": "obs-overview",
+  "title": "Observability Overview",
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Resolver p95 (ms)",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(graphql_resolver_duration_ms_bucket[5m])) by (le))"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Neo4j Query ms",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(neo4j_query_duration_ms_bucket[5m])) by (le))"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Hit Ratio",
+      "targets": [
+        {
+          "expr": "rate(cache_hits_total[5m]) / (rate(cache_hits_total[5m]) + rate(cache_misses_total[5m]))"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM Call ms",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(llm_request_duration_ms_bucket[5m])) by (le))"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP RTT ms",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_ms_bucket[5m])) by (le))"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Data Refresh Lag",
+      "targets": [{ "expr": "data_refresh_lag_seconds" }],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
+    }
+  ]
+}

--- a/server/src/services/LLMService.js
+++ b/server/src/services/LLMService.js
@@ -3,20 +3,21 @@
  * Supports multiple LLM providers for text generation and completion
  */
 
-import logger from '../utils/logger.js';
-import { applicationErrors } from '../monitoring/metrics.js';
+import logger from "../utils/logger.js";
+import { applicationErrors } from "../monitoring/metrics.js";
+import { otelService } from "../monitoring/opentelemetry.js";
 
 class LLMService {
   constructor(config = {}) {
     this.config = {
-      provider: process.env.LLM_PROVIDER || 'openai',
+      provider: process.env.LLM_PROVIDER || "openai",
       apiKey: process.env.OPENAI_API_KEY || process.env.LLM_API_KEY,
-      model: process.env.LLM_MODEL || 'gpt-3.5-turbo',
+      model: process.env.LLM_MODEL || "gpt-3.5-turbo",
       maxTokens: parseInt(process.env.LLM_MAX_TOKENS) || 2000,
       temperature: parseFloat(process.env.LLM_TEMPERATURE) || 0.3,
       timeout: parseInt(process.env.LLM_TIMEOUT) || 60000,
       maxRetries: parseInt(process.env.LLM_MAX_RETRIES) || 3,
-      ...config
+      ...config,
     };
 
     this.logger = logger;
@@ -25,7 +26,7 @@ class LLMService {
       averageLatency: 0,
       errorCount: 0,
       totalTokensGenerated: 0,
-      averageTokensPerCompletion: 0
+      averageTokensPerCompletion: 0,
     };
   }
 
@@ -39,11 +40,11 @@ class LLMService {
       maxTokens = this.config.maxTokens,
       temperature = this.config.temperature,
       systemMessage,
-      stream = false
+      stream = false,
     } = params;
 
     if (!prompt) {
-      throw new Error('Prompt is required');
+      throw new Error("Prompt is required");
     }
 
     const startTime = Date.now();
@@ -52,67 +53,72 @@ class LLMService {
     while (attempt < this.config.maxRetries) {
       try {
         let response;
-        
+
         switch (this.config.provider) {
-          case 'openai':
+          case "openai":
             response = await this.openAICompletion({
               prompt,
               model,
               maxTokens,
               temperature,
               systemMessage,
-              stream
+              stream,
             });
             break;
-          case 'anthropic':
+          case "anthropic":
             response = await this.anthropicCompletion(params);
             break;
-          case 'local':
+          case "local":
             response = await this.localCompletion(params);
             break;
           default:
-            throw new Error(`Unsupported LLM provider: ${this.config.provider}`);
+            throw new Error(
+              `Unsupported LLM provider: ${this.config.provider}`,
+            );
         }
 
         const latency = Date.now() - startTime;
         this.updateMetrics(latency, response.usage);
 
-        logger.debug('LLM completion successful', {
+        logger.debug("LLM completion successful", {
           provider: this.config.provider,
           model,
           promptLength: prompt.length,
           responseLength: response.content.length,
           latency,
-          tokensUsed: response.usage
+          tokensUsed: response.usage,
         });
 
         return response.content;
-
       } catch (error) {
         attempt++;
-        
+
         if (attempt >= this.config.maxRetries) {
           this.metrics.errorCount++;
-          applicationErrors.labels('llm_service', 'CompletionError', 'error').inc();
-          
-          logger.error('LLM completion failed after retries', {
+          applicationErrors
+            .labels("llm_service", "CompletionError", "error")
+            .inc();
+
+          logger.error("LLM completion failed after retries", {
             provider: this.config.provider,
             model,
             attempt,
-            error: error.message
+            error: error.message,
           });
-          
+
           throw error;
         }
 
-        logger.warn('LLM completion failed, retrying', {
+        logger.warn("LLM completion failed, retrying", {
           provider: this.config.provider,
           attempt,
-          error: error.message
+          error: error.message,
         });
 
         // Exponential backoff
-        await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.pow(2, attempt) * 1000),
+        );
       }
     }
   }
@@ -124,41 +130,46 @@ class LLMService {
     const {
       model = this.config.model,
       maxTokens = this.config.maxTokens,
-      temperature = this.config.temperature
+      temperature = this.config.temperature,
     } = options;
 
     if (!Array.isArray(messages) || messages.length === 0) {
-      throw new Error('Messages array is required');
+      throw new Error("Messages array is required");
     }
 
     const startTime = Date.now();
 
     try {
       let response;
-      
+
       switch (this.config.provider) {
-        case 'openai':
-          response = await this.openAIChat(messages, { model, maxTokens, temperature });
+        case "openai":
+          response = await this.openAIChat(messages, {
+            model,
+            maxTokens,
+            temperature,
+          });
           break;
         default:
-          throw new Error(`Chat not supported for provider: ${this.config.provider}`);
+          throw new Error(
+            `Chat not supported for provider: ${this.config.provider}`,
+          );
       }
 
       const latency = Date.now() - startTime;
       this.updateMetrics(latency, response.usage);
 
       return response.content;
-
     } catch (error) {
       this.metrics.errorCount++;
-      applicationErrors.labels('llm_service', 'ChatError', 'error').inc();
-      
-      logger.error('LLM chat failed', {
+      applicationErrors.labels("llm_service", "ChatError", "error").inc();
+
+      logger.error("LLM chat failed", {
         provider: this.config.provider,
         messageCount: messages.length,
-        error: error.message
+        error: error.message,
       });
-      
+
       throw error;
     }
   }
@@ -170,31 +181,34 @@ class LLMService {
     const { prompt, model, maxTokens, temperature, systemMessage } = params;
 
     if (!this.config.apiKey) {
-      throw new Error('OpenAI API key not configured');
+      throw new Error("OpenAI API key not configured");
     }
 
     const messages = [];
-    
-    if (systemMessage) {
-      messages.push({ role: 'system', content: systemMessage });
-    }
-    
-    messages.push({ role: 'user', content: prompt });
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
+    if (systemMessage) {
+      messages.push({ role: "system", content: systemMessage });
+    }
+
+    messages.push({ role: "user", content: prompt });
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
       headers: {
-        'Authorization': `Bearer ${this.config.apiKey}`,
-        'Content-Type': 'application/json'
+        Authorization: `Bearer ${this.config.apiKey}`,
+        "Content-Type": "application/json",
+        ...(otelService.getCurrentTraceContext()
+          ? { traceparent: otelService.getCurrentTraceContext() }
+          : {}),
       },
       body: JSON.stringify({
         model: model,
         messages: messages,
         max_tokens: maxTokens,
         temperature: temperature,
-        stream: false
+        stream: false,
       }),
-      signal: AbortSignal.timeout(this.config.timeout)
+      signal: AbortSignal.timeout(this.config.timeout),
     });
 
     if (!response.ok) {
@@ -205,12 +219,12 @@ class LLMService {
     const data = await response.json();
 
     if (!data.choices || data.choices.length === 0) {
-      throw new Error('No completion returned from OpenAI');
+      throw new Error("No completion returned from OpenAI");
     }
 
     return {
       content: data.choices[0].message.content,
-      usage: data.usage
+      usage: data.usage,
     };
   }
 
@@ -220,31 +234,36 @@ class LLMService {
   async openAIChat(messages, options) {
     const { model, maxTokens, temperature } = options;
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
       headers: {
-        'Authorization': `Bearer ${this.config.apiKey}`,
-        'Content-Type': 'application/json'
+        Authorization: `Bearer ${this.config.apiKey}`,
+        "Content-Type": "application/json",
+        ...(otelService.getCurrentTraceContext()
+          ? { traceparent: otelService.getCurrentTraceContext() }
+          : {}),
       },
       body: JSON.stringify({
         model: model,
         messages: messages,
         max_tokens: maxTokens,
-        temperature: temperature
+        temperature: temperature,
       }),
-      signal: AbortSignal.timeout(this.config.timeout)
+      signal: AbortSignal.timeout(this.config.timeout),
     });
 
     if (!response.ok) {
       const errorData = await response.text();
-      throw new Error(`OpenAI Chat API error: ${response.status} - ${errorData}`);
+      throw new Error(
+        `OpenAI Chat API error: ${response.status} - ${errorData}`,
+      );
     }
 
     const data = await response.json();
 
     return {
       content: data.choices[0].message.content,
-      usage: data.usage
+      usage: data.usage,
     };
   }
 
@@ -252,14 +271,14 @@ class LLMService {
    * Anthropic completion (placeholder)
    */
   async anthropicCompletion(params) {
-    throw new Error('Anthropic provider not yet implemented');
+    throw new Error("Anthropic provider not yet implemented");
   }
 
   /**
    * Local completion (placeholder)
    */
   async localCompletion(params) {
-    throw new Error('Local provider not yet implemented');
+    throw new Error("Local provider not yet implemented");
   }
 
   /**
@@ -268,8 +287,8 @@ class LLMService {
   async summarize(text, options = {}) {
     const {
       maxLength = 100,
-      style = 'concise',
-      model = this.config.model
+      style = "concise",
+      model = this.config.model,
     } = options;
 
     const prompt = `Please provide a ${style} summary of the following text in no more than ${maxLength} words:
@@ -282,7 +301,7 @@ Summary:`;
       prompt,
       model,
       maxTokens: Math.min(maxLength * 2, 500), // Rough token estimation
-      temperature: 0.3
+      temperature: 0.3,
     });
   }
 
@@ -292,8 +311,8 @@ Summary:`;
   async extract(text, entities, options = {}) {
     const { model = this.config.model } = options;
 
-    const entityList = Array.isArray(entities) ? entities.join(', ') : entities;
-    
+    const entityList = Array.isArray(entities) ? entities.join(", ") : entities;
+
     const prompt = `Extract the following types of information from the text: ${entityList}
 
 Text: ${text}
@@ -305,15 +324,15 @@ Response:`;
     const response = await this.complete({
       prompt,
       model,
-      temperature: 0.1
+      temperature: 0.1,
     });
 
     try {
       return JSON.parse(response);
     } catch (error) {
-      logger.warn('Failed to parse extraction response as JSON', {
+      logger.warn("Failed to parse extraction response as JSON", {
         response,
-        error: error.message
+        error: error.message,
       });
       return { raw_response: response };
     }
@@ -336,7 +355,7 @@ Answer:`;
     return this.complete({
       prompt,
       model,
-      temperature: 0.2
+      temperature: 0.2,
     });
   }
 
@@ -345,7 +364,7 @@ Answer:`;
    */
   updateMetrics(latency, usage = {}) {
     this.metrics.totalCompletions++;
-    
+
     const currentLatency = this.metrics.averageLatency;
     this.metrics.averageLatency = currentLatency
       ? (currentLatency + latency) / 2
@@ -353,7 +372,7 @@ Answer:`;
 
     if (usage.total_tokens) {
       this.metrics.totalTokensGenerated += usage.total_tokens;
-      
+
       const currentAvgTokens = this.metrics.averageTokensPerCompletion;
       this.metrics.averageTokensPerCompletion = currentAvgTokens
         ? (currentAvgTokens + usage.total_tokens) / 2
@@ -366,7 +385,7 @@ Answer:`;
    */
   getHealth() {
     return {
-      status: 'healthy',
+      status: "healthy",
       provider: this.config.provider,
       model: this.config.model,
       metrics: {
@@ -374,11 +393,18 @@ Answer:`;
         averageLatency: Math.round(this.metrics.averageLatency),
         errorCount: this.metrics.errorCount,
         totalTokensGenerated: this.metrics.totalTokensGenerated,
-        averageTokensPerCompletion: Math.round(this.metrics.averageTokensPerCompletion),
-        successRate: this.metrics.totalCompletions > 0 
-          ? ((this.metrics.totalCompletions - this.metrics.errorCount) / this.metrics.totalCompletions * 100).toFixed(1) + '%'
-          : '100%'
-      }
+        averageTokensPerCompletion: Math.round(
+          this.metrics.averageTokensPerCompletion,
+        ),
+        successRate:
+          this.metrics.totalCompletions > 0
+            ? (
+                ((this.metrics.totalCompletions - this.metrics.errorCount) /
+                  this.metrics.totalCompletions) *
+                100
+              ).toFixed(1) + "%"
+            : "100%",
+      },
     };
   }
 
@@ -389,17 +415,17 @@ Answer:`;
     try {
       const response = await this.complete({
         prompt: "What is 2+2?",
-        maxTokens: 50
+        maxTokens: 50,
       });
-      
+
       return {
         success: true,
-        response: response.substring(0, 100) // Truncate for logging
+        response: response.substring(0, 100), // Truncate for logging
       };
     } catch (error) {
       return {
         success: false,
-        error: error.message
+        error: error.message,
       };
     }
   }


### PR DESCRIPTION
## Summary
- forward traceparent from browser to API for end-to-end tracing
- propagate trace context to LLM calls and BullMQ worker jobs
- add Grafana observability dashboard and Prometheus alert rules

## Testing
- `npm install` *(passed)*
- `cd server && npm install` *(failed: 404 Not Found - @turf/point-in-polygon)*
- `npx prettier --write client/src/services/apollo.js server/src/services/LLMService.js server/src/workers/embeddingUpsertWorker.ts monitoring/alert_rules.yml monitoring/dashboards/observability.json`
- `npm run lint` *(failed: Cannot find package '@eslint/js')*
- `npm test` *(failed: repository contains syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c62e788833396ce563f03037e7b