### PR TITLE
feat: enforce attribute-based entity access

### DIFF
--- a/intelgraph_enhancements/fixes/compartmentation/abac_entity_visibility.rego
+++ b/intelgraph_enhancements/fixes/compartmentation/abac_entity_visibility.rego
@@ -1,0 +1,14 @@
+package fixes.compartmentation
+
+default allow = false
+
+# Example ABAC policy enforcing mission tags, compartments and time windows
+allow if {
+  user_tag := input.user.missionTags[_]
+  input.resource.missionTags[_] == user_tag
+  input.user.compartment.orgId == input.resource.compartment.orgId
+  not input.resource.compartment.teamId
+  now := time.parse_rfc3339_ns(input.context.time)
+  not input.resource.validFrom
+  not input.resource.validUntil
+}

--- a/server/policies/abac.rego
+++ b/server/policies/abac.rego
@@ -1,5 +1,7 @@
 package intelgraph
 
+import future.keywords.if
+
 default allow = false
 
 # Input example:
@@ -9,13 +11,63 @@ default allow = false
 #   "resource": {"sensitivity": "low"}
 # }
 
-allow {
+allow if {
   input.action == "read:chat"
   input.resource.sensitivity != "high"
 }
 
-allow {
+allow if {
   input.action == "write:comment"
   input.user.role == "ADMIN"
+}
+
+# Attribute-based entity visibility controls
+allow if {
+  input.action == "read:entity"
+  mission_tag_match
+  compartment_match
+  temporal_match
+}
+
+mission_tag_match if {
+  user_tag := input.user.missionTags[_]
+  input.resource.missionTags[_] == user_tag
+}
+
+compartment_match if {
+  input.user.compartment.orgId == input.resource.compartment.orgId
+  not input.resource.compartment.teamId
+}
+
+compartment_match if {
+  input.user.compartment.orgId == input.resource.compartment.orgId
+  input.user.compartment.teamId == input.resource.compartment.teamId
+}
+
+temporal_match if {
+  not input.resource.validFrom
+  not input.resource.validUntil
+}
+
+temporal_match if {
+  not input.resource.validFrom
+  now := time.parse_rfc3339_ns(input.context.time)
+  end := time.parse_rfc3339_ns(input.resource.validUntil)
+  now <= end
+}
+
+temporal_match if {
+  not input.resource.validUntil
+  now := time.parse_rfc3339_ns(input.context.time)
+  start := time.parse_rfc3339_ns(input.resource.validFrom)
+  now >= start
+}
+
+temporal_match if {
+  now := time.parse_rfc3339_ns(input.context.time)
+  start := time.parse_rfc3339_ns(input.resource.validFrom)
+  end := time.parse_rfc3339_ns(input.resource.validUntil)
+  now >= start
+  now <= end
 }
 

--- a/server/src/middleware/graphql-authz.ts
+++ b/server/src/middleware/graphql-authz.ts
@@ -10,6 +10,9 @@ interface User {
   role: string;
   tenantId?: string;
   permissions?: string[];
+  missionTags?: string[];
+  orgId?: string;
+  teamId?: string;
 }
 
 interface AuthContext {
@@ -25,6 +28,13 @@ interface OPAInput {
     type: string;
     field?: string;
     args?: any;
+    missionTags?: string[];
+    compartment?: {
+      orgId?: string;
+      teamId?: string;
+    };
+    validFrom?: string;
+    validUntil?: string;
   };
   context: {
     tenantId?: string;
@@ -32,6 +42,7 @@ interface OPAInput {
     environment: string;
     ip?: string;
     userAgent?: string;
+    time: string;
   };
 }
 
@@ -151,20 +162,31 @@ export class GraphQLAuthzPlugin {
         email: context.user.email,
         role: context.user.role,
         tenantId: context.user.tenantId,
-        permissions: context.user.permissions || []
+        permissions: context.user.permissions || [],
+        missionTags: context.user.missionTags || [],
+        orgId: context.user.orgId,
+        teamId: context.user.teamId
       },
       action: `${operation}.${fieldName}`,
       resource: {
         type: returnType,
         field: fieldName,
-        args: this.sanitizeArgs(args)
+        args: this.sanitizeArgs(args),
+        missionTags: args.missionTags || [],
+        compartment: {
+          orgId: args.orgId,
+          teamId: args.teamId
+        },
+        validFrom: args.validFrom,
+        validUntil: args.validUntil
       },
       context: {
         tenantId: this.extractTenantId(context, args),
         investigationId: args.investigationId || args.id,
         environment: config.env,
         ip: context.req?.ip,
-        userAgent: context.req?.get('user-agent')
+        userAgent: context.req?.get('user-agent'),
+        time: new Date().toISOString()
       }
     };
   }

--- a/server/tests/abac-entity-visibility.test.ts
+++ b/server/tests/abac-entity-visibility.test.ts
@@ -1,0 +1,58 @@
+import { withAuthAndPolicy } from "../src/middleware/withAuthAndPolicy";
+import { ForbiddenError } from "apollo-server-express";
+
+describe("mission tag and temporal ABAC", () => {
+  const baseUser = {
+    id: "u1",
+    email: "user@example.com",
+    roles: ["analyst"],
+    permissions: [],
+    orgId: "org-1",
+    teamId: "team-1",
+    missionTags: ["alpha", "bravo"],
+  };
+
+  it("allows entity access with matching mission tag and valid time", async () => {
+    const resolver = withAuthAndPolicy("read", () => ({
+      type: "entity",
+      id: "e1",
+      orgId: "org-1",
+      teamId: "team-1",
+      missionTags: ["alpha"],
+      validFrom: new Date(Date.now() - 1000).toISOString(),
+      validTo: new Date(Date.now() + 1000).toISOString(),
+    }))(async () => "ok");
+
+    const result = await resolver({}, {}, { user: baseUser }, { fieldName: "test", path: "testPath" });
+    expect(result).toBe("ok");
+  });
+
+  it("denies entity access when mission tag mismatch", async () => {
+    const resolver = withAuthAndPolicy("read", () => ({
+      type: "entity",
+      id: "e1",
+      orgId: "org-1",
+      teamId: "team-1",
+      missionTags: ["charlie"],
+    }))(async () => "ok");
+
+    await expect(
+      resolver({}, {}, { user: baseUser }, { fieldName: "test", path: "testPath" }),
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it("denies entity access outside valid time window", async () => {
+    const resolver = withAuthAndPolicy("read", () => ({
+      type: "entity",
+      id: "e1",
+      orgId: "org-1",
+      teamId: "team-1",
+      missionTags: ["alpha"],
+      validFrom: new Date(Date.now() + 10000).toISOString(),
+    }))(async () => "ok");
+
+    await expect(
+      resolver({}, {}, { user: baseUser }, { fieldName: "test", path: "testPath" }),
+    ).rejects.toThrow(ForbiddenError);
+  });
+});


### PR DESCRIPTION
## Summary
- integrate mission tag, compartment, and temporal rules into ABAC policy
- include mission tags and compartment context in GraphQL OPA guard
- add tests and sample policy for compartment-aware access

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx prettier --check server/policies/abac.rego server/src/middleware/graphql-authz.ts server/src/middleware/withAuthAndPolicy.ts server/tests/abac-entity-visibility.test.ts intelgraph_enhancements/fixes/compartmentation/abac_entity_visibility.rego` *(errors: No parser could be inferred for .rego files)*
- `cd server && npm test` *(fails: SyntaxError: Invalid or unexpected token)*
- `opa test server/policies/abac.rego`


------
https://chatgpt.com/codex/tasks/task_e_68a21c0a979883338f9ab41ba3e68e2f