### PR TITLE
feat: add micro alpha detector pipeline

### DIFF
--- a/python/micro_alpha_detector.py
+++ b/python/micro_alpha_detector.py
@@ -1,0 +1,184 @@
+"""Micro alpha signal detection pipeline.
+
+This module ingests news and social data, performs sentiment and entity
+analysis, correlates events with asset price moves and outputs ranked
+signals with confidence intervals.
+
+The implementation keeps external API calls minimal so the core logic can
+be tested offline. Ingestors should be extended with real credentials when
+used in production.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+import json
+import re
+from datetime import datetime, timedelta
+
+import pandas as pd
+import numpy as np
+import requests
+import feedparser
+import nltk
+from nltk.sentiment import SentimentIntensityAnalyzer
+
+nltk.download("vader_lexicon", quiet=True)
+
+
+@dataclass
+class NewsItem:
+    """Representation of a news or social post mentioning financial assets."""
+
+    timestamp: datetime
+    text: str
+    symbols: List[str]
+
+
+class BaseIngestor:
+    """Base class for news/twitter/rss ingestors."""
+
+    def fetch(self) -> Sequence[NewsItem]:
+        raise NotImplementedError
+
+
+class NewsAPIIngestor(BaseIngestor):
+    """Fetch news articles from the NewsAPI service."""
+
+    def __init__(self, api_key: str, query: str = "stocks"):
+        self.api_key = api_key
+        self.query = query
+
+    def fetch(self) -> Sequence[NewsItem]:
+        url = "https://newsapi.org/v2/everything"
+        params = {"q": self.query, "apiKey": self.api_key, "language": "en"}
+        res = requests.get(url, params=params, timeout=10)
+        data = res.json()
+        items: List[NewsItem] = []
+        for art in data.get("articles", []):
+            timestamp = datetime.fromisoformat(art["publishedAt"].replace("Z", "+00:00"))
+            text = f"{art.get('title', '')}. {art.get('description', '')}"
+            symbols = extract_entities(text)
+            items.append(NewsItem(timestamp=timestamp, text=text, symbols=symbols))
+        return items
+
+
+class RSSIngestor(BaseIngestor):
+    """Ingest RSS feeds."""
+
+    def __init__(self, feed_url: str):
+        self.feed_url = feed_url
+
+    def fetch(self) -> Sequence[NewsItem]:
+        parsed = feedparser.parse(self.feed_url)
+        items: List[NewsItem] = []
+        for entry in parsed.entries:
+            timestamp = datetime(*entry.published_parsed[:6]) if entry.get("published_parsed") else datetime.utcnow()
+            text = entry.get("title", "")
+            symbols = extract_entities(text)
+            items.append(NewsItem(timestamp=timestamp, text=text, symbols=symbols))
+        return items
+
+
+class TwitterIngestor(BaseIngestor):
+    """Fetch tweets using Twitter API v2."""
+
+    def __init__(self, bearer_token: str, query: str = "(stock OR stocks) -is:retweet"):
+        self.bearer_token = bearer_token
+        self.query = query
+
+    def fetch(self) -> Sequence[NewsItem]:
+        url = "https://api.twitter.com/2/tweets/search/recent"
+        headers = {"Authorization": f"Bearer {self.bearer_token}"}
+        params = {"query": self.query, "tweet.fields": "created_at"}
+        res = requests.get(url, headers=headers, params=params, timeout=10)
+        data = res.json()
+        items: List[NewsItem] = []
+        for tw in data.get("data", []):
+            timestamp = datetime.fromisoformat(tw["created_at"].replace("Z", "+00:00"))
+            text = tw.get("text", "")
+            symbols = extract_entities(text)
+            items.append(NewsItem(timestamp=timestamp, text=text, symbols=symbols))
+        return items
+
+
+class MicroAlphaDetector:
+    """High level pipeline orchestrating ingestion and signal generation."""
+
+    def __init__(self, ingestors: Iterable[BaseIngestor]):
+        self.ingestors = ingestors
+        self.sia = SentimentIntensityAnalyzer()
+
+    def ingest(self) -> List[NewsItem]:
+        items: List[NewsItem] = []
+        for ing in self.ingestors:
+            try:
+                items.extend(ing.fetch())
+            except Exception:
+                continue
+        return items
+
+    def analyze(self, news: Sequence[NewsItem], price_df: pd.DataFrame, horizon: timedelta = timedelta(minutes=30)) -> List["Signal"]:
+        """Compute sentiment and correlate with price moves."""
+        signals: List[Signal] = []
+        price_df = price_df.sort_values("timestamp")
+        for item in news:
+            sentiment = self.sia.polarity_scores(item.text)["compound"]
+            for symbol in item.symbols:
+                subset = price_df[price_df["symbol"] == symbol]
+                before = subset[subset["timestamp"] <= item.timestamp].tail(1)
+                after = subset[subset["timestamp"] >= item.timestamp + horizon].head(1)
+                if before.empty or after.empty:
+                    continue
+                ret = (after["price"].iat[0] - before["price"].iat[0]) / before["price"].iat[0]
+                signals.append({"time": item.timestamp, "asset": symbol, "sentiment": sentiment, "ret": ret})
+        if not signals:
+            return []
+        df = pd.DataFrame(signals)
+        results: List[Signal] = []
+        for asset, grp in df.groupby("asset"):
+            corr = grp["sentiment"].corr(grp["ret"])
+            n = len(grp)
+            if np.isnan(corr) or n < 3:
+                continue
+            z = np.arctanh(corr)
+            se = 1 / np.sqrt(n - 3) if n > 3 else float("inf")
+            ci_low = np.tanh(z - 1.96 * se)
+            ci_high = np.tanh(z + 1.96 * se)
+            results.append(Signal(time=grp["time"].iloc[-1], asset=asset, strength=corr, confidence_low=ci_low, confidence_high=ci_high))
+        results.sort(key=lambda s: abs(s.strength), reverse=True)
+        return results
+
+    @staticmethod
+    def to_json(signals: Sequence["Signal"]) -> str:
+        return json.dumps([s.__dict__ for s in signals], default=str)
+
+    @staticmethod
+    def to_csv(signals: Sequence["Signal"], path: str) -> None:
+        pd.DataFrame([s.__dict__ for s in signals]).to_csv(path, index=False)
+
+
+@dataclass
+class Signal:
+    time: datetime
+    asset: str
+    strength: float
+    confidence_low: float
+    confidence_high: float
+
+
+def extract_entities(text: str) -> List[str]:
+    """Very small helper using uppercase words as tickers."""
+    return re.findall(r"\b[A-Z]{2,5}\b", text)
+
+
+__all__ = [
+    "NewsItem",
+    "Signal",
+    "BaseIngestor",
+    "NewsAPIIngestor",
+    "RSSIngestor",
+    "TwitterIngestor",
+    "MicroAlphaDetector",
+    "extract_entities",
+]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,3 +7,7 @@ networkx
 nltk
 python-multipart
 uvloop
+pandas
+numpy
+requests
+feedparser

--- a/python/tests/test_micro_alpha_detector.py
+++ b/python/tests/test_micro_alpha_detector.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+import sys
+import pathlib
+
+import pandas as pd
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from micro_alpha_detector import MicroAlphaDetector, NewsItem
+
+
+def test_micro_alpha_detector_generates_signal():
+    news = [
+        NewsItem(timestamp=datetime(2023, 1, 1, 9, 0), text="AAPL strong sales", symbols=["AAPL"]),
+        NewsItem(timestamp=datetime(2023, 1, 1, 10, 0), text="AAPL product recall", symbols=["AAPL"]),
+        NewsItem(timestamp=datetime(2023, 1, 1, 11, 0), text="AAPL steady demand", symbols=["AAPL"]),
+    ]
+    price_data = pd.DataFrame(
+        [
+            {"timestamp": datetime(2023, 1, 1, 9, 0), "symbol": "AAPL", "price": 100.0},
+            {"timestamp": datetime(2023, 1, 1, 9, 30), "symbol": "AAPL", "price": 105.0},
+            {"timestamp": datetime(2023, 1, 1, 10, 0), "symbol": "AAPL", "price": 102.0},
+            {"timestamp": datetime(2023, 1, 1, 10, 30), "symbol": "AAPL", "price": 100.0},
+            {"timestamp": datetime(2023, 1, 1, 11, 0), "symbol": "AAPL", "price": 101.0},
+            {"timestamp": datetime(2023, 1, 1, 11, 30), "symbol": "AAPL", "price": 101.0},
+        ]
+    )
+
+    detector = MicroAlphaDetector([])
+    signals = detector.analyze(news, price_data, horizon=timedelta(minutes=30))
+
+    assert len(signals) == 1
+    s = signals[0]
+    assert s.asset == "AAPL"
+    assert -1.0 <= s.strength <= 1.0
+    assert s.confidence_low <= s.confidence_high


### PR DESCRIPTION
## Summary
- add micro-alpha detector that ingests news and social data, scores sentiment and correlates with price moves
- output ranked signals with confidence intervals and CSV/JSON export helpers
- cover pipeline with unit test and add required python dependencies

## Testing
- `pytest python/tests/test_micro_alpha_detector.py -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: syntax errors in existing YAML and JS files)*
- `npm test` *(fails: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a2382d57b48333a658ab179262d19a