### PR TITLE
feat: add dark mode and accessibility toggles

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -94,6 +94,9 @@
     "ts-jest": "^29.4.1",
     "vite": "^4.5.14",
     "vite-plugin-babel": "^1.3.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.14"
   }
 }

--- a/client/postcss.config.cjs
+++ b/client/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -53,6 +53,7 @@ import ThreatAssessmentEngine from "./components/threat/ThreatAssessmentEngine";
 import OsintFeedConfig from "./components/admin/OSINTFeedConfig";
 import ExecutiveDashboard from "./features/wargame/ExecutiveDashboard"; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
 import { MilitaryTech } from "@mui/icons-material"; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
+import AccessibilityToggle from "./components/AccessibilityToggle.jsx";
 
 // Navigation items
 const navigationItems = [
@@ -66,7 +67,11 @@ const navigationItems = [
   { path: "/system", label: "System", icon: <Settings /> },
   // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
   // Ethics Compliance: This dashboard is for hypothetical scenario simulation only.
-  { path: "/wargame-dashboard", label: "WarGame Dashboard", icon: <MilitaryTech /> },
+  {
+    path: "/wargame-dashboard",
+    label: "WarGame Dashboard",
+    icon: <MilitaryTech />,
+  },
 ];
 
 // Connection Status Component
@@ -164,6 +169,7 @@ function AppHeader({ onMenuClick }) {
         <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
           IntelGraph Platform - {currentPage?.label || "Unknown"}
         </Typography>
+        <AccessibilityToggle />
       </Toolbar>
     </AppBar>
   );
@@ -595,8 +601,6 @@ function MainLayout() {
     </Box>
   );
 }
-
-
 
 // Themed App Shell with Beautiful Background
 

--- a/client/src/components/AccessibilityToggle.jsx
+++ b/client/src/components/AccessibilityToggle.jsx
@@ -1,0 +1,35 @@
+import { usePreferences } from "../context/PreferencesContext.jsx";
+
+export default function AccessibilityToggle() {
+  const { darkMode, highContrast, toggleDarkMode, toggleHighContrast } =
+    usePreferences();
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={toggleDarkMode}
+        aria-pressed={darkMode}
+        aria-label="Toggle dark mode"
+        className="px-2 py-1 border rounded focus:outline-none focus:ring"
+      >
+        <span aria-hidden="true">{darkMode ? "🌙" : "☀️"}</span>
+        <span className="sr-only">
+          {darkMode ? "Enable light mode" : "Enable dark mode"}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={toggleHighContrast}
+        aria-pressed={highContrast}
+        aria-label="Toggle high contrast mode"
+        className="px-2 py-1 border rounded focus:outline-none focus:ring"
+      >
+        <span aria-hidden="true">⚡</span>
+        <span className="sr-only">
+          {highContrast ? "Disable high contrast" : "Enable high contrast"}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/client/src/context/PreferencesContext.jsx
+++ b/client/src/context/PreferencesContext.jsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const PreferencesContext = createContext();
+
+export const usePreferences = () => useContext(PreferencesContext);
+
+export function PreferencesProvider({ children }) {
+  const [darkMode, setDarkMode] = useState(() => {
+    return localStorage.getItem("prefers-dark") === "true";
+  });
+  const [highContrast, setHighContrast] = useState(() => {
+    return localStorage.getItem("prefers-contrast") === "true";
+  });
+  const [isMobile, setIsMobile] = useState(
+    () => window.matchMedia("(max-width: 640px)").matches,
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia("(max-width: 640px)");
+    const handler = () => setIsMobile(media.matches);
+    media.addEventListener("change", handler);
+    return () => media.removeEventListener("change", handler);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("prefers-dark", darkMode);
+    const root = document.documentElement;
+    if (darkMode) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [darkMode]);
+
+  useEffect(() => {
+    localStorage.setItem("prefers-contrast", highContrast);
+    const root = document.documentElement;
+    if (highContrast) {
+      root.classList.add("contrast");
+    } else {
+      root.classList.remove("contrast");
+    }
+  }, [highContrast]);
+
+  const value = {
+    darkMode,
+    highContrast,
+    isMobile,
+    toggleDarkMode: () => setDarkMode((v) => !v),
+    toggleHighContrast: () => setHighContrast((v) => !v),
+  };
+
+  return (
+    <PreferencesContext.Provider value={value}>
+      {children}
+    </PreferencesContext.Provider>
+  );
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,39 +1,41 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.router.jsx'
-import './styles/globals.css'
-import { initWebVitals } from './utils/webVitals.js'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.router.jsx";
+import "./styles/globals.css";
+import { initWebVitals } from "./utils/webVitals.js";
+import { PreferencesProvider } from "./context/PreferencesContext.jsx";
 
-console.log('🚀 Starting Full IntelGraph Router App...');
+console.log("🚀 Starting Full IntelGraph Router App...");
 
 // Global error handlers
-window.addEventListener('error', (event) => {
-  console.error('🚨 GLOBAL ERROR:', event.error);
+window.addEventListener("error", (event) => {
+  console.error("🚨 GLOBAL ERROR:", event.error);
 });
 
-window.addEventListener('unhandledrejection', (event) => {
-  console.error('🚨 UNHANDLED PROMISE REJECTION:', event.reason);
+window.addEventListener("unhandledrejection", (event) => {
+  console.error("🚨 UNHANDLED PROMISE REJECTION:", event.reason);
 });
 
-const root = document.getElementById('root');
+const root = document.getElementById("root");
 
 if (!root) {
-  console.error('❌ CRITICAL: Root element not found!');
+  console.error("❌ CRITICAL: Root element not found!");
 } else {
   try {
-    console.log('📍 Creating React root with full stack...');
-    
+    console.log("📍 Creating React root with full stack...");
+
     ReactDOM.createRoot(root).render(
       <React.StrictMode>
-        <App />
-      </React.StrictMode>
+        <PreferencesProvider>
+          <App />
+        </PreferencesProvider>
+      </React.StrictMode>,
     );
-    
-    console.log('✅ Full IntelGraph app rendered successfully');
 
+    console.log("✅ Full IntelGraph app rendered successfully");
   } catch (error) {
-    console.error('❌ CRITICAL ERROR during render:', error);
-    
+    console.error("❌ CRITICAL ERROR during render:", error);
+
     root.innerHTML = `
       <div style="padding: 20px; background: #ffcdd2; border: 2px solid #f44336; border-radius: 8px; margin: 20px; font-family: Arial;">
         <h1 style="color: #d32f2f;">❌ IntelGraph App Failed</h1>

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -1,12 +1,28 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
-html, body, #root { height: 100%; }
+html,
+body,
+#root {
+  height: 100%;
+}
 body {
-  font-family: ui-sans-serif, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, sans-serif;
+  font-family:
+    ui-sans-serif,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Inter,
+    Helvetica,
+    Arial,
+    sans-serif;
   line-height: 1.55;
   color: #0c0d0e;
   background-color: #fafbfc;
@@ -43,11 +59,44 @@ body {
 
 /* Tufte/Wright-inspired refinements */
 :root {
-  --hairline: rgba(12,13,14,0.08);
+  --hairline: rgba(12, 13, 14, 0.08);
 }
-.hairline { border-color: var(--hairline) !important; }
-.muted { color: rgba(12,13,14,0.56); }
-.smallcaps { font-variant-caps: small-caps; letter-spacing: 0.06em; }
-.note { color: rgba(12,13,14,0.56); font-size: 0.85rem; }
-.section-title { font-weight: 600; letter-spacing: 0.12rem; text-transform: none; }
-.panel { border: 1px solid var(--hairline); border-radius: 6px; background: #fff; }
+.hairline {
+  border-color: var(--hairline) !important;
+}
+.muted {
+  color: rgba(12, 13, 14, 0.56);
+}
+.smallcaps {
+  font-variant-caps: small-caps;
+  letter-spacing: 0.06em;
+}
+.note {
+  color: rgba(12, 13, 14, 0.56);
+  font-size: 0.85rem;
+}
+.section-title {
+  font-weight: 600;
+  letter-spacing: 0.12rem;
+  text-transform: none;
+}
+.panel {
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  background: #fff;
+}
+
+html.dark body {
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+html.contrast body {
+  background-color: #000;
+  color: #fff;
+}
+
+html.dark.contrast body {
+  background-color: #000;
+  color: #fff;
+}

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind config and PostCSS pipeline for dark mode support
- introduce PreferencesContext with localStorage-backed theme and contrast options
- provide AccessibilityToggle component and wire it into app header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in .github/workflows/ci-security.yml)*
- `npm test` *(fails: Invalid or unexpected token in server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a242b0b45c833388f9af350109b5cb