### PR TITLE
feat: scope GraphQL mutations and subscriptions by tenant

### DIFF
--- a/server/src/graphql/subscriptions.ts
+++ b/server/src/graphql/subscriptions.ts
@@ -1,48 +1,103 @@
-import pino from 'pino';
-import OrderedPubSub from './ordered-pubsub';
+import pino from "pino";
+import OrderedPubSub from "./ordered-pubsub";
+import { requireTenant } from "../middleware/withTenant.js";
 
 const logger = pino();
 export const pubsub = new OrderedPubSub();
 
-export const ENTITY_CREATED = 'ENTITY_CREATED';
-export const ENTITY_UPDATED = 'ENTITY_UPDATED';
-export const ENTITY_DELETED = 'ENTITY_DELETED';
-export const RELATIONSHIP_CREATED = 'RELATIONSHIP_CREATED';
-export const RELATIONSHIP_UPDATED = 'RELATIONSHIP_UPDATED';
-export const RELATIONSHIP_DELETED = 'RELATIONSHIP_DELETED';
+export const ENTITY_CREATED = "ENTITY_CREATED";
+export const ENTITY_UPDATED = "ENTITY_UPDATED";
+export const ENTITY_DELETED = "ENTITY_DELETED";
+export const RELATIONSHIP_CREATED = "RELATIONSHIP_CREATED";
+export const RELATIONSHIP_UPDATED = "RELATIONSHIP_UPDATED";
+export const RELATIONSHIP_DELETED = "RELATIONSHIP_DELETED";
+
+export const tenantEvent = (base: string, tenantId: string): string =>
+  `${base}_${tenantId}`;
 
 const subscriptionResolvers = {
   Subscription: {
     entityCreated: {
-      subscribe: () => pubsub.asyncIterator([ENTITY_CREATED]),
+      subscribe: (_: any, __: any, context: any) => {
+        const tenantId = requireTenant(context);
+        return pubsub.asyncIterator([tenantEvent(ENTITY_CREATED, tenantId)]);
+      },
       resolve: (event: any) => {
         const { payload } = event;
-        logger.info({ payload }, 'Resolving entityCreated subscription');
+        logger.info({ payload }, "Resolving entityCreated subscription");
         return payload;
       },
     },
     entityUpdated: {
-      subscribe: () => pubsub.asyncIterator([ENTITY_UPDATED]),
+      subscribe: (_: any, __: any, context: any) => {
+        const tenantId = requireTenant(context);
+        return pubsub.asyncIterator([tenantEvent(ENTITY_UPDATED, tenantId)]);
+      },
       resolve: (event: any) => {
         const { payload } = event;
-        logger.info({ payload }, 'Resolving entityUpdated subscription');
+        logger.info({ payload }, "Resolving entityUpdated subscription");
         return payload;
       },
     },
     entityDeleted: {
-      subscribe: () => pubsub.asyncIterator([ENTITY_DELETED]),
+      subscribe: (_: any, __: any, context: any) => {
+        const tenantId = requireTenant(context);
+        return pubsub.asyncIterator([tenantEvent(ENTITY_DELETED, tenantId)]);
+      },
       resolve: (event: any) => {
         const { payload } = event;
-        logger.info({ payload }, 'Resolving entityDeleted subscription');
+        logger.info({ payload }, "Resolving entityDeleted subscription");
+        return payload;
+      },
+    },
+    relationshipCreated: {
+      subscribe: (_: any, __: any, context: any) => {
+        const tenantId = requireTenant(context);
+        return pubsub.asyncIterator([
+          tenantEvent(RELATIONSHIP_CREATED, tenantId),
+        ]);
+      },
+      resolve: (event: any) => {
+        const { payload } = event;
+        logger.info({ payload }, "Resolving relationshipCreated subscription");
+        return payload;
+      },
+    },
+    relationshipUpdated: {
+      subscribe: (_: any, __: any, context: any) => {
+        const tenantId = requireTenant(context);
+        return pubsub.asyncIterator([
+          tenantEvent(RELATIONSHIP_UPDATED, tenantId),
+        ]);
+      },
+      resolve: (event: any) => {
+        const { payload } = event;
+        logger.info({ payload }, "Resolving relationshipUpdated subscription");
+        return payload;
+      },
+    },
+    relationshipDeleted: {
+      subscribe: (_: any, __: any, context: any) => {
+        const tenantId = requireTenant(context);
+        return pubsub.asyncIterator([
+          tenantEvent(RELATIONSHIP_DELETED, tenantId),
+        ]);
+      },
+      resolve: (event: any) => {
+        const { payload } = event;
+        logger.info({ payload }, "Resolving relationshipDeleted subscription");
         return payload;
       },
     },
     // Placeholder for aiRecommendationUpdated
     aiRecommendationUpdated: {
-      subscribe: () => pubsub.asyncIterator(['AI_RECOMMENDATION_UPDATED']),
+      subscribe: () => pubsub.asyncIterator(["AI_RECOMMENDATION_UPDATED"]),
       resolve: (event: any) => {
         const { payload } = event;
-        logger.info({ payload }, 'Resolving aiRecommendationUpdated subscription');
+        logger.info(
+          { payload },
+          "Resolving aiRecommendationUpdated subscription",
+        );
         return payload;
       },
     },


### PR DESCRIPTION
## Summary
- scope entity and relationship mutations by tenantId
- isolate GraphQL subscriptions with tenant-specific async iterators

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in workflows)*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*
- `npx tsc --pretty false --noEmit server/src/graphql/resolvers/entity.ts` *(fails: Cannot find module 'uuid', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a241f18110833383447adc6042da9a