### PR TITLE
feat: add bulk create mutations

### DIFF
--- a/server/src/graphql/resolvers/crudResolvers.ts
+++ b/server/src/graphql/resolvers/crudResolvers.ts
@@ -617,6 +617,113 @@ const crudResolvers = {
       }
     },
 
+    createEntities: async (
+      _: any,
+      { inputs }: { inputs: EntityInput[] },
+      { user }: Context,
+    ) => {
+      if (!user) throw new Error("Not authenticated");
+
+      const driver = getNeo4jDriver();
+      const session = driver.session();
+      const pgPool = getPostgresPool();
+
+      const tx = session.beginTransaction();
+      const pgClient = await pgPool.connect();
+      const opId = uuidv4();
+      const created: any[] = [];
+
+      try {
+        await pgClient.query('BEGIN');
+        for (const input of inputs) {
+          const id = uuidv4();
+          const now = new Date().toISOString();
+
+          if (input.customMetadata) {
+            await validateCustomMetadata(
+              input.investigationId!,
+              input.customMetadata,
+            );
+          }
+
+          const result = await tx.run(
+            `CREATE (e:Entity {
+               id: $id,
+               type: $type,
+               label: $label,
+               description: $description,
+               properties: $properties,
+               customMetadata: $customMetadata,
+               confidence: $confidence,
+               source: $source,
+               investigationId: $investigationId,
+               canonicalId: $canonicalId,
+               createdBy: $createdBy,
+               createdAt: datetime($now),
+               updatedAt: datetime($now)
+             })
+             RETURN e`,
+            {
+              id,
+              type: input.type,
+              label: input.label,
+              description: input.description || null,
+              properties: JSON.stringify(input.properties || {}),
+              customMetadata: JSON.stringify(input.customMetadata || {}),
+              confidence: input.confidence || 1.0,
+              source: input.source || "user_input",
+              investigationId: input.investigationId,
+              canonicalId: input.canonicalId || id,
+              createdBy: user.id,
+              now,
+            },
+          );
+
+          const entity = result.records[0].get("e").properties;
+          created.push(entity);
+
+          const payloadHash = crypto
+            .createHash("sha256")
+            .update(JSON.stringify(input))
+            .digest("hex");
+          const auditQuery =
+            'INSERT INTO "AuditLog" (user_id, timestamp, entity_type, payload_hash, operation_id) VALUES ($1,$2,$3,$4,$5)';
+          await pgClient.query(auditQuery, [
+            user.id,
+            now,
+            "Evidence",
+            payloadHash,
+            opId,
+          ]);
+        }
+
+        await tx.commit();
+        await pgClient.query('COMMIT');
+      } catch (err) {
+        await tx.rollback();
+        await pgClient.query('ROLLBACK');
+        throw err;
+      } finally {
+        pgClient.release();
+        await session.close();
+      }
+
+      for (const entity of created) {
+        pubsub.publish("ENTITY_CREATED", {
+          entityCreated: entity,
+          investigationId: entity.investigationId,
+        });
+        await nbhdCache.invalidate(
+          user.tenantId,
+          entity.investigationId,
+          [entity.id],
+        );
+        logger.info(`Entity created: ${entity.id} by user ${user.id}`);
+      }
+
+      return created;
+    },
+
     updateEntity: async (
       _: any,
       { id, input }: { id: string; input: EntityInput },
@@ -831,6 +938,124 @@ const crudResolvers = {
       } finally {
         await session.close();
       }
+    },
+
+    createRelationships: async (
+      _: any,
+      { inputs }: { inputs: RelationshipInput[] },
+      { user }: Context,
+    ) => {
+      if (!user) throw new Error("Not authenticated");
+
+      const driver = getNeo4jDriver();
+      const session = driver.session();
+      const pgPool = getPostgresPool();
+
+      const tx = session.beginTransaction();
+      const pgClient = await pgPool.connect();
+      const opId = uuidv4();
+      const created: any[] = [];
+
+      try {
+        await pgClient.query('BEGIN');
+        for (const input of inputs) {
+          const id = uuidv4();
+          const now = new Date().toISOString();
+
+          if (input.customMetadata) {
+            await validateCustomMetadata(
+              input.investigationId!,
+              input.customMetadata,
+            );
+          }
+
+          const result = await tx.run(
+            `MATCH (from:Entity {id: $fromEntityId})
+             MATCH (to:Entity {id: $toEntityId})
+             CREATE (from)-[r:RELATIONSHIP {
+               id: $id,
+               type: $type,
+               label: $label,
+               description: $description,
+               properties: $properties,
+               customMetadata: $customMetadata,
+               confidence: $confidence,
+               source: $source,
+               investigationId: $investigationId,
+               createdBy: $createdBy,
+               since: $since,
+               until: $until,
+               createdAt: datetime($now),
+               updatedAt: datetime($now)
+             }]->(to)
+             RETURN r, from, to`,
+            {
+              id,
+              type: input.type,
+              label: input.label || null,
+              description: input.description || null,
+              properties: JSON.stringify(input.properties || {}),
+              customMetadata: JSON.stringify(input.customMetadata || {}),
+              confidence: input.confidence || 1.0,
+              source: input.source || "user_input",
+              fromEntityId: input.fromEntityId,
+              toEntityId: input.toEntityId,
+              investigationId: input.investigationId,
+              createdBy: user.id,
+              since: input.since || null,
+              until: input.until || null,
+              now,
+            },
+          );
+
+          if (result.records.length === 0) {
+            throw new Error("One or both entities not found");
+          }
+
+          const record = result.records[0];
+          const relationship = {
+            ...record.get("r").properties,
+            fromEntity: record.get("from").properties,
+            toEntity: record.get("to").properties,
+          };
+          created.push(relationship);
+
+          const payloadHash = crypto
+            .createHash("sha256")
+            .update(JSON.stringify(input))
+            .digest("hex");
+          const auditQuery =
+            'INSERT INTO "AuditLog" (user_id, timestamp, entity_type, payload_hash, operation_id) VALUES ($1,$2,$3,$4,$5)';
+          await pgClient.query(auditQuery, [
+            user.id,
+            now,
+            "Relationship",
+            payloadHash,
+            opId,
+          ]);
+        }
+
+        await tx.commit();
+        await pgClient.query('COMMIT');
+      } catch (err) {
+        await tx.rollback();
+        await pgClient.query('ROLLBACK');
+        throw err;
+      } finally {
+        pgClient.release();
+        await session.close();
+      }
+
+      for (const rel of created) {
+        pubsub.publish("RELATIONSHIP_CREATED", {
+          relationshipCreated: rel,
+          investigationId: rel.investigationId,
+        });
+        await nbhdCache.invalidate(user.tenantId, rel.investigationId, [rel.fromEntity.id, rel.toEntity.id]);
+        logger.info(`Relationship created: ${rel.id} by user ${user.id}`);
+      }
+
+      return created;
     },
 
     updateRelationship: async (

--- a/server/src/graphql/schema/crudSchema.ts
+++ b/server/src/graphql/schema/crudSchema.ts
@@ -363,6 +363,7 @@ export const crudTypeDefs = gql`
   type Mutation {
     # Entity mutations
     createEntity(input: EntityInput!): Entity!
+    createEntities(inputs: [EntityInput!]!): [Entity!]!
     updateEntity(
       id: ID!
       input: EntityUpdateInput!
@@ -372,6 +373,7 @@ export const crudTypeDefs = gql`
 
     # Relationship mutations
     createRelationship(input: RelationshipInput!): Relationship!
+    createRelationships(inputs: [RelationshipInput!]!): [Relationship!]!
     updateRelationship(
       id: ID!
       input: RelationshipUpdateInput!

--- a/server/tests/bulk-create.test.ts
+++ b/server/tests/bulk-create.test.ts
@@ -1,0 +1,34 @@
+const { crudResolvers: resolvers } = require('../src/graphql/resolvers/crudResolvers');
+
+jest.mock('../src/config/database', () => {
+  const tx = {
+    run: jest.fn().mockResolvedValue({ records: [{ get: () => ({ properties: { id: 'id1', investigationId: 'inv1', fromEntity: { id: 'a' }, toEntity: { id: 'b' } } }) }] }),
+    commit: jest.fn(),
+    rollback: jest.fn(),
+  };
+  const session = { beginTransaction: () => tx, close: jest.fn() };
+  const pgClient = { query: jest.fn().mockResolvedValue({}), release: jest.fn() };
+  return {
+    getNeo4jDriver: () => ({ session: () => session }),
+    getPostgresPool: () => ({ connect: () => pgClient }),
+    getRedisClient: () => ({ smembers: jest.fn().mockResolvedValue([]), del: jest.fn(), get: jest.fn(), set: jest.fn(), sadd: jest.fn() }),
+  };
+});
+
+describe('Bulk mutations', () => {
+  const user = { id: 'u1', tenantId: 't1' };
+
+  test('createEntities returns array', async () => {
+    const inputs = [{ type: 'PERSON', label: 'E1', investigationId: 'inv1' }];
+    const res = await resolvers.Mutation.createEntities(null, { inputs }, { user });
+    expect(Array.isArray(res)).toBe(true);
+    expect(res).toHaveLength(1);
+  });
+
+  test('createRelationships returns array', async () => {
+    const inputs = [{ type: 'CONNECTED_TO', fromEntityId: 'a', toEntityId: 'b', investigationId: 'inv1' }];
+    const res = await resolvers.Mutation.createRelationships(null, { inputs }, { user });
+    expect(Array.isArray(res)).toBe(true);
+    expect(res).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add transactional bulk create mutations for entities and relationships with audit logging
- expose bulk mutations in GraphQL schema
- cover bulk mutation paths with basic tests

## Testing
- `cd server && npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a241e1dff08333a91205d757ca5be9