### PR TITLE
feat: track provenance metadata on mutations

### DIFF
--- a/server/src/graphql/schema/crudSchema.ts
+++ b/server/src/graphql/schema/crudSchema.ts
@@ -206,12 +206,19 @@ export const crudTypeDefs = gql`
   }
 
   # Input types
+  input ProvenanceInput {
+    originService: String!
+    ingestedAt: DateTime!
+    transformationLog: [String!]!
+  }
+
   input EntityInput {
     type: EntityType!
     label: String!
     description: String
     properties: JSON
     customMetadata: JSON
+    provenance: ProvenanceInput
     confidence: Float
     source: String
     investigationId: ID!
@@ -223,6 +230,7 @@ export const crudTypeDefs = gql`
     description: String
     properties: JSON
     customMetadata: JSON
+    provenance: ProvenanceInput
     confidence: Float
     source: String
     canonicalId: ID
@@ -234,6 +242,7 @@ export const crudTypeDefs = gql`
     description: String
     properties: JSON
     customMetadata: JSON
+    provenance: ProvenanceInput
     confidence: Float
     source: String
     fromEntityId: ID!
@@ -248,6 +257,7 @@ export const crudTypeDefs = gql`
     description: String
     properties: JSON
     customMetadata: JSON
+    provenance: ProvenanceInput
     confidence: Float
     source: String
     since: DateTime


### PR DESCRIPTION
## Summary
- support provenance metadata on entity and relationship mutations
- add GraphQL ProvenanceInput and attach to customMetadata

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run format` (fails: YAML parsing errors)
- `npm test` (fails: SyntaxError: Invalid or unexpected token)


------
https://chatgpt.com/codex/tasks/task_e_68a241d6e54883339425793d87278d63