### PR TITLE
feat: prewarm neighborhood cache

### DIFF
--- a/server/src/services/neighborhood-cache.ts
+++ b/server/src/services/neighborhood-cache.ts
@@ -1,5 +1,10 @@
-import Redis from 'ioredis';
-import { neighborhoodCacheHitRatio, neighborhoodCacheLatencyMs } from '../monitoring/metrics.js';
+import Redis from "ioredis";
+import {
+  neighborhoodCacheHitRatio,
+  neighborhoodCacheLatencyMs,
+} from "../monitoring/metrics.js";
+import { getNeo4jDriver } from "../config/database.js";
+import { expandNeighborhood } from "./GraphOpsService.js";
 
 export interface Graph {
   nodes: Array<{ id: string }>;
@@ -10,15 +15,73 @@ export class NeighborhoodCache {
   private hits = 0;
   private total = 0;
   private ttl: number;
-  constructor(private redis: Redis, ttl = 300) {
+  constructor(
+    private redis: Redis,
+    ttl = 300,
+  ) {
     this.ttl = ttl;
+    this.startBackgroundSync();
   }
 
-  private key(tenantId: string, investigationId: string, entityId: string, radius: number): string {
+  private startBackgroundSync(): void {
+    import("node-cron")
+      .then((cron) => {
+        cron.schedule("0 * * * *", async () => {
+          const driver = getNeo4jDriver();
+          const session = driver.session();
+          try {
+            const ctxRes = await session.run(
+              "MATCH (n:Entity) RETURN DISTINCT n.tenantId AS tenantId, n.investigationId AS investigationId",
+            );
+            for (const record of ctxRes.records) {
+              const tenantId = record.get("tenantId");
+              const investigationId = record.get("investigationId");
+              if (!tenantId || !investigationId) continue;
+              const topRes = await session.run(
+                `MATCH (e:Entity {tenantId: $tenantId, investigationId: $investigationId})-[r]-(m:Entity {tenantId: $tenantId, investigationId: $investigationId})
+                 RETURN e.id AS id, count(r) AS score
+                 ORDER BY score DESC
+                 LIMIT 10`,
+                { tenantId, investigationId },
+              );
+              for (const rec of topRes.records) {
+                const entityId = rec.get("id");
+                const graph = await expandNeighborhood(entityId, 2, {
+                  tenantId,
+                  investigationId,
+                });
+                await this.set(tenantId, investigationId, entityId, 2, graph);
+              }
+            }
+          } catch (err) {
+            console.error("Neighborhood cache prewarm failed", err);
+          } finally {
+            await session.close();
+          }
+        });
+      })
+      .catch((err) => {
+        console.error(
+          "node-cron not available, skipping neighborhood prewarm",
+          err,
+        );
+      });
+  }
+
+  private key(
+    tenantId: string,
+    investigationId: string,
+    entityId: string,
+    radius: number,
+  ): string {
     return `nbhd:${tenantId}:${investigationId}:${entityId}:${radius}`;
   }
 
-  private tagKey(tenantId: string, investigationId: string, entityId: string): string {
+  private tagKey(
+    tenantId: string,
+    investigationId: string,
+    entityId: string,
+  ): string {
     return `nbhd:tag:${tenantId}:${investigationId}:${entityId}`;
   }
 
@@ -26,7 +89,7 @@ export class NeighborhoodCache {
     tenantId: string,
     investigationId: string,
     entityId: string,
-    radius: number
+    radius: number,
   ): Promise<Graph | null> {
     const key = this.key(tenantId, investigationId, entityId, radius);
     const start = Date.now();
@@ -47,11 +110,11 @@ export class NeighborhoodCache {
     investigationId: string,
     entityId: string,
     radius: number,
-    data: Graph
+    data: Graph,
   ): Promise<void> {
     const key = this.key(tenantId, investigationId, entityId, radius);
-    await this.redis.set(key, JSON.stringify(data), 'EX', this.ttl);
-    const ids = new Set<string>([entityId, ...data.nodes.map(n => n.id)]);
+    await this.redis.set(key, JSON.stringify(data), "EX", this.ttl);
+    const ids = new Set<string>([entityId, ...data.nodes.map((n) => n.id)]);
     for (const id of ids) {
       await this.redis.sadd(this.tagKey(tenantId, investigationId, id), key);
     }
@@ -60,7 +123,7 @@ export class NeighborhoodCache {
   async invalidate(
     tenantId: string,
     investigationId: string,
-    entityIds: string[]
+    entityIds: string[],
   ): Promise<void> {
     for (const id of entityIds) {
       const tKey = this.tagKey(tenantId, investigationId, id);


### PR DESCRIPTION
## Summary
- schedule hourly cron job to preload top central entities into neighborhood cache
- fetch top entities by degree centrality per investigation and cache their neighborhoods
- gracefully skip if node-cron is unavailable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in .github/workflows/cd-deploy.yml)*
- `npm test` *(fails: SyntaxError: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a241cc07dc83339de4b6e66f9cffd5