### PR TITLE
feat(server): add filtering to graphData query

### DIFF
--- a/server/src/graphql/schema/crudSchema.ts
+++ b/server/src/graphql/schema/crudSchema.ts
@@ -303,6 +303,13 @@ export const crudTypeDefs = gql`
     createdBy: ID
   }
 
+  input GraphDataFilter {
+    minConfidence: Float
+    tags: [String!]
+    startDate: DateTime
+    endDate: DateTime
+  }
+
   # Core Queries
   type Query {
     # Entity queries
@@ -336,7 +343,7 @@ export const crudTypeDefs = gql`
     ): InvestigationConnection!
 
     # Graph data for investigation
-    graphData(investigationId: ID!): GraphData!
+    graphData(investigationId: ID!, filter: GraphDataFilter): GraphData!
 
     # Related entities query
     relatedEntities(entityId: ID!): [RelatedEntity!]!

--- a/server/tests/graphData.filter.test.ts
+++ b/server/tests/graphData.filter.test.ts
@@ -1,0 +1,85 @@
+import { crudResolvers } from "../src/graphql/resolvers/crudResolvers";
+
+let session: any;
+
+jest.mock("../src/config/database.js", () => ({
+  getNeo4jDriver: () => ({ session: () => session }),
+  getPostgresPool: () => ({ query: jest.fn() }),
+  getRedisClient: () => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    sadd: jest.fn(),
+    smembers: jest.fn(),
+    del: jest.fn(),
+  }),
+}));
+
+describe("graphData filtering", () => {
+  beforeEach(() => {
+    session = { run: jest.fn(), close: jest.fn() };
+  });
+
+  test("applies confidence, tag, and time filters", async () => {
+    const nodeRecords = [
+      {
+        get: () => ({
+          properties: {
+            id: "1",
+            confidence: 0.9,
+            createdAt: "2024-01-01T00:00:00.000Z",
+            customMetadata: JSON.stringify({ tags: ["keep"] }),
+          },
+        }),
+      },
+      {
+        get: () => ({
+          properties: {
+            id: "2",
+            confidence: 0.5,
+            createdAt: "2024-01-01T00:00:00.000Z",
+            customMetadata: JSON.stringify({ tags: ["drop"] }),
+          },
+        }),
+      },
+    ];
+
+    const edgeRecord = {
+      get: (key: string) => {
+        if (key === "r")
+          return {
+            properties: {
+              id: "e1",
+              confidence: 0.95,
+              createdAt: "2024-01-01T00:00:00.000Z",
+              customMetadata: JSON.stringify({ tags: ["keep"] }),
+            },
+          };
+        if (key === "from")
+          return { properties: nodeRecords[0].get().properties };
+        return { properties: nodeRecords[1].get().properties };
+      },
+    };
+
+    session.run
+      .mockResolvedValueOnce({ records: nodeRecords })
+      .mockResolvedValueOnce({ records: [edgeRecord] });
+
+    const result = await crudResolvers.Query.graphData(
+      null,
+      {
+        investigationId: "inv1",
+        filter: {
+          minConfidence: 0.8,
+          tags: ["keep"],
+          startDate: "2023-12-01T00:00:00.000Z",
+          endDate: "2024-12-31T00:00:00.000Z",
+        },
+      },
+      { user: { id: "u1" } },
+    );
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].id).toBe("1");
+    expect(result.edges).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `graphData` schema with optional filter input
- support confidence, tag, and time filtering in `graphData` resolver
- add unit test covering subgraph filter logic

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npx prettier --write server/src/graphql/resolvers/crudResolvers.ts server/src/graphql/schema/crudSchema.ts server/tests/graphData.filter.test.ts`
- `npm test` (fails: SyntaxError: Invalid or unexpected token)

------
https://chatgpt.com/codex/tasks/task_e_68a241bed2c883339035b9ca7d75e8a9