### PR TITLE
feat: add kafka anomaly streaming

### DIFF
--- a/intelgraph_kafka_consumer.py
+++ b/intelgraph_kafka_consumer.py
@@ -5,6 +5,7 @@ from confluent_kafka.serialization import MessageField
 import json
 import logging
 from jsonschema import validate, ValidationError
+import requests
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -75,6 +76,19 @@ class IntelGraphKafkaConsumer:
             logger.error(f"Error initializing Kafka consumer: {e}")
             raise
 
+    def _forward_to_ml_service(self, payload: dict) -> None:
+        """Send a deserialized message to the ML service for inference."""
+        ml_url = self.config.get('ml_service_url')
+        if not ml_url:
+            logger.debug("ML service URL not provided; skipping forward.")
+            return
+        try:
+            resp = requests.post(f"{ml_url}/stream/anomaly", json=payload, timeout=5)
+            resp.raise_for_status()
+            logger.debug("Message forwarded to ML service successfully.")
+        except Exception as e:
+            logger.error(f"Failed to forward message to ML service: {e}")
+
     def _json_deserializer(self, obj, ctx):
         """
         Helper function for AvroDeserializer to convert Avro record to Python dict.
@@ -88,15 +102,15 @@ class IntelGraphKafkaConsumer:
     def consume_messages(self, timeout_ms: int = 1000):
         """
         Continuously consumes messages from the Kafka topic.
-        Yields deserialized Avro messages.
+        Yields deserialized Avro messages and forwards them to the ML service
+        for real-time anomaly detection.
         """
         logger.info(f"Starting message consumption from topic {self.config['topic']}...")
         while True:
             try:
-                msg = self.consumer.poll(timeout_ms / 1000.0) # Convert ms to seconds
+                msg = self.consumer.poll(timeout_ms / 1000.0)
 
                 if msg is None:
-                    # logger.debug("No message received within timeout.")
                     continue
                 if msg.error():
                     if msg.error().is_fatal():
@@ -106,28 +120,34 @@ class IntelGraphKafkaConsumer:
                         logger.warning(f"Consumer error: {msg.error()}")
                         continue
 
-                # Deserialize the message value
                 deserialized_value = self.avro_deserializer(msg.value(), MessageField.VALUE)
 
                 if deserialized_value is not None:
-                    logger.info(f"Received message: offset={msg.offset()}, partition={msg.partition()}")
+                    logger.info(
+                        f"Received message: offset={msg.offset()}, partition={msg.partition()}"
+                    )
                     try:
                         validate(instance=deserialized_value, schema=SOCIAL_INGEST_JSON_SCHEMA)
                         logger.debug("Message validated successfully against JSON schema.")
+                        self._forward_to_ml_service(deserialized_value)
                         yield deserialized_value
                     except ValidationError as e:
-                        logger.error(f"JSON Schema validation failed for message at offset {msg.offset()}: {e.message}")
+                        logger.error(
+                            f"JSON Schema validation failed for message at offset {msg.offset()}: {e.message}"
+                        )
                         logger.debug(f"Invalid message content: {deserialized_value}")
-                        # Optionally, send to a dead-letter queue here
                 else:
-                    logger.warning(f"Could not deserialize message value at offset {msg.offset()}")
+                    logger.warning(
+                        f"Could not deserialize message value at offset {msg.offset()}"
+                    )
 
             except KeyboardInterrupt:
                 logger.info("Consumption interrupted by user.")
                 break
             except Exception as e:
-                logger.error(f"An unexpected error occurred during consumption: {e}", exc_info=True)
-                # Depending on error, might want to break or continue
+                logger.error(
+                    f"An unexpected error occurred during consumption: {e}", exc_info=True
+                )
 
     def close(self):
         """
@@ -147,7 +167,8 @@ if __name__ == "__main__":
         'group_id': 'psyops_counter_engine',
         'sasl_username': 'your_sasl_username',
         'sasl_password': 'your_sasl_password',
-        'ssl_ca_location': None # Optional: '/path/to/your/ca.pem' if using custom CA
+        'ssl_ca_location': None, # Optional: '/path/to/your/ca.pem' if using custom CA
+        'ml_service_url': 'http://localhost:8000'
     }
 
     consumer = None

--- a/ml/app/main.py
+++ b/ml/app/main.py
@@ -1,4 +1,4 @@
-import os, json, time
+import os, json, time, logging
 from fastapi import FastAPI, Depends, HTTPException, Header, Request, Response
 from fastapi.responses import PlainTextResponse
 from jose import jwt
@@ -49,8 +49,10 @@ from .monitoring import (
     health_checker,
 )
 
+logger = logging.getLogger(__name__)
 JWT_PUBLIC_KEY = os.getenv("JWT_PUBLIC_KEY", "")
 JWT_ALGO = "RS256"
+GRAPHQL_URL = os.getenv("GRAPHQL_URL", "http://localhost:4000/graphql")
 
 
 def verify_token(authorization: str = Header(...)):
@@ -82,6 +84,24 @@ def verify_token(authorization: str = Header(...)):
 link_predictor = LinkPredictor()
 
 api = FastAPI(title="IntelGraph ML Service", version="0.2.0")
+
+
+async def _annotate_anomaly(entity_id: str, anomaly_score: float, reason: str) -> None:
+    """Call the GraphQL API to record an anomaly annotation."""
+    mutation = (
+        "mutation RecordAnomaly($entityId: ID!, $anomalyScore: Float!, $reason: String) {"
+        " recordAnomaly(entityId: $entityId, anomalyScore: $anomalyScore, reason: $reason) { entityId } }"
+    )
+    variables = {
+        "entityId": entity_id,
+        "anomalyScore": anomaly_score,
+        "reason": reason,
+    }
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(GRAPHQL_URL, json={"query": mutation, "variables": variables})
+    except Exception as e:
+        logger.error("Failed to record anomaly via GraphQL: %s", e)
 
 
 # Middleware for tracking HTTP requests
@@ -174,6 +194,20 @@ async def health_info():
     }
 
     return info
+
+
+@api.post("/stream/anomaly")
+async def stream_anomaly(event: dict):
+    """Process a streamed event and annotate anomalies via GraphQL."""
+    score = float(event.get("signal_score", 0))
+    is_anomaly = score > 0.8
+    if is_anomaly and event.get("author_id"):
+        await _annotate_anomaly(event["author_id"], score, "High signal score")
+    return {
+        "entityId": event.get("author_id"),
+        "anomalyScore": score,
+        "isAnomaly": is_anomaly,
+    }
 
 
 async def _maybe_webhook(callback_url: str, result: dict):

--- a/server/src/graphql/schema.ai.js
+++ b/server/src/graphql/schema.ai.js
@@ -15,6 +15,10 @@ const aiTypeDefs = gql`
   extend type Subscription {
     aiSuggestions(entityId: ID!): [AIRecommendation!]!
   }
+
+  extend type Mutation {
+    recordAnomaly(entityId: ID!, anomalyScore: Float!, reason: String): AIAnomaly!
+  }
 `;
 
 module.exports = { aiTypeDefs };


### PR DESCRIPTION
## Summary
- forward Kafka social ingest messages to ML service
- add ML endpoint to annotate streamed anomalies via GraphQL
- expose GraphQL mutation to record anomaly annotations

## Testing
- `npm run lint` *(fails: 3063 errors, 862 warnings)*
- `npm run format` *(fails: syntax errors in YAML workflows)*
- `npm test` *(fails: Invalid or unexpected token)*
- `cd ml && pytest` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68a24143838c83338bdc3703bad5eab9