### PR TITLE
feat: add predictive threat intelligence scaffolding

### DIFF
--- a/cognitive_insights_engine/counterfactual_sim/graph_ops.py
+++ b/cognitive_insights_engine/counterfactual_sim/graph_ops.py
@@ -1,0 +1,14 @@
+"""Graph operations used by the counterfactual simulator."""
+from typing import Any, Dict
+
+
+def snapshot_neo4j() -> Dict[str, str]:
+    return {"snapshot": "neo4j"}
+
+
+def remove_edge(snapshot: Dict[str, str], node_id: str, edge_type: str) -> Dict[str, str]:
+    return {"snapshot": snapshot, "removed": (node_id, edge_type)}
+
+
+def run_inference(graph: Dict[str, str]) -> Dict[str, str]:
+    return {"result": graph}

--- a/cognitive_insights_engine/counterfactual_sim/simulator.py
+++ b/cognitive_insights_engine/counterfactual_sim/simulator.py
@@ -1,0 +1,11 @@
+"""Counterfactual simulation utilities."""
+from typing import Any
+
+from graph_ops import snapshot_neo4j, remove_edge, run_inference
+
+
+def simulate_counterfactual(node_id: str, remove_edge_type: str) -> Any:
+    """Return inference results after removing an edge type from a node."""
+    snapshot = snapshot_neo4j()
+    modified = remove_edge(snapshot, node_id, remove_edge_type)
+    return run_inference(modified)

--- a/cognitive_insights_engine/counterfactual_sim/tests/test_simulation.py
+++ b/cognitive_insights_engine/counterfactual_sim/tests/test_simulation.py
@@ -1,0 +1,6 @@
+from simulator import simulate_counterfactual
+
+
+def test_simulate_counterfactual_returns_result():
+    result = simulate_counterfactual("A", "uses")
+    assert "result" in result

--- a/docs/predictive-threat-suite/README.md
+++ b/docs/predictive-threat-suite/README.md
@@ -1,0 +1,35 @@
+# Predictive Threat Intelligence Suite
+
+This module provides three complementary capabilities for forecasting and
+analysing threat activity on the IntelGraph platform.
+
+## Components
+
+1. **Predictive Timeline Generator** (`graph-service/timeline_prediction`)
+   - FastAPI service that forecasts future graph activity.
+   - Demo model returns stub data for the next *N* days.
+2. **Causal GNN Explainer** (`ml/causal_explanations`)
+   - Wraps a graph neural network explainer to highlight influential nodes and
+     edges. The current implementation is a placeholder awaiting a trained
+     model.
+3. **Counterfactual Simulator** (`cognitive_insights_engine/counterfactual_sim`)
+   - Allows "what-if" analysis by removing edges and re-running inference.
+
+## Running tests
+
+```bash
+pytest graph-service/timeline_prediction/tests/test_timeline.py
+pytest ml/causal_explanations/tests/test_explanations.py
+pytest cognitive_insights_engine/counterfactual_sim/tests/test_simulation.py
+```
+
+## Helm deployment
+
+A lightweight Helm chart is provided in `helm/predictive-suite` to deploy the
+three services. Example usage:
+
+```bash
+helm install predictive-suite helm/predictive-suite --namespace intelgraph
+```
+
+Provide custom images or configuration via `--set` flags or a values file.

--- a/graph-service/timeline_prediction/main.py
+++ b/graph-service/timeline_prediction/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI, Query
+from timeline_model import predict_timeline
+import uvicorn
+
+app = FastAPI()
+
+
+@app.get("/predict")
+async def predict(days: int = Query(7, description="Forecast horizon")):
+    result = await predict_timeline(days)
+    return result
+
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", port=8081, reload=True)

--- a/graph-service/timeline_prediction/tests/test_timeline.py
+++ b/graph-service/timeline_prediction/tests/test_timeline.py
@@ -1,0 +1,8 @@
+import asyncio
+from timeline_model import predict_timeline
+
+
+def test_predict_timeline_returns_message():
+    result = asyncio.run(predict_timeline(3))
+    assert "prediction" in result
+    assert "3" in result["prediction"]

--- a/graph-service/timeline_prediction/timeline_model.py
+++ b/graph-service/timeline_prediction/timeline_model.py
@@ -1,0 +1,11 @@
+from typing import Dict
+
+
+async def predict_timeline(days: int) -> Dict[str, str]:
+    """Stub timeline predictor.
+
+    In a full implementation this function would access Neo4j for historical
+    events and use an ML model to forecast future activity. For now it returns
+    a placeholder response so the API and tests have deterministic behaviour.
+    """
+    return {"prediction": f"Timeline forecast for {days} days"}

--- a/graph-service/timeline_prediction/visualizer.py
+++ b/graph-service/timeline_prediction/visualizer.py
@@ -1,0 +1,11 @@
+"""Streamlit visualisation for timeline predictions.
+
+This is a lightweight placeholder so future work can add interactive charts
+based on the prediction API.
+"""
+
+from typing import Dict
+
+
+def render_timeline(prediction: Dict[str, str]) -> None:
+    print(prediction["prediction"])

--- a/helm/predictive-suite/Chart.yaml
+++ b/helm/predictive-suite/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: predictive-suite
+version: 0.1.0
+description: Deploys predictive timeline, causal explanation and counterfactual simulation services.
+type: application

--- a/helm/predictive-suite/templates/deployments.yaml
+++ b/helm/predictive-suite/templates/deployments.yaml
@@ -1,0 +1,34 @@
+{{- $services := .Values.services -}}
+{{- range $name, $cfg := $services }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ $name }}
+  template:
+    metadata:
+      labels:
+        app: {{ $name }}
+    spec:
+      containers:
+        - name: {{ $name }}
+          image: {{ $cfg.image }}
+          ports:
+            - containerPort: {{ $cfg.port }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+spec:
+  selector:
+    app: {{ $name }}
+  ports:
+    - port: {{ $cfg.port }}
+      targetPort: {{ $cfg.port }}
+{{- end }}

--- a/helm/predictive-suite/values.yaml
+++ b/helm/predictive-suite/values.yaml
@@ -1,0 +1,10 @@
+services:
+  timeline:
+    image: timeline-prediction:latest
+    port: 8081
+  explainer:
+    image: causal-explanations:latest
+    port: 8082
+  simulator:
+    image: counterfactual-sim:latest
+    port: 8083

--- a/ml/causal_explanations/explain.py
+++ b/ml/causal_explanations/explain.py
@@ -1,0 +1,17 @@
+"""GNN explainer stubs using PyTorch Geometric style interfaces."""
+from typing import Any
+
+from gnn_model import load_model
+from graph_data_loader import load_graph_data
+
+
+def explain_prediction() -> Any:
+    """Return a placeholder explanation structure.
+
+    Real logic would utilise GNNExplainer or PGExplainer from PyTorch Geometric
+    together with SHAP to highlight influential nodes and edges.
+    """
+    model = load_model()
+    data = load_graph_data()
+    # Normally an explainer would be fit here; for scaffolding we echo inputs.
+    return {"model": model, "data": data}

--- a/ml/causal_explanations/gnn_model.py
+++ b/ml/causal_explanations/gnn_model.py
@@ -1,0 +1,7 @@
+"""Placeholder for loading a trained GNN model."""
+from typing import Any
+
+
+def load_model() -> Any:
+    """Return a stub model reference."""
+    return "stub-model"

--- a/ml/causal_explanations/graph_data_loader.py
+++ b/ml/causal_explanations/graph_data_loader.py
@@ -1,0 +1,8 @@
+"""Load graph data for explanation routines."""
+from types import SimpleNamespace
+from typing import Any
+
+
+def load_graph_data() -> Any:
+    """Return a minimal structure mimicking a PyG data object."""
+    return SimpleNamespace(x=None, edge_index=None)

--- a/ml/causal_explanations/tests/test_explanations.py
+++ b/ml/causal_explanations/tests/test_explanations.py
@@ -1,0 +1,7 @@
+from explain import explain_prediction
+
+
+def test_explain_prediction_returns_structure():
+    result = explain_prediction()
+    assert "model" in result
+    assert "data" in result


### PR DESCRIPTION
## Summary
- scaffold timeline prediction FastAPI service
- add GNN explainer and counterfactual simulator modules
- provide helm chart and docs for predictive threat suite

## Testing
- `PYTHONPATH=graph-service/timeline_prediction pytest graph-service/timeline_prediction/tests/test_timeline.py`
- `PYTHONPATH=ml/causal_explanations pytest ml/causal_explanations/tests/test_explanations.py`
- `PYTHONPATH=cognitive_insights_engine/counterfactual_sim pytest cognitive_insights_engine/counterfactual_sim/tests/test_simulation.py`
- `npm test` *(fails: Invalid or unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a24f9b8ce88333b3e0815b3deeb424