### PR TITLE
feat: add graph sentiment microservice

### DIFF
--- a/cognitive_insights_engine/sentiment_service/main.py
+++ b/cognitive_insights_engine/sentiment_service/main.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .router import router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="Graph Sentiment Service", version="0.1.0")
+    app.include_router(router)
+    return app
+
+
+app = create_app()

--- a/cognitive_insights_engine/sentiment_service/model.py
+++ b/cognitive_insights_engine/sentiment_service/model.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from transformers import pipeline
+
+
+class LLMGraphSentimentModel:
+    """Wrapper around a HuggingFace sentiment pipeline.
+
+    The model exposes a simple ``analyze`` coroutine that returns a sentiment
+    label, confidence score and an influence map for neighbouring entities. The
+    influence map is a naive distribution that shares the model's confidence
+    equally across neighbours; this is sufficient for unit testing and can be
+    replaced with a learned GNN in the future.
+    """
+
+    def __init__(self, model_name: str = "distilbert-base-uncased-finetuned-sst-2-english") -> None:
+        # The pipeline loads lazily and caches the model on first use which keeps
+        # tests reasonably fast while still exercising the transformers API.
+        self._pipe = pipeline("sentiment-analysis", model=model_name)
+
+    async def analyze(self, text: str, neighbours: List[str] | None = None) -> Dict[str, object]:
+        result = self._pipe(text)[0]
+        label = result["label"].lower()
+        score = float(result["score"])
+
+        # Distribute confidence equally across neighbours if provided.
+        influence: Dict[str, float] = {}
+        if neighbours:
+            weight = score / len(neighbours)
+            influence = {n: weight for n in neighbours}
+
+        return {"sentiment": label, "score": score, "influence_map": influence}

--- a/cognitive_insights_engine/sentiment_service/openapi_spec.yaml
+++ b/cognitive_insights_engine/sentiment_service/openapi_spec.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.2
+info:
+  title: Graph Sentiment Service
+  version: "0.1.0"
+paths:
+  /sentiment/analyze:
+    post:
+      summary: Analyze sentiment for an entity in graph context
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SentimentRequest"
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SentimentResponse"
+components:
+  schemas:
+    SentimentRequest:
+      type: object
+      required: [entity_id, text]
+      properties:
+        entity_id:
+          type: string
+        text:
+          type: string
+    SentimentResponse:
+      type: object
+      required: [sentiment, score, influence_map]
+      properties:
+        sentiment:
+          type: string
+        score:
+          type: number
+          format: float
+        influence_map:
+          type: object
+          additionalProperties:
+            type: number

--- a/cognitive_insights_engine/sentiment_service/router.py
+++ b/cognitive_insights_engine/sentiment_service/router.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from .model import LLMGraphSentimentModel
+from .utils import fetch_neighbour_entities
+
+
+class SentimentRequest(BaseModel):
+    entity_id: str
+    text: str
+
+
+class SentimentResponse(BaseModel):
+    sentiment: str
+    score: float
+    influence_map: dict[str, float]
+
+
+router = APIRouter(prefix="/sentiment", tags=["sentiment"])
+
+
+async def get_model() -> LLMGraphSentimentModel:
+    return LLMGraphSentimentModel()
+
+
+@router.post("/analyze", response_model=SentimentResponse)
+async def analyze(
+    request: SentimentRequest, model: LLMGraphSentimentModel = Depends(get_model)
+) -> SentimentResponse:
+    neighbours = await fetch_neighbour_entities(None, request.entity_id)
+    result = await model.analyze(request.text, neighbours)
+    return SentimentResponse(**result)

--- a/cognitive_insights_engine/sentiment_service/sample_prompt.txt
+++ b/cognitive_insights_engine/sentiment_service/sample_prompt.txt
@@ -1,0 +1,1 @@
+Entity: {entity}\nContext: {context}\nText: {text}

--- a/cognitive_insights_engine/sentiment_service/tests/test_sentiment.py
+++ b/cognitive_insights_engine/sentiment_service/tests/test_sentiment.py
@@ -1,0 +1,28 @@
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from cognitive_insights_engine.sentiment_service.main import app
+from cognitive_insights_engine.sentiment_service import router, model
+
+
+@pytest.mark.asyncio
+async def test_analyze_endpoint(monkeypatch):
+    async def fake_fetch(driver, entity_id):
+        return ["n1", "n2"]
+
+    async def fake_analyze(self, text, neighbours):
+        return {
+            "sentiment": "positive",
+            "score": 0.9,
+            "influence_map": {n: 0.45 for n in neighbours},
+        }
+
+    monkeypatch.setattr(router, "fetch_neighbour_entities", fake_fetch)
+    monkeypatch.setattr(model.LLMGraphSentimentModel, "analyze", fake_analyze)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        resp = await ac.post("/sentiment/analyze", json={"entity_id": "e1", "text": "hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sentiment"] == "positive"
+    assert data["influence_map"] == {"n1": 0.45, "n2": 0.45}

--- a/cognitive_insights_engine/sentiment_service/utils.py
+++ b/cognitive_insights_engine/sentiment_service/utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+try:
+    from neo4j import AsyncDriver
+except Exception:  # pragma: no cover - neo4j may not be installed
+    AsyncDriver = None  # type: ignore
+
+
+async def fetch_neighbour_entities(driver: Optional[AsyncDriver], entity_id: str) -> List[str]:
+    """Return ids of entities connected to ``entity_id``.
+
+    When ``driver`` is ``None`` an empty list is returned which keeps the
+    function usable in tests without a running Neo4j instance.
+    """
+
+    if driver is None:
+        return []
+
+    query = "MATCH (e)-[:RELATED_TO]-(n) WHERE e.id = $id RETURN n.id AS id"
+    async with driver.session() as session:  # pragma: no cover - network I/O
+        result = await session.run(query, id=entity_id)
+        return [record["id"] for record in await result.data()]


### PR DESCRIPTION
## Summary
- add FastAPI service for graph-aware sentiment analysis
- document endpoint in OpenAPI spec and provide unit test

## Testing
- `PYTHONPATH=. pytest cognitive_insights_engine/sentiment_service/tests/test_sentiment.py -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e6637b88333ad7cfe0045bea697