### PR TITLE
feat: finalize nlp tasks and ui visuals

### DIFF
--- a/client/src/components/SentimentVolatility.tsx
+++ b/client/src/components/SentimentVolatility.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import { useMutation, gql } from '@apollo/client';
+import React, { useState, useEffect, useRef } from "react";
+import { useMutation, gql } from "@apollo/client";
+import * as d3 from "d3";
 
 const ANALYZE_SENTIMENT_VOLATILITY_MUTATION = gql`
   mutation AnalyzeSentimentVolatility($signalsInput: JSON!) {
@@ -11,18 +12,69 @@ const ANALYZE_SENTIMENT_VOLATILITY_MUTATION = gql`
 `;
 
 const SentimentVolatility: React.FC = () => {
-  const [signalsData, setSignalsData] = useState('');
-  const [analyzeSentimentVolatility, { data, loading, error }] = useMutation(ANALYZE_SENTIMENT_VOLATILITY_MUTATION);
+  const [signalsData, setSignalsData] = useState("");
+  const [analyzeSentimentVolatility, { data, loading, error }] = useMutation(
+    ANALYZE_SENTIMENT_VOLATILITY_MUTATION,
+  );
+  const chartRef = useRef<HTMLDivElement | null>(null);
 
   const handleSubmit = async () => {
     try {
       const parsedSignalsData = JSON.parse(signalsData);
-      await analyzeSentimentVolatility({ variables: { signalsInput: parsedSignalsData } });
+      await analyzeSentimentVolatility({
+        variables: { signalsInput: parsedSignalsData },
+      });
     } catch (e) {
-      alert('Invalid JSON input for signals data.');
+      alert("Invalid JSON input for signals data.");
       console.error(e);
     }
   };
+
+  useEffect(() => {
+    if (data && chartRef.current) {
+      const dashboard = data.analyzeSentimentVolatility?.dashboard_json || {};
+      const points = Object.entries(dashboard).map(([k, v]) => ({
+        label: k,
+        value: Number(v),
+      }));
+
+      const width = 300;
+      const height = 200;
+      d3.select(chartRef.current).selectAll("*").remove();
+      const svg = d3
+        .select(chartRef.current)
+        .append("svg")
+        .attr("width", width)
+        .attr("height", height);
+
+      const x = d3
+        .scaleBand()
+        .domain(points.map((p) => p.label))
+        .range([0, width])
+        .padding(0.2);
+      const y = d3
+        .scaleLinear()
+        .domain([0, d3.max(points, (p) => p.value) || 1])
+        .range([height, 0]);
+
+      svg
+        .append("g")
+        .attr("transform", `translate(0,${height})`)
+        .call(d3.axisBottom(x));
+      svg.append("g").call(d3.axisLeft(y));
+
+      svg
+        .selectAll("rect")
+        .data(points)
+        .enter()
+        .append("rect")
+        .attr("x", (d) => x(d.label) || 0)
+        .attr("y", (d) => y(d.value))
+        .attr("width", x.bandwidth())
+        .attr("height", (d) => height - y(d.value))
+        .attr("fill", "#10b981");
+    }
+  }, [data]);
 
   return (
     <div className="sentiment-volatility">
@@ -38,15 +90,17 @@ const SentimentVolatility: React.FC = () => {
         onClick={handleSubmit}
         disabled={loading}
       >
-        {loading ? 'Analyzing...' : 'Run Sentiment-to-Volatility Analysis'}
+        {loading ? "Analyzing..." : "Run Sentiment-to-Volatility Analysis"}
       </button>
 
       {error && <p className="text-red-500 mt-4">Error: {error.message}</p>}
       {data && (
         <div className="mt-4 p-4 bg-gray-100 rounded">
           <h3 className="font-semibold">Analysis Results:</h3>
-          <pre className="whitespace-pre-wrap text-sm">{JSON.stringify(data.analyzeSentimentVolatility, null, 2)}</pre>
-          {/* TODO: Integrate Chart.js for dashboard visualization here */}
+          <pre className="whitespace-pre-wrap text-sm">
+            {JSON.stringify(data.analyzeSentimentVolatility, null, 2)}
+          </pre>
+          <div ref={chartRef} />
         </div>
       )}
     </div>

--- a/client/src/components/ThreatCorrelation.tsx
+++ b/client/src/components/ThreatCorrelation.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
-import { useMutation, gql } from '@apollo/client'; // Assuming Apollo Client is set up
+import React, { useState, useEffect, useRef } from "react";
+import { useMutation, gql } from "@apollo/client"; // Assuming Apollo Client is set up
+import cytoscape, { Core } from "cytoscape";
 
 const CORRELATE_THREATS_MUTATION = gql`
   mutation CorrelateThreats($osintInput: JSON!) {
@@ -12,18 +13,53 @@ const CORRELATE_THREATS_MUTATION = gql`
 `;
 
 const ThreatCorrelation: React.FC = () => {
-  const [osintData, setOsintData] = useState('');
-  const [correlateThreats, { data, loading, error }] = useMutation(CORRELATE_THREATS_MUTATION);
+  const [osintData, setOsintData] = useState("");
+  const [correlateThreats, { data, loading, error }] = useMutation(
+    CORRELATE_THREATS_MUTATION,
+  );
+  const cyContainer = useRef<HTMLDivElement | null>(null);
+  const cyInstance = useRef<Core | null>(null);
 
   const handleSubmit = async () => {
     try {
       const parsedOsintData = JSON.parse(osintData);
       await correlateThreats({ variables: { osintInput: parsedOsintData } });
     } catch (e) {
-      alert('Invalid JSON input for OSINT data.');
+      alert("Invalid JSON input for OSINT data.");
       console.error(e);
     }
   };
+
+  useEffect(() => {
+    if (data && cyContainer.current) {
+      const prioritizedMap = data.correlateThreats?.prioritized_map || {};
+      const keys = Object.keys(prioritizedMap);
+      const elements = [
+        ...keys.map((id) => ({ data: { id } })),
+        ...keys.slice(1).map((id, idx) => ({
+          data: { id: `${keys[idx]}-${id}`, source: keys[idx], target: id },
+        })),
+      ];
+
+      if (cyInstance.current) {
+        cyInstance.current.destroy();
+      }
+
+      cyInstance.current = cytoscape({
+        container: cyContainer.current,
+        elements,
+        layout: { name: "grid" },
+        style: [
+          {
+            selector: "node",
+            style: { "background-color": "#0074D9", label: "data(id)" },
+          },
+        ],
+      });
+
+      (window as any).cy = cyInstance.current;
+    }
+  }, [data]);
 
   return (
     <div className="threat-correlation">
@@ -39,15 +75,17 @@ const ThreatCorrelation: React.FC = () => {
         onClick={handleSubmit}
         disabled={loading}
       >
-        {loading ? 'Correlating...' : 'Run Threat Correlation'}
+        {loading ? "Correlating..." : "Run Threat Correlation"}
       </button>
 
       {error && <p className="text-red-500 mt-4">Error: {error.message}</p>}
       {data && (
         <div className="mt-4 p-4 bg-gray-100 rounded">
           <h3 className="font-semibold">Correlation Results:</h3>
-          <pre className="whitespace-pre-wrap text-sm">{JSON.stringify(data.correlateThreats, null, 2)}</pre>
-          {/* TODO: Integrate Cytoscape.js for graph visualization here */}
+          <pre className="whitespace-pre-wrap text-sm">
+            {JSON.stringify(data.correlateThreats, null, 2)}
+          </pre>
+          <div ref={cyContainer} style={{ height: 300 }} />
         </div>
       )}
     </div>

--- a/client/src/components/ai/AIInsightsPanel.jsx
+++ b/client/src/components/ai/AIInsightsPanel.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import $ from 'jquery';
+import React from "react";
+import { useSelector, useDispatch } from "react-redux";
+import $ from "jquery";
 import {
   setHighlightEnabled,
   setSelectedInsightType,
   setCommunityIdFilter,
-} from '../../store/slices/aiInsightsSlice';
+} from "../../store/slices/aiInsightsSlice";
 import {
   Drawer,
   Box,
@@ -25,24 +25,30 @@ import {
   Select,
   MenuItem,
   FormControl,
-  Chip
-} from '@mui/material';
+  Chip,
+} from "@mui/material";
 import {
   ChevronLeft,
   ExpandMore,
   Download,
   Highlight,
-  InfoOutlined
-} from '@mui/icons-material';
+  InfoOutlined,
+} from "@mui/icons-material";
 
 function AIInsightsPanel({ open, onClose, onExportData }) {
   const dispatch = useDispatch();
-  const { highlightEnabled, selectedInsightType, communityIdFilter, communityData } = useSelector((state) => state.aiInsights);
+  const {
+    highlightEnabled,
+    selectedInsightType,
+    communityIdFilter,
+    communityData,
+  } = useSelector((state) => state.aiInsights);
   const contentRef = React.useRef(null);
 
-  const maxCommunityId = Object.values(communityData).length > 0 
-    ? Math.max(...Object.values(communityData)) 
-    : 100; // Default max if no community data
+  const maxCommunityId =
+    Object.values(communityData).length > 0
+      ? Math.max(...Object.values(communityData))
+      : 100; // Default max if no community data
 
   React.useEffect(() => {
     if (open) {
@@ -52,8 +58,20 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
   }, [open]);
 
   const handleHighlightToggle = (event) => {
-    dispatch(setHighlightEnabled(event.target.checked));
-    // TODO: Implement actual highlighting logic for Cytoscape.js
+    const enabled = event.target.checked;
+    dispatch(setHighlightEnabled(enabled));
+
+    // Toggle a "highlighted" class on Cytoscape elements if available
+    const cy = window.cy;
+    if (cy && typeof cy.elements === "function") {
+      cy.elements(".ai-insight").forEach((el) => {
+        if (enabled) {
+          el.addClass("highlighted");
+        } else {
+          el.removeClass("highlighted");
+        }
+      });
+    }
   };
 
   const handleInsightTypeChange = (event) => {
@@ -76,21 +94,21 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
       sx={{
         width: 350,
         flexShrink: 0,
-        '& .MuiDrawer-paper': {
+        "& .MuiDrawer-paper": {
           width: 350,
-          boxSizing: 'border-box',
+          boxSizing: "border-box",
           p: 2,
           // Responsive width
-          width: { xs: '100%', sm: 350 },
+          width: { xs: "100%", sm: 350 },
         },
       }}
     >
       <Box
         ref={contentRef}
         sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
           mb: 2,
         }}
       >
@@ -115,7 +133,11 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
           }
           label="Enable Highlighting"
         />
-        <Typography variant="body2" color="text.secondary" sx={{ ml: 4, mb: 2 }}>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ ml: 4, mb: 2 }}
+        >
           Toggle to visually highlight insights on the graph.
         </Typography>
       </Box>
@@ -143,7 +165,7 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
         </Select>
       </FormControl>
 
-      {selectedInsightType === 'community_detection' && (
+      {selectedInsightType === "community_detection" && (
         <Accordion sx={{ mb: 2 }}>
           <AccordionSummary
             expandIcon={<ExpandMore />}
@@ -162,7 +184,7 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
               max={maxCommunityId} // Dynamic max based on community data
               sx={{ mt: 2 }}
             />
-            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
               <Chip label={`Min: ${communityIdFilter[0]}`} />
               <Chip label={`Max: ${communityIdFilter[1]}`} />
             </Box>
@@ -175,7 +197,7 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
         <Typography variant="subtitle1" sx={{ mb: 1 }}>
           Metadata Popovers
         </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
           <InfoOutlined color="action" />
           <Typography variant="body2" color="text.secondary">
             Hover over graph elements to see detailed metadata.
@@ -188,11 +210,11 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
       <Typography variant="subtitle1" sx={{ mb: 1 }}>
         Export Insights
       </Typography>
-      <Box sx={{ display: 'flex', gap: 1 }}>
+      <Box sx={{ display: "flex", gap: 1 }}>
         <Button
           variant="contained"
           startIcon={<Download />}
-          onClick={() => handleExport('csv')}
+          onClick={() => handleExport("csv")}
           fullWidth
         >
           Export CSV
@@ -200,7 +222,7 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
         <Button
           variant="contained"
           startIcon={<Download />}
-          onClick={() => handleExport('json')}
+          onClick={() => handleExport("json")}
           fullWidth
         >
           Export JSON
@@ -209,13 +231,22 @@ function AIInsightsPanel({ open, onClose, onExportData }) {
 
       <List sx={{ mt: 2 }}>
         <ListItem>
-          <ListItemText primary="A11y Compliance" secondary="Ensured through Material-UI components." />
+          <ListItemText
+            primary="A11y Compliance"
+            secondary="Ensured through Material-UI components."
+          />
         </ListItem>
         <ListItem>
-          <ListItemText primary="Responsiveness" secondary="Handled by Material-UI's responsive design." />
+          <ListItemText
+            primary="Responsiveness"
+            secondary="Handled by Material-UI's responsive design."
+          />
         </ListItem>
         <ListItem>
-          <ListItemText primary="E2E Test Coverage" secondary="To be implemented with Playwright." />
+          <ListItemText
+            primary="E2E Test Coverage"
+            secondary="To be implemented with Playwright."
+          />
         </ListItem>
       </List>
     </Drawer>

--- a/ml/app/tasks/nlp_tasks.py
+++ b/ml/app/tasks/nlp_tasks.py
@@ -1,18 +1,34 @@
-import os
-import json
+"""Celery NLP-related tasks."""
+
 from typing import Dict, Any
-from celery import Celery
 from datetime import datetime
+
+import requests
 
 from ..celery_app import celery_app
 from ..monitoring import track_task_processing, track_error
+
+
+def _post_callback(callback_url: str, payload: Dict[str, Any]) -> None:
+    """POST ``payload`` to ``callback_url`` if provided.
+
+    Errors are swallowed but recorded via :func:`track_error` to ensure the
+    calling task always completes successfully.
+    """
+    if not callback_url:
+        return
+    try:  # pragma: no cover - network failures shouldn't crash tests
+        requests.post(callback_url, json=payload, timeout=5)
+    except Exception:  # pragma: no cover - defensive
+        track_error("nlp_tasks", "CallbackError")
+
 
 @celery_app.task(bind=True)
 @track_task_processing
 def task_entity_linking(self, payload: Dict[str, Any]) -> Dict[str, Any]:
     """
     Perform entity linking on text.
-    
+
     Args:
         payload: {
             'text': str,
@@ -20,84 +36,90 @@ def task_entity_linking(self, payload: Dict[str, Any]) -> Dict[str, Any]:
             'callback_url': str
         }
     """
-    job_id = payload.get('job_id', 'unknown')
-    text = payload.get('text', '')
-    callback_url = payload.get('callback_url')
+    job_id = payload.get("job_id", "unknown")
+    text = payload.get("text", "")
+    callback_url = payload.get("callback_url")
 
     try:
         # Placeholder for actual entity linking logic
         # In a real scenario, this would involve:
         # 1. Named Entity Recognition (NER) to identify potential entities
         # 2. Entity Disambiguation/Linking to connect them to a knowledge base
-        
+
         linked_entities = []
         # Simulate NER and Disambiguation
         if "Apple" in text:
             # Simulate disambiguation: Apple Inc. vs Apple (fruit)
             if "company" in text.lower() or "tech" in text.lower():
-                linked_entities.append({
-                    "text": "Apple",
-                    "label": "ORGANIZATION",
-                    "start_char": text.find("Apple"),
-                    "end_char": text.find("Apple") + len("Apple"),
-                    "entity_id": "Q312" # Example Wikidata ID for Apple Inc.
-                })
+                linked_entities.append(
+                    {
+                        "text": "Apple",
+                        "label": "ORGANIZATION",
+                        "start_char": text.find("Apple"),
+                        "end_char": text.find("Apple") + len("Apple"),
+                        "entity_id": "Q312",  # Example Wikidata ID for Apple Inc.
+                    }
+                )
             else:
-                linked_entities.append({
-                    "text": "apple",
-                    "label": "FRUIT",
-                    "start_char": text.find("Apple"),
-                    "end_char": text.find("Apple") + len("Apple"),
-                    "entity_id": "Q89" # Example Wikidata ID for Apple (fruit)
-                })
+                linked_entities.append(
+                    {
+                        "text": "apple",
+                        "label": "FRUIT",
+                        "start_char": text.find("Apple"),
+                        "end_char": text.find("Apple") + len("Apple"),
+                        "entity_id": "Q89",  # Example Wikidata ID for Apple (fruit)
+                    }
+                )
         if "Neo4j" in text:
-            linked_entities.append({
-                "text": "Neo4j",
-                "label": "DATABASE",
-                "start_char": text.find("Neo4j"),
-                "end_char": text.find("Neo4j") + len("Neo4j"),
-                "entity_id": "Q1065908" # Example Wikidata ID for Neo4j
-            })
+            linked_entities.append(
+                {
+                    "text": "Neo4j",
+                    "label": "DATABASE",
+                    "start_char": text.find("Neo4j"),
+                    "end_char": text.find("Neo4j") + len("Neo4j"),
+                    "entity_id": "Q1065908",  # Example Wikidata ID for Neo4j
+                }
+            )
         if "IntelGraph" in text:
-            linked_entities.append({
-                "text": "IntelGraph",
-                "label": "ORGANIZATION",
-                "start_char": text.find("IntelGraph"),
-                "end_char": text.find("IntelGraph") + len("IntelGraph"),
-                "entity_id": "intelgraph-org-id" # Internal ID
-            })
+            linked_entities.append(
+                {
+                    "text": "IntelGraph",
+                    "label": "ORGANIZATION",
+                    "start_char": text.find("IntelGraph"),
+                    "end_char": text.find("IntelGraph") + len("IntelGraph"),
+                    "entity_id": "intelgraph-org-id",  # Internal ID
+                }
+            )
 
         result = {
-            'job_id': job_id,
-            'entities': linked_entities,
-            'status': 'completed',
-            'completed_at': datetime.utcnow().isoformat()
+            "job_id": job_id,
+            "kind": "entity_linking",
+            "entities": linked_entities,
+            "status": "completed",
+            "completed_at": datetime.utcnow().isoformat(),
         }
 
-        # TODO: Implement webhook callback if callback_url is provided
-
-        return result
-
-    }
+        _post_callback(callback_url, result)
 
         return result
 
     except Exception as e:
-        track_error('nlp_tasks', 'EntityLinkingError')
+        track_error("nlp_tasks", "EntityLinkingError")
         return {
-            'job_id': job_id,
-            'kind': 'entity_linking',
-            'error': str(e),
-            'status': 'failed',
-            'completed_at': datetime.utcnow().isoformat()
+            "job_id": job_id,
+            "kind": "entity_linking",
+            "error": str(e),
+            "status": "failed",
+            "completed_at": datetime.utcnow().isoformat(),
         }
+
 
 @celery_app.task(bind=True)
 @track_task_processing
 def task_relationship_extraction(self, payload: Dict[str, Any]) -> Dict[str, Any]:
     """
     Perform relationship extraction on text given identified entities.
-    
+
     Args:
         payload: {
             'text': str,
@@ -106,10 +128,10 @@ def task_relationship_extraction(self, payload: Dict[str, Any]) -> Dict[str, Any
             'callback_url': str
         }
     """
-    job_id = payload.get('job_id', 'unknown')
-    text = payload.get('text', '')
-    entities = payload.get('entities', [])
-    callback_url = payload.get('callback_url')
+    job_id = payload.get("job_id", "unknown")
+    text = payload.get("text", "")
+    entities = payload.get("entities", [])
+    callback_url = payload.get("callback_url")
 
     try:
         # Placeholder for actual relationship extraction logic
@@ -117,40 +139,45 @@ def task_relationship_extraction(self, payload: Dict[str, Any]) -> Dict[str, Any
         # 1. Identifying potential relations between entities in the text.
         # 2. Classifying the type of relationship.
         # 3. Assigning a confidence score.
-        
+
         extracted_relationships = []
-        
+
         # Example: If "IntelGraph" and "Neo4j" are both in the text, and linked
         # we might infer a "USES" relationship.
-        intelgraph_entity = next((e for e in entities if e['text'] == 'IntelGraph'), None)
-        neo4j_entity = next((e for e in entities if e['text'] == 'Neo4j'), None)
+        intelgraph_entity = next(
+            (e for e in entities if e["text"] == "IntelGraph"), None
+        )
+        neo4j_entity = next((e for e in entities if e["text"] == "Neo4j"), None)
 
         if intelgraph_entity and neo4j_entity and "uses" in text.lower():
-            extracted_relationships.append({
-                "source_entity_id": intelgraph_entity['entity_id'],
-                "target_entity_id": neo4j_entity['entity_id'],
-                "type": "USES",
-                "confidence": 0.95,
-                "text_span": "IntelGraph uses Neo4j" # Example span
-            })
-        
+            extracted_relationships.append(
+                {
+                    "source_entity_id": intelgraph_entity["entity_id"],
+                    "target_entity_id": neo4j_entity["entity_id"],
+                    "type": "USES",
+                    "confidence": 0.95,
+                    "text_span": "IntelGraph uses Neo4j",  # Example span
+                }
+            )
+
         result = {
-            'job_id': job_id,
-            'relationships': extracted_relationships,
-            'status': 'completed',
-            'completed_at': datetime.utcnow().isoformat()
+            "job_id": job_id,
+            "kind": "relationship_extraction",
+            "relationships": extracted_relationships,
+            "status": "completed",
+            "completed_at": datetime.utcnow().isoformat(),
         }
 
-        # TODO: Implement webhook callback if callback_url is provided
+        _post_callback(callback_url, result)
 
         return result
 
     except Exception as e:
-        track_error('nlp_tasks', 'RelationshipExtractionError')
+        track_error("nlp_tasks", "RelationshipExtractionError")
         return {
-            'job_id': job_id,
-            'kind': 'relationship_extraction',
-            'error': str(e),
-            'status': 'failed',
-            'completed_at': datetime.utcnow().isoformat()
+            "job_id": job_id,
+            "kind": "relationship_extraction",
+            "error": str(e),
+            "status": "failed",
+            "completed_at": datetime.utcnow().isoformat(),
         }

--- a/ml/tests/test_nlp_callbacks.py
+++ b/ml/tests/test_nlp_callbacks.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import types
+import importlib.util
+import pathlib
+from unittest.mock import patch
+
+base_dir = pathlib.Path(__file__).resolve().parents[1]
+
+
+class _DummyTask:
+    pass
+
+
+class _DummyCelery:
+    def task(self, *args, **kwargs):
+        def decorator(func):
+            def wrapper(*f_args, **f_kwargs):
+                return func(_DummyTask(), *f_args, **f_kwargs)
+
+            return wrapper
+
+        return decorator
+
+
+sys.modules.setdefault(
+    "celery", types.SimpleNamespace(Celery=lambda *a, **k: _DummyCelery())
+)
+
+# Provide minimal monitoring module to satisfy imports
+monitoring_module = types.SimpleNamespace(
+    track_task_processing=lambda f: f,
+    track_error=lambda *a, **k: None,
+)
+sys.modules.setdefault("ml.app.monitoring", monitoring_module)
+
+# Set up minimal package structure for relative imports
+pkg_ml = types.ModuleType("ml")
+pkg_ml.__path__ = [str(base_dir)]
+pkg_app = types.ModuleType("ml.app")
+pkg_app.__path__ = [str(base_dir / "app")]
+pkg_tasks_pkg = types.ModuleType("ml.app.tasks")
+pkg_tasks_pkg.__path__ = [str(base_dir / "app" / "tasks")]
+sys.modules.update({"ml": pkg_ml, "ml.app": pkg_app, "ml.app.tasks": pkg_tasks_pkg})
+
+spec = importlib.util.spec_from_file_location(
+    "ml.app.tasks.nlp_tasks", base_dir / "app" / "tasks" / "nlp_tasks.py"
+)
+nlp_tasks = importlib.util.module_from_spec(spec)
+sys.modules["ml.app.tasks.nlp_tasks"] = nlp_tasks
+spec.loader.exec_module(nlp_tasks)
+
+
+SAMPLE_TEXT = "IntelGraph uses Neo4j while Apple builds software"
+
+
+def test_entity_linking_calls_callback():
+    payload = {
+        "text": SAMPLE_TEXT,
+        "job_id": "job1",
+        "callback_url": "http://example.com",
+    }
+    with patch("ml.app.tasks.nlp_tasks.requests.post") as mock_post:
+        result = nlp_tasks.task_entity_linking(payload)
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert kwargs["json"]["job_id"] == "job1"
+    assert result["kind"] == "entity_linking"
+    assert len(result["entities"]) >= 1
+
+
+def test_relationship_extraction_callback():
+    entities = [
+        {"text": "IntelGraph", "entity_id": "intelgraph-org-id"},
+        {"text": "Neo4j", "entity_id": "Q1065908"},
+    ]
+    payload = {
+        "text": SAMPLE_TEXT,
+        "entities": entities,
+        "job_id": "job2",
+        "callback_url": "http://example.com",
+    }
+    with patch("ml.app.tasks.nlp_tasks.requests.post") as mock_post:
+        result = nlp_tasks.task_relationship_extraction(payload)
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert kwargs["json"]["job_id"] == "job2"
+    assert result["kind"] == "relationship_extraction"
+    assert isinstance(result["relationships"], list)


### PR DESCRIPTION
## Summary
- add resilient webhook callbacks for NLP tasks
- integrate Cytoscape and D3 visualizations in React components
- test NLP tasks webhook callbacks

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/parser')*
- `npm run format` *(fails: Prettier YAML syntax errors)*
- `npm test` *(fails: SyntaxError in ESM module loading)*
- `pytest ml/tests/test_nlp_callbacks.py`

------
https://chatgpt.com/codex/tasks/task_e_68a24d055ea483339db60e2dd282d258