### PR TITLE
feat(client): add graph canvas and copilot drawer scaffolding

### DIFF
--- a/client/src/components/CopilotDrawer.tsx
+++ b/client/src/components/CopilotDrawer.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable indent */
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  TextField,
+  Typography,
+} from "@mui/material";
+import ChatIcon from "@mui/icons-material/Chat";
+import { io, Socket } from "socket.io-client";
+
+interface Message {
+  from: "user" | "ai";
+  text: string;
+}
+
+/**
+ * CopilotDrawer provides a lightweight chat interface that
+ * streams messages from an AI endpoint via Socket.IO.
+ */
+const CopilotDrawer: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    socketRef.current = io("/copilot");
+    socketRef.current.on("copilot:response", (text: string) => {
+      setMessages((m) => [...m, { from: "ai", text }]);
+    });
+    return () => socketRef.current?.disconnect();
+  }, []);
+
+  const send = () => {
+    if (!input.trim()) return;
+    setMessages((m) => [...m, { from: "user", text: input }]);
+    socketRef.current?.emit("copilot:question", input);
+    setInput("");
+  };
+
+  return (
+    <>
+      <IconButton
+        aria-label="open copilot"
+        onClick={() => setOpen(true)}
+        sx={{ position: "fixed", bottom: 16, right: 16 }}
+      >
+        <ChatIcon />
+      </IconButton>
+      <Drawer anchor="right" open={open} onClose={() => setOpen(false)}>
+        <Box sx={{ width: 320, p: 2 }}>
+          <Typography variant="h6" gutterBottom>
+            Copilot
+          </Typography>
+          <List sx={{ height: 360, overflowY: "auto" }}>
+            {messages.map((m, idx) => (
+              <ListItem key={idx}>
+                <ListItemText
+                  primary={m.text}
+                  secondary={m.from === "ai" ? "AI" : "You"}
+                />
+              </ListItem>
+            ))}
+          </List>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <TextField
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              fullWidth
+              size="small"
+              placeholder="Ask a question"
+            />
+            <Button onClick={send} variant="contained">
+              Send
+            </Button>
+          </Box>
+        </Box>
+      </Drawer>
+    </>
+  );
+};
+
+export default CopilotDrawer;

--- a/client/src/components/GraphCanvas.tsx
+++ b/client/src/components/GraphCanvas.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable indent */
+import React, { useEffect, useRef } from "react";
+import cytoscape, { ElementDefinition } from "cytoscape";
+import $ from "jquery";
+import { useDispatch, useSelector } from "react-redux";
+import { addNode, addEdge } from "../store/graphSlice";
+import { RootState } from "../store/types";
+import { io, Socket } from "socket.io-client";
+
+/**
+ * GraphCanvas mounts a Cytoscape instance and wires up
+ * jQuery interactions plus live updates via Socket.IO.
+ * It manages basic drag events and listens for backend
+ * node/edge additions, dispatching them into Redux.
+ */
+const GraphCanvas: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const dispatch = useDispatch();
+  const graph = useSelector((s: RootState) => s.graphData);
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements: [...graph.nodes, ...graph.edges] as ElementDefinition[],
+      style: [{ selector: "node", style: { label: "data(id)" } }],
+      layout: { name: "grid" },
+    });
+
+    // jQuery wrapper for simple drag feedback
+    $(cy.container()).on("mouseup", "node", (evt) => {
+      const n = evt.target;
+      dispatch(
+        addNode({
+          data: { id: n.id() },
+          position: n.position(),
+        }),
+      );
+    });
+
+    socketRef.current = io();
+    socketRef.current.on("graph:add-node", (n: ElementDefinition) =>
+      dispatch(addNode(n)),
+    );
+    socketRef.current.on("graph:add-edge", (e: ElementDefinition) =>
+      dispatch(addEdge(e)),
+    );
+
+    return () => {
+      cy.destroy();
+      socketRef.current?.disconnect();
+    };
+  }, [dispatch, graph.nodes, graph.edges]);
+
+  return <div ref={containerRef} style={{ width: "100%", height: "100%" }} />;
+};
+
+export default GraphCanvas;

--- a/client/src/store/graphSlice.ts
+++ b/client/src/store/graphSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { ElementDefinition } from "cytoscape";
+
+export interface GraphDataState {
+  nodes: ElementDefinition[];
+  edges: ElementDefinition[];
+}
+
+const initialState: GraphDataState = {
+  nodes: [],
+  edges: [],
+};
+
+const graphSlice = createSlice({
+  name: "graphData",
+  initialState,
+  reducers: {
+    addNode(state, action: PayloadAction<ElementDefinition>) {
+      state.nodes.push(action.payload);
+    },
+    addEdge(state, action: PayloadAction<ElementDefinition>) {
+      state.edges.push(action.payload);
+    },
+    reset(state) {
+      state.nodes = [];
+      state.edges = [];
+    },
+  },
+});
+
+export const { addNode, addEdge, reset } = graphSlice.actions;
+export default graphSlice.reducer;

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -6,6 +6,8 @@ import graphInteraction from "./slices/graphInteractionSlice";
 import graphUISlice from "./slices/graphUISlice"; // Import the new graphUISlice
 import aiInsightsReducer from "./slices/aiInsightsSlice"; // Import the new aiInsightsSlice
 import timelineReducer from "./slices/timelineSlice";
+import graphData from "./graphSlice";
+import socket from "./socketSlice";
 
 export const store = configureStore({
   reducer: {
@@ -16,6 +18,8 @@ export const store = configureStore({
     graphInteraction,
     graphUI: graphUISlice, // Add the new graphUISlice
     aiInsights: aiInsightsReducer, // Add the new aiInsightsReducer
+    graphData,
+    socket,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/client/src/store/socketSlice.ts
+++ b/client/src/store/socketSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export interface SocketState {
+  connected: boolean;
+}
+
+const initialState: SocketState = {
+  connected: false,
+};
+
+const socketSlice = createSlice({
+  name: "socket",
+  initialState,
+  reducers: {
+    connected(state) {
+      state.connected = true;
+    },
+    disconnected(state) {
+      state.connected = false;
+    },
+  },
+});
+
+export const { connected, disconnected } = socketSlice.actions;
+export default socketSlice.reducer;

--- a/client/src/store/types.ts
+++ b/client/src/store/types.ts
@@ -1,0 +1,7 @@
+import { GraphDataState } from "./graphSlice";
+import { type SocketState } from "./socketSlice";
+
+export interface RootState {
+  graphData: GraphDataState;
+  socket: SocketState;
+}


### PR DESCRIPTION
## Summary
- add Cytoscape-based GraphCanvas with jQuery and live Socket.IO events
- introduce CopilotDrawer for AI chat via Socket.IO
- create Redux slices for graph data and socket state and wire into store

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in existing files)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a253f5c8b48333b8b07c452f86259a