### PR TITLE
docs: add initial GraphRAG review and demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- docs: initial GraphRAG review and operations guides
+- docs: README GraphRAG demo snippet
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ make up        # Core services only (minimal hardware)
 make smoke
 ```
 
-* Client: [http://localhost:3000](http://localhost:3000)
-* GraphQL: [http://localhost:4000/graphql](http://localhost:4000/graphql)
-* Neo4j Browser: [http://localhost:7474](http://localhost:7474) (neo4j / devpassword)
+- Client: [http://localhost:3000](http://localhost:3000)
+- GraphQL: [http://localhost:4000/graphql](http://localhost:4000/graphql)
+- Neo4j Browser: [http://localhost:7474](http://localhost:7474) (neo4j / devpassword)
 
 ### Optional AI/Kafka Services
 
@@ -35,6 +35,17 @@ make up-full   # All services (AI + Kafka)
 make ingest    # produce sample posts to Kafka
 make graph     # consume and write to Neo4j
 ```
+
+### GraphRAG Demo (Experimental)
+
+```bash
+# After `make up`
+curl -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query($input:GraphRAGQueryInput!){ graphRagAnswer(input:$input){ answer }}","variables":{"input":{"investigationId":"demo","question":"What is GraphRAG?"}}}'
+```
+
+See [docs/GRAPHRAG_OVERVIEW.md](docs/GRAPHRAG_OVERVIEW.md) for details.
 
 📖 Full details: [docs/ONBOARDING.md](docs/ONBOARDING.md)
 
@@ -449,7 +460,7 @@ make bootstrap && make up
 # With AI capabilities
 make up-ai
 
-# With Kafka streaming  
+# With Kafka streaming
 make up-kafka
 
 # Full deployment (AI + Kafka)

--- a/docs/GRAPHRAG_OPERATIONS.md
+++ b/docs/GRAPHRAG_OPERATIONS.md
@@ -1,0 +1,38 @@
+# GraphRAG Operations
+
+This guide describes how to run the GraphRAG slice locally. All commands assume the repository root.
+
+## Make Targets
+
+```bash
+make bootstrap
+make up          # start core services (Neo4j, API, frontend)
+make up-ai       # optional: start AI helpers
+make smoke       # run smoke tests (expects GraphRAG query to succeed)
+```
+
+## Environment
+
+- `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD` – Neo4j connection for GraphRAG services.
+- `REDIS_URL` – optional cache for subgraph responses.
+- `OPENAI_API_KEY` or compatible LLM provider key for generation.
+
+Copy `.env.example` to `.env` and set the above variables before running services.
+
+## Neo4j Indices & Constraints
+
+Run migrations to ensure required indexes exist:
+
+```bash
+npm run db:neo4j:migrate
+```
+
+This script should be idempotent; rerunning it will not duplicate constraints.
+
+## Smoke Test Workflow
+
+1. Place sample markdown/JSONL files in `ingestion` input folder.
+2. Run the ingestion job to populate Neo4j.
+3. Execute `make smoke` – the test seeds documents, performs a GraphRAG query, and verifies a non‑empty answer payload.
+
+Logs for GraphRAG operations can be viewed in the server console; metrics are exposed via Prometheus under the `graphrag_*` prefix.

--- a/docs/GRAPHRAG_OVERVIEW.md
+++ b/docs/GRAPHRAG_OVERVIEW.md
@@ -1,0 +1,22 @@
+# GraphRAG Overview
+
+GraphRAG (Graph‑based Retrieval Augmented Generation) enhances question answering by grounding language model prompts in a knowledge graph. IntelGraph builds upon Microsoft’s open GraphRAG design and adapts it to Neo4j and the project’s golden path.
+
+## Architecture
+
+1. **Ingestion** – Documents are parsed and converted into entities and relationships.
+2. **Graph Store** – Data is stored in Neo4j with constraints for uniqueness and traversal performance.
+3. **Community Analysis** – Periodic clustering (e.g., Louvain) generates community summaries and embeddings.
+4. **Retrieval & Generation** – A GraphQL endpoint collects a subgraph around the query, assembles summaries, and invokes an LLM for an answer with citations and why‑paths.
+
+## Current Status
+
+- GraphQL schema (`server/src/graphql/schema/graphrag.graphql`) exposes `graphRagAnswer`, cache control, and health checks.
+- `GraphRAGService.ts` orchestrates Neo4j traversal, path ranking, and LLM invocation.
+- Frontend GraphQL queries exist but UI exposure is minimal.
+
+## Next Steps
+
+- Flesh out ingestion and community summarization pipelines.
+- Persist embeddings and summaries alongside graph nodes.
+- Provide a simple UI to trigger GraphRAG queries from investigations.

--- a/docs/GRAPHRAG_REVIEW.md
+++ b/docs/GRAPHRAG_REVIEW.md
@@ -1,0 +1,49 @@
+# GraphRAG Repository Review
+
+This document summarizes the current state of the `intelgraph` repository with a focus on readiness for a production GraphRAG implementation.
+
+## Service Inventory
+
+- **graph-service** – Python microservice responsible for graph analytics utilities.
+- **ingestion** – Handles document and media ingestion; entry point for creating graph nodes from raw data.
+- **ml** – Mixed collection of ML prototypes and training scripts; overlaps with `intelgraph_ai_ml`.
+- **nlp-service** – Minimal service intended for language processing and extraction tasks.
+- **server** – Node/Express GraphQL API exposing GraphRAG endpoints (`graphragResolvers.ts`, `graphrag.schema.graphql`).
+- **frontend** – React application that already issues GraphRAG queries through `GraphRagAnswer`.
+- **ingestion** and **graph-service** appear twice in various folders (e.g. `intelgraph_ai_ml` vs `ml`), suggesting drift and potential duplication.
+
+## Graph Storage & Access
+
+- Neo4j is configured as the primary graph store (`docker-compose.yml`, `neo4j-driver` usage in `GraphRAGService.ts`).
+- Graph schema and resolvers live in `server/src/graphql/` and `server/src/services/GraphRAGService.ts`.
+- GraphRAG service uses Zod‑validated requests/responses and caches subgraphs in Redis.
+
+## Security Posture
+
+- Secret management enforced via `.sops.yaml` and `.secrets.baseline`.
+- Pre‑commit hooks (`.pre-commit-config.yaml`) integrate `gitleaks` to prevent secret leaks.
+- No secrets were found in the repository during review.
+
+## CI / Testing / Linting
+
+- GitHub Actions present under `.github/` (not exhaustively reviewed).
+- Linting relies on ESLint and Ruff; formatting via Prettier.
+- Jest tests exist for GraphRAG schema validation but overall test coverage is unclear.
+
+## Risks & Gaps for GraphRAG
+
+| Risk                                                  | Impact                                     | Mitigation                                  |
+| ----------------------------------------------------- | ------------------------------------------ | ------------------------------------------- |
+| Neo4j indexes/constraints not defined                 | Query performance & data integrity issues  | Add idempotent migrations for nodes/edges   |
+| Ingestion pipeline incomplete                         | Graph may lack real entities/relationships | Implement document → entity extraction path |
+| Duplicate ML directories (`ml` vs `intelgraph_ai_ml`) | Maintenance overhead                       | Consolidate or deprecate outdated folders   |
+| Limited automated tests around GraphRAG resolvers     | Regressions in retrieval API               | Add unit & smoke tests for GraphRAG queries |
+
+## Proposed Minimal GraphRAG Slice
+
+1. **Ingestion Job** – Parse markdown/JSONL documents, extract entities & relations, upsert into Neo4j.
+2. **Community Summaries** – Run periodic Louvain clustering, store per‑community summaries.
+3. **GraphQL Retrieval API** – Extend `graphRagAnswer` to include subgraph context and summaries.
+4. **Frontend Hook** – Add button in investigation view to trigger a GraphRAG query and display answer + evidence.
+
+This slice provides end‑to‑end GraphRAG functionality while keeping scope small and aligned with the golden path workflow.


### PR DESCRIPTION
## Summary
- add GraphRAG repository review outlining services, risks, and minimal slice
- document GraphRAG overview and operations
- include README demo snippet for running a basic GraphRAG query

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68a3b07a2c808333a78955c8209dccfc