### PR TITLE
feat: add shared TypeScript contracts

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@intelgraph/contracts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/contracts/src/graphql.ts
+++ b/packages/contracts/src/graphql.ts
@@ -1,0 +1,25 @@
+// Stable v1 contracts used by server & web
+export type EntityID = string;
+export type InvestigationID = string;
+
+export interface Entity {
+  id: EntityID;
+  type: string; // e.g., Person, Org, Domain
+  value: string; // display label / canonical value
+  confidence?: number; // 0..1
+  source?: string;
+  firstSeen?: string; // ISO
+  lastSeen?: string; // ISO
+  properties?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Relationship {
+  id: string;
+  source: EntityID;
+  target: EntityID;
+  type: string; // e.g., COMMUNICATES_WITH
+  label?: string;
+  confidence?: number; // 0..1
+  properties?: Record<string, unknown>;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,2 @@
+export * from './graphql';
+export * from './realtime';

--- a/packages/contracts/src/realtime.ts
+++ b/packages/contracts/src/realtime.ts
@@ -1,0 +1,31 @@
+// Socket.IO event names & payloads (authoritative)
+export const RT_NS = {
+  COLLAB: '/collab',
+} as const;
+
+export const EVT = {
+  PRESENCE: 'presence', // user presence & cursors
+  NOTE_EDIT: 'note.edit', // rich-text notes
+  GRAPH_MUT: 'graph.mutate', // add/update/delete nodes/edges
+  GRAPH_LOCK: 'graph.lock', // optimistic lock hints
+  TOAST: 'ui.toast',
+} as const;
+
+export interface PresencePayload {
+  userId: string;
+  investigationId: string;
+  cursor?: { x: number; y: number };
+  ts: string;
+}
+export interface GraphMutatePayload {
+  investigationId: string;
+  ops: Array<
+    | { kind: 'addNode'; node: { id: string; type: string; value: string } }
+    | { kind: 'addEdge'; edge: { id: string; source: string; target: string; type: string } }
+    | { kind: 'updateNode'; id: string; patch: Record<string, unknown> }
+    | { kind: 'deleteNode'; id: string }
+    | { kind: 'deleteEdge'; id: string }
+  >;
+  clientId: string; // for echo-suppress
+  ts: string;
+}

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add `packages/contracts` module for shared GraphQL and realtime contracts

## Testing
- `npm run format` *(fails: .github/workflows YAML syntax errors)*
- `npm run lint` *(fails: 2653 problems across repo)*
- `npm test` *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_68a44945b7888333b794101c47baea68