### PR TITLE
feat: add devsecops pipeline and mvp1+ deployment values

### DIFF
--- a/.github/workflows/golden-path.yml
+++ b/.github/workflows/golden-path.yml
@@ -1,0 +1,88 @@
+name: golden-path
+
+on:
+  push:
+    branches: [feature/devsecops-v1]
+  pull_request:
+    branches: [feature/devsecops-v1]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    needs: typecheck
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker build -t intelgraph:ci .
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    needs: docker
+    strategy:
+      matrix:
+        chart: [deploy/helm/intelgraph]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v3
+      - run: helm lint ${{ matrix.chart }}
+
+  policy-check:
+    runs-on: ubuntu-latest
+    needs: helm-lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: instrumenta/conftest-action@v2
+        with:
+          files: deploy/k8s
+
+  trivy-scan:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: aquasecurity/trivy-action@v0
+        with:
+          image-ref: intelgraph:ci
+          format: table

--- a/deploy/helm/intelgraph/values-mvp1plus.yaml
+++ b/deploy/helm/intelgraph/values-mvp1plus.yaml
@@ -1,0 +1,10 @@
+server:
+  enabled: true
+web:
+  enabled: true
+api:
+  enabled: true
+neo4j:
+  enabled: true
+redis:
+  enabled: true

--- a/deploy/k8s/falco/intelgraph_rules.yaml
+++ b/deploy/k8s/falco/intelgraph_rules.yaml
@@ -27,3 +27,15 @@
   tags: [intelgraph, security, file_access]
 
 # Add more rules based on IntelGraph specific behaviors and known threats
+
+- rule: Detect Suspicious SocketIO Access
+  desc: Detect unexpected access to Socket.IO endpoints
+  condition: evt.type in (accept, connect) and fd.name contains "/socket.io/"
+  output: Suspicious Socket.IO connection to %fd.name
+  priority: NOTICE
+
+- rule: Detect Excessive GraphQL Queries
+  desc: Detect high rate of GraphQL requests which may indicate abuse
+  condition: evt.type=recv and fd.name contains "/graphql" and evt.count > 100
+  output: High volume GraphQL traffic detected on %fd.name
+  priority: WARNING

--- a/monitoring/dashboards/central-logging.json
+++ b/monitoring/dashboards/central-logging.json
@@ -1,0 +1,12 @@
+{
+  "title": "Central Logging",
+  "panels": [
+    {
+      "type": "logs",
+      "title": "IntelGraph Logs",
+      "targets": [
+        { "expr": "{app='intelgraph'}" }
+      ]
+    }
+  ]
+}

--- a/monitoring/dashboards/metrics-overview.json
+++ b/monitoring/dashboards/metrics-overview.json
@@ -1,0 +1,19 @@
+{
+  "title": "Metrics Overview",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "targets": [
+        { "expr": "sum(rate(container_cpu_usage_seconds_total{image!=''}[5m]))" }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "targets": [
+        { "expr": "sum(container_memory_usage_bytes{image!=''})" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add golden-path CI with lint/typecheck/test/build/docker/helm lint plus conftest and trivy checks
- provide MVP-1+ helm values and monitoring dashboards
- extend Falco runtime rules for Socket.IO and GraphQL traffic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a448f831a08333b7f9c227ed921992