### PR TITLE
feat: add redis-backed realtime collaboration

### DIFF
--- a/server/src/realtime/adapter.ts
+++ b/server/src/realtime/adapter.ts
@@ -1,0 +1,10 @@
+import { createAdapter as redisAdapter } from '@socket.io/redis-adapter';
+import { createClient } from 'redis';
+
+export async function createAdapter() {
+  const url = process.env.REDIS_URL || 'redis://localhost:6379';
+  const pub = createClient({ url });
+  const sub = pub.duplicate();
+  await Promise.all([pub.connect(), sub.connect()]);
+  return redisAdapter(pub, sub);
+}

--- a/server/src/realtime/auth.ts
+++ b/server/src/realtime/auth.ts
@@ -1,0 +1,31 @@
+import { Socket } from 'socket.io';
+import { verifyToken } from '../lib/auth.js';
+import pino from 'pino';
+
+const logger = pino();
+
+interface AuthedSocket extends Socket {
+  user?: {
+    id: string;
+    username?: string;
+    email?: string;
+    role?: string;
+  };
+  userId?: string;
+}
+
+export async function jwtAuth(socket: AuthedSocket, next: (err?: Error) => void) {
+  try {
+    const token =
+      socket.handshake.auth?.token ||
+      socket.handshake.headers?.authorization?.replace('Bearer ', '');
+    const user = await verifyToken(token);
+    socket.user = user;
+    socket.userId = user.id;
+    next();
+  } catch (e) {
+    const err = e as Error;
+    logger.warn({ error: err.message }, 'Unauthorized socket connection attempt');
+    next(new Error('Unauthorized'));
+  }
+}

--- a/server/src/realtime/mutation.ts
+++ b/server/src/realtime/mutation.ts
@@ -1,0 +1,46 @@
+import { Socket } from 'socket.io';
+import { z } from 'zod';
+import pino from 'pino';
+import { writeAudit } from '../utils/audit.js';
+
+const logger = pino();
+
+interface AuthedSocket extends Socket {
+  userId?: string;
+}
+
+const mutationSchema = z.object({
+  graphId: z.string(),
+  entityId: z.string(),
+  changes: z.record(z.any()),
+});
+
+export function registerMutationHandlers(socket: AuthedSocket) {
+  socket.on('graph:join', ({ graphId }: { graphId: string }) => {
+    if (graphId) socket.join(`graph:${graphId}`);
+  });
+
+  socket.on('graph:mutate', async (payload) => {
+    const parsed = mutationSchema.safeParse(payload);
+    if (!parsed.success) {
+      socket.emit('error', 'INVALID_PAYLOAD');
+      return;
+    }
+    const { graphId, entityId, changes } = parsed.data;
+    const userId = socket.userId;
+    socket.to(`graph:${graphId}`).emit('graph:mutated', {
+      userId,
+      entityId,
+      changes,
+      ts: Date.now(),
+    });
+    logger.info({ userId, graphId, entityId }, 'graph:mutate');
+    await writeAudit({
+      userId,
+      action: 'graph.mutate',
+      resourceType: 'graph',
+      resourceId: graphId,
+      details: { entityId, changes },
+    });
+  });
+}

--- a/server/src/realtime/socket.ts
+++ b/server/src/realtime/socket.ts
@@ -1,18 +1,27 @@
 import { Server, Socket } from 'socket.io';
-import { verifyToken } from '../lib/auth.js';
+import { Server as HttpServer } from 'http';
 import pino from 'pino';
 import { initGraphSync, registerGraphHandlers } from './graph-crdt.js';
 import { registerPresenceHandlers } from './presence.js';
+import { jwtAuth } from './auth.js';
+import { createAdapter } from './adapter.js';
+import { registerMutationHandlers } from './mutation.js';
 
 const logger = pino();
 
 interface UserSocket extends Socket {
-  user?: any;
+  user?: {
+    id: string;
+    email?: string;
+    username?: string;
+    role?: string;
+  };
+  userId?: string;
 }
 
 let ioInstance: Server | null = null;
 
-export function initSocket(httpServer: any): Server {
+export function initSocket(httpServer: HttpServer): Server {
   const io = new Server(httpServer, {
     cors: {
       origin: process.env.CORS_ORIGIN?.split(',') || ['http://localhost:3000'],
@@ -20,32 +29,23 @@ export function initSocket(httpServer: any): Server {
     },
   });
 
+  if (process.env.REDIS_URL) {
+    createAdapter()
+      .then((adapter) => io.adapter(adapter))
+      .catch((err) => logger.warn({ err }, 'redis-adapter-unavailable'));
+  }
+
   const ns = io.of('/realtime');
 
-  ns.use(async (socket: UserSocket, next) => {
-    try {
-      const token =
-        socket.handshake.auth?.token ||
-        socket.handshake.headers?.authorization?.replace('Bearer ', '');
-      const user = await verifyToken(token);
-      if (!user) {
-        logger.warn({ token }, 'Unauthorized socket connection attempt');
-        return next(new Error('Unauthorized'));
-      }
-      socket.user = user;
-      next();
-    } catch (e: any) {
-      logger.warn({ error: e.message }, 'Unauthorized socket connection attempt');
-      next(new Error('Unauthorized'));
-    }
-  });
+  ns.use(jwtAuth);
 
   ns.on('connection', (socket: UserSocket) => {
-    logger.info(`Realtime connected ${socket.id} for user ${socket.user?.id}`);
+    const uid = socket.userId || socket.user?.id;
+    logger.info(`Realtime connected ${socket.id} for user ${uid}`);
 
     const authorize =
-      (roles: string[], event: string, handler: (...args: any[]) => void) =>
-      (...args: any[]) => {
+      (roles: string[], event: string, handler: (...args: unknown[]) => void) =>
+      (...args: unknown[]) => {
         const userRole = socket.user?.role;
         if (!userRole || !roles.includes(userRole)) {
           logger.warn(
@@ -65,7 +65,15 @@ export function initSocket(httpServer: any): Server {
       authorize(
         EDIT_ROLES,
         'entity_update',
-        ({ graphId, entityId, changes }: { graphId: string; entityId: string; changes: any }) => {
+        ({
+          graphId,
+          entityId,
+          changes,
+        }: {
+          graphId: string;
+          entityId: string;
+          changes: Record<string, unknown>;
+        }) => {
           if (!graphId || !entityId) return;
           socket.to(`graph:${graphId}`).emit('entity_updated', {
             userId: socket.user?.id,
@@ -79,10 +87,11 @@ export function initSocket(httpServer: any): Server {
     );
 
     registerGraphHandlers(socket);
+    registerMutationHandlers(socket);
     registerPresenceHandlers(socket);
 
     socket.on('disconnect', () => {
-      logger.info(`Realtime disconnect ${socket.id} for user ${socket.user?.id}`);
+      logger.info(`Realtime disconnect ${socket.id} for user ${uid}`);
     });
   });
 

--- a/server/tests/graph-mutation.test.ts
+++ b/server/tests/graph-mutation.test.ts
@@ -1,0 +1,74 @@
+import http from 'http';
+import { AddressInfo } from 'net';
+import ioClient from 'socket.io-client';
+import { Server } from 'socket.io';
+import { initSocket } from '../src/realtime/socket';
+
+jest.mock('../src/lib/auth.js', () => ({
+  verifyToken: jest.fn(async (token: string) => {
+    if (token === 't1') {
+      return { id: '1', email: 'u1@example.com', username: 'u1', role: 'ADMIN' };
+    }
+    if (token === 't2') {
+      return { id: '2', email: 'u2@example.com', username: 'u2', role: 'ADMIN' };
+    }
+    throw new Error('Invalid token');
+  }),
+}));
+
+describe('graph mutation websocket', () => {
+  let server: http.Server;
+  let url: string;
+  let io: Server;
+
+  beforeAll((done) => {
+    server = http.createServer();
+    io = initSocket(server);
+    server.listen(() => {
+      const address = server.address() as AddressInfo;
+      url = `http://localhost:${address.port}/realtime`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    io.close();
+    server.close(done);
+  });
+
+  it('broadcasts mutations without echoing to sender', (done) => {
+    const clientA = ioClient(url, {
+      auth: { token: 't1' },
+      transports: ['websocket'],
+    });
+    const clientB = ioClient(url, {
+      auth: { token: 't2' },
+      transports: ['websocket'],
+    });
+
+    let receivedByA = false;
+
+    clientA.on('graph:mutated', () => {
+      receivedByA = true;
+    });
+
+    clientB.on('graph:mutated', (msg: { entityId: string }) => {
+      expect(msg.entityId).toBe('e1');
+      setTimeout(() => {
+        expect(receivedByA).toBe(false);
+        clientA.close();
+        clientB.close();
+        done();
+      }, 50);
+    });
+
+    clientA.emit('graph:join', { graphId: 'g1' });
+    clientB.emit('graph:join', { graphId: 'g1' });
+
+    clientA.emit('graph:mutate', {
+      graphId: 'g1',
+      entityId: 'e1',
+      changes: { label: 'n1' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Socket.IO Redis adapter helper
- implement JWT handshake middleware and graph mutation handler with audit logging
- broadcast graph edits to peers without echo

## Testing
- `npx eslint server/src/realtime/adapter.ts server/src/realtime/auth.ts server/src/realtime/mutation.ts server/src/realtime/socket.ts server/tests/graph-mutation.test.ts`
- `npx prettier -w server/src/realtime/adapter.ts server/src/realtime/auth.ts server/src/realtime/mutation.ts server/src/realtime/socket.ts server/tests/graph-mutation.test.ts`
- `npm test tests/presence.test.ts tests/socket-auth-rbac.test.ts tests/graph-mutation.test.ts -- --reporters=default --testResultsProcessor=` (fails: Cannot find module 'socket.io-client')

------
https://chatgpt.com/codex/tasks/task_e_68a448f3d9a08333acfa12de60d16848