### PR TITLE
feat: add graph store service with neo4j persistence

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -10,7 +10,7 @@ export default {
     'jest-extended/all',
   ],
   testMatch: [
-    '<rootDir>/tests/**/*.test.ts',
+    '<rootDir>/tests/**/*.{test,spec}.ts',
     '<rootDir>/src/tests/**/*.test.ts',
     '<rootDir>/src/**/__tests__/**/*.test.ts',
   ],

--- a/server/src/db/neo4j/migrations/001_graph_store_init.cypher
+++ b/server/src/db/neo4j/migrations/001_graph_store_init.cypher
@@ -1,0 +1,15 @@
+// Constraints
+CREATE CONSTRAINT entity_id_unique IF NOT EXISTS FOR (e:Entity) REQUIRE e.id IS UNIQUE;
+CREATE CONSTRAINT relationship_id_unique IF NOT EXISTS FOR ()-[r:RELATIONSHIP]-() REQUIRE r.id IS UNIQUE;
+
+// Indexes
+CREATE INDEX entity_type_idx IF NOT EXISTS FOR (e:Entity) ON (e.type);
+CREATE INDEX relationship_type_idx IF NOT EXISTS FOR ()-[r:RELATIONSHIP]-() ON (r.type);
+CREATE INDEX relationship_from_idx IF NOT EXISTS FOR ()-[r:RELATIONSHIP]-() ON (r.fromId);
+CREATE INDEX relationship_to_idx IF NOT EXISTS FOR ()-[r:RELATIONSHIP]-() ON (r.toId);
+
+// Full text index
+CALL db.index.fulltext.createNodeIndex('entity_fulltext', ['Entity'], ['value', 'label', 'type']);
+
+// TTL index for relationships using `until`
+CALL db.index.expire.createRelationshipIndex('relationship_until_ttl', 'RELATIONSHIP', 'until');

--- a/server/src/services/GraphStore.ts
+++ b/server/src/services/GraphStore.ts
@@ -1,0 +1,146 @@
+import { Driver, Node, Relationship as Neo4jRelationship } from 'neo4j-driver';
+import { getNeo4jDriver } from '../db/neo4j';
+
+export interface Entity {
+  id: string;
+  type: string;
+  value: string;
+  label?: string;
+}
+
+export interface Relationship {
+  id: string;
+  fromId: string;
+  toId: string;
+  type: string;
+  since?: string;
+  until?: string;
+}
+
+export interface GraphStore {
+  getEntities(filters: Partial<{ type: string; q: string; limit: number }>): Promise<Entity[]>;
+  getRelationships(entityId: string): Promise<Relationship[]>;
+  upsertEntity(e: Entity): Promise<Entity>;
+  upsertRelationship(r: Relationship): Promise<Relationship>;
+  deleteEntity(id: string): Promise<void>;
+  deleteRelationship(id: string): Promise<void>;
+}
+
+function nodeToEntity(node: Node): Entity {
+  const props: any = node.properties;
+  return {
+    id: props.id,
+    type: props.type,
+    value: props.value,
+    label: props.label,
+  };
+}
+
+function relToRelationship(rel: Neo4jRelationship): Relationship {
+  const props: any = rel.properties;
+  return {
+    id: props.id,
+    fromId: props.fromId,
+    toId: props.toId,
+    type: props.type,
+    since: props.since,
+    until: props.until,
+  };
+}
+
+export function createGraphStore(driver: Driver = getNeo4jDriver()): GraphStore {
+  return {
+    async getEntities(filters = {}) {
+      const session = driver.session();
+      const { type = null, q = null, limit = 25 } = filters;
+      try {
+        if (q) {
+          const res = await session.run(
+            `CALL db.index.fulltext.queryNodes('entity_fulltext', $q) YIELD node WHERE $type IS NULL OR node.type = $type RETURN node LIMIT $limit`,
+            { q, type, limit }
+          );
+          return res.records.map(r => nodeToEntity(r.get('node')));
+        }
+        const res = await session.run(
+          `MATCH (e:Entity) WHERE $type IS NULL OR e.type = $type RETURN e LIMIT $limit`,
+          { type, limit }
+        );
+        return res.records.map(r => nodeToEntity(r.get('e')));
+      } finally {
+        await session.close();
+      }
+    },
+
+    async getRelationships(entityId: string) {
+      const session = driver.session();
+      try {
+        const res = await session.run(
+          `MATCH (:Entity {id: $id})-[r:RELATIONSHIP]-(:Entity) RETURN r`,
+          { id: entityId }
+        );
+        return res.records.map(r => relToRelationship(r.get('r')));
+      } finally {
+        await session.close();
+      }
+    },
+
+    async upsertEntity(e: Entity) {
+      const session = driver.session();
+      try {
+        const res = await session.writeTransaction(tx =>
+          tx.run(
+            `MERGE (n:Entity {id: $id})
+             ON CREATE SET n.type=$type, n.value=$value, n.label=$label, n.createdAt=timestamp()
+             ON MATCH SET n.type=$type, n.value=$value, n.label=$label, n.updatedAt=timestamp()
+             RETURN n`,
+            e
+          )
+        );
+        return nodeToEntity(res.records[0].get('n'));
+      } finally {
+        await session.close();
+      }
+    },
+
+    async upsertRelationship(r: Relationship) {
+      const session = driver.session();
+      try {
+        const res = await session.writeTransaction(tx =>
+          tx.run(
+            `MATCH (a:Entity {id: $fromId}), (b:Entity {id: $toId})
+             MERGE (a)-[rel:RELATIONSHIP {id: $id}]->(b)
+             ON CREATE SET rel.type=$type, rel.fromId=$fromId, rel.toId=$toId, rel.since=$since, rel.until=$until, rel.createdAt=timestamp()
+             ON MATCH SET rel.type=$type, rel.since=$since, rel.until=$until, rel.updatedAt=timestamp()
+             RETURN rel`,
+            r
+          )
+        );
+        return relToRelationship(res.records[0].get('rel'));
+      } finally {
+        await session.close();
+      }
+    },
+
+    async deleteEntity(id: string) {
+      const session = driver.session();
+      try {
+        await session.writeTransaction(tx =>
+          tx.run(`MATCH (n:Entity {id: $id}) DETACH DELETE n`, { id })
+        );
+      } finally {
+        await session.close();
+      }
+    },
+
+    async deleteRelationship(id: string) {
+      const session = driver.session();
+      try {
+        await session.writeTransaction(tx =>
+          tx.run(`MATCH ()-[r:RELATIONSHIP {id: $id}]-() DELETE r`, { id })
+        );
+      } finally {
+        await session.close();
+      }
+    },
+  };
+}

--- a/server/tests/services/graphstore.spec.ts
+++ b/server/tests/services/graphstore.spec.ts
@@ -1,0 +1,77 @@
+import { GenericContainer } from 'testcontainers';
+import fs from 'fs/promises';
+import path from 'path';
+import { createGraphStore } from '../../src/services/GraphStore';
+import { getNeo4jDriver, closeNeo4jDriver } from '../../src/db/neo4j';
+
+const maybe = GenericContainer ? describe : describe.skip;
+
+maybe('GraphStore', () => {
+  let container: any;
+  let store: ReturnType<typeof createGraphStore>;
+  let driver: any;
+
+  beforeAll(async () => {
+    container = await new GenericContainer('neo4j:5')
+      .withEnv('NEO4J_AUTH', 'neo4j/test')
+      .withExposedPorts(7687)
+      .start();
+    const port = container.getMappedPort(7687);
+    process.env.NEO4J_URI = `bolt://localhost:${port}`;
+    process.env.NEO4J_USER = 'neo4j';
+    process.env.NEO4J_PASSWORD = 'test';
+
+    store = createGraphStore();
+    driver = getNeo4jDriver();
+
+    const session = driver.session();
+    const migrationsDir = path.join(__dirname, '../../src/db/neo4j/migrations');
+    const files = (await fs.readdir(migrationsDir)).filter(f => f.endsWith('.cypher')).sort();
+    for (const file of files) {
+      const cypher = await fs.readFile(path.join(migrationsDir, file), 'utf8');
+      const statements = cypher.split(';').map(s => s.trim()).filter(Boolean);
+      for (const stmt of statements) {
+        await session.run(stmt);
+      }
+    }
+    await session.close();
+  }, 60000);
+
+  afterAll(async () => {
+    if (driver) await closeNeo4jDriver();
+    if (container) await container.stop();
+  });
+
+  it('upserts and queries entities', async () => {
+    await store.upsertEntity({ id: 'e1', type: 'Person', value: 'Alice', label: 'Alice' });
+    await store.upsertEntity({ id: 'e2', type: 'Person', value: 'Bob', label: 'Bob' });
+    const search = await store.getEntities({ q: 'Alice' });
+    expect(search).toEqual([
+      { id: 'e1', type: 'Person', value: 'Alice', label: 'Alice' },
+    ]);
+    const all = await store.getEntities({ type: 'Person' });
+    expect(all).toHaveLength(2);
+  });
+
+  it('manages relationships with temporal properties', async () => {
+    await store.upsertRelationship({ id: 'r1', fromId: 'e1', toId: 'e2', type: 'KNOWS', since: '2020', until: '2025' });
+    const rels = await store.getRelationships('e1');
+    expect(rels).toEqual([
+      { id: 'r1', fromId: 'e1', toId: 'e2', type: 'KNOWS', since: '2020', until: '2025' },
+    ]);
+    await store.deleteRelationship('r1');
+    const after = await store.getRelationships('e1');
+    expect(after).toHaveLength(0);
+  });
+
+  it('deletes entities with cascading edges', async () => {
+    await store.upsertRelationship({ id: 'r2', fromId: 'e1', toId: 'e2', type: 'KNOWS', since: '2020', until: '2025' });
+    await store.deleteEntity('e1');
+    const entities = await store.getEntities({ type: 'Person' });
+    expect(entities).toEqual([
+      { id: 'e2', type: 'Person', value: 'Bob', label: 'Bob' },
+    ]);
+    const rels = await store.getRelationships('e2');
+    expect(rels).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Neo4j-backed GraphStore service with typed CRUD APIs
- seed constraints and indexes via new migration
- cover GraphStore with containerized Neo4j tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Prettier YAML syntax errors)*
- `cd server && npm run test:coverage` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a448813c48833380f31ae85c227633