### PR TITLE
feat: add codemod pack and logger utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,17 @@ Use the [Feature Request template](https://github.com/BrianCLong/intelgraph/issu
 
 ---
 
+## Rapid Lint Burn-Down
+
+To clean up logs and migrate modules quickly:
+
+```bash
+npm run codemod:console
+npm run codemod:cjs
+npm run lint
+npm run format
+```
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/apps/web/src/utils/logger.spec.ts
+++ b/apps/web/src/utils/logger.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from './logger';
+
+describe('logger', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('prints timestamp and request id', () => {
+    process.env.REQUEST_ID = 'req-123';
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    logger.info('hello');
+    expect(spy).toHaveBeenCalledWith('[2024-01-01T00:00:00.000Z] [req-123]', 'hello');
+  });
+});

--- a/apps/web/src/utils/logger.ts
+++ b/apps/web/src/utils/logger.ts
@@ -1,0 +1,23 @@
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+function format(level: LogLevel, args: unknown[]) {
+  const ts = new Date().toISOString();
+  const id = process?.env?.TRACE_ID || process?.env?.REQUEST_ID;
+  const prefix = id ? `[${ts}] [${id}]` : `[${ts}]`;
+  return [prefix, ...args];
+}
+
+function createLogger(level: LogLevel) {
+  return (...args: unknown[]): void => {
+    // Always write to console in production; methods map one-to-one
+    // eslint-disable-next-line no-console
+    (console as any)[level](...format(level, args));
+  };
+}
+
+export const logger = {
+  info: createLogger('info'),
+  warn: createLogger('warn'),
+  error: createLogger('error'),
+  debug: createLogger('debug'),
+};

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "db:neo4j:migrate": "node scripts/neo4j-migrate.js",
     "changeset": "changeset",
     "release": "changeset version && changeset publish",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "codemod:console": "npx jscodeshift -t scripts/codemods/console-to-logger.js \"apps/**/src/**/*.{ts,tsx,js}\" \"api/src/**/*.{ts,js,tsx}\" \"notify-api/src/**/*.{ts,js}\" \"server/src/**/*.{ts,js}\" \"audit-janitor/src/**/*.{ts,js}\"",
+    "codemod:cjs": "npx jscodeshift -t scripts/codemods/cjs-to-esm.js \"api/src/**/*.{ts,js}\" \"notify-api/src/**/*.{ts,js}\" \"server/src/**/*.{ts,js}\""
   },
   "keywords": [
     "intelligence-analysis",

--- a/scripts/codemods/cjs-to-esm.js
+++ b/scripts/codemods/cjs-to-esm.js
@@ -1,0 +1,52 @@
+/**
+ * Codemod: cjs-to-esm
+ *
+ * Transforms CommonJS modules to ESM.
+ * - `const X = require('x')` -> `import X from 'x'`.
+ * - `const {a} = require('x')` -> `import {a} from 'x'`.
+ * - `module.exports = ...` -> `export default ...`.
+ * - Leaves dynamic require() untouched and adds TODO comment above.
+ * Idempotent.
+ */
+
+module.exports = function (fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  let transformed = false;
+
+  root.find(j.VariableDeclaration).forEach((path) => {
+    const decl = path.value.declarations && path.value.declarations[0];
+    if (!decl || !decl.init || decl.init.type !== 'CallExpression' || decl.init.callee.name !== 'require') {
+      return;
+    }
+    const arg = decl.init.arguments[0];
+    if (!arg) return;
+
+    if (arg.type === 'Literal') {
+      transformed = true;
+      let specifiers = [];
+      if (decl.id.type === 'Identifier') {
+        specifiers = [j.importDefaultSpecifier(j.identifier(decl.id.name))];
+      } else if (decl.id.type === 'ObjectPattern') {
+        specifiers = decl.id.properties.map((p) =>
+          j.importSpecifier(j.identifier(p.key.name), j.identifier(p.value ? p.value.name : p.key.name))
+        );
+      }
+      const importDecl = j.importDeclaration(specifiers, j.literal(arg.value));
+      j(path).replaceWith(importDecl);
+    } else {
+      const todo = j.commentLine('TODO: dynamic require() needs manual review');
+      path.value.comments = path.value.comments || [];
+      path.value.comments.unshift(todo);
+    }
+  });
+
+  root.find(j.AssignmentExpression, {
+    left: { object: { name: 'module' }, property: { name: 'exports' } },
+  }).forEach((p) => {
+    transformed = true;
+    j(p.parent).replaceWith(j.exportDefaultDeclaration(p.value.right));
+  });
+
+  return transformed ? root.toSource({ quote: 'single' }) : null;
+};

--- a/scripts/codemods/console-to-logger.js
+++ b/scripts/codemods/console-to-logger.js
@@ -1,0 +1,72 @@
+/**
+ * Codemod: console-to-logger
+ *
+ * Replaces console.log/warn/error/debug with logger.info/warn/error/debug.
+ * Skips files already importing logger.
+ * Adds import { logger } from "@/utils/logger" when tsconfig path mapping for "@/*" exists,
+ * otherwise uses relative import to src/utils/logger.
+ * Idempotent.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function getImportPath(filePath) {
+  let dir = path.dirname(filePath);
+  let rootDir = dir;
+  while (dir && dir !== path.dirname(dir)) {
+    const tsconfigPath = path.join(dir, 'tsconfig.json');
+    if (fs.existsSync(tsconfigPath)) {
+      rootDir = dir;
+      try {
+        const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, 'utf8'));
+        const paths = tsconfig.compilerOptions && tsconfig.compilerOptions.paths;
+        if (paths && paths['@/*']) {
+          return '@/utils/logger';
+        }
+      } catch (e) {
+        // ignore
+      }
+      break;
+    }
+    dir = path.dirname(dir);
+  }
+  const rel = path.relative(path.dirname(filePath), path.join(rootDir, 'src', 'utils', 'logger')).replace(/\\/g, '/');
+  return rel.startsWith('.') ? rel : './' + rel;
+}
+
+module.exports = function (fileInfo, api) {
+  const j = api.jscodeshift;
+  const filePath = fileInfo.path;
+
+  if (/src\/utils\/logger\.(ts|js)$/.test(filePath)) {
+    return fileInfo.source;
+  }
+
+  const root = j(fileInfo.source);
+  const hasLoggerImport = root
+    .find(j.ImportDeclaration, (node) => /utils\/logger$/.test(node.source.value))
+    .size() > 0;
+
+  let replaced = false;
+  root
+    .find(j.MemberExpression, { object: { name: 'console' } })
+    .filter((p) => ['log', 'warn', 'error', 'debug'].includes(p.value.property.name))
+    .forEach((p) => {
+      replaced = true;
+      const method = p.value.property.name;
+      p.value.object.name = 'logger';
+      p.value.property.name = method === 'log' ? 'info' : method;
+    });
+
+  if (replaced && !hasLoggerImport) {
+    const importPath = getImportPath(filePath);
+    const importDecl = j.importDeclaration(
+      [j.importSpecifier(j.identifier('logger'))],
+      j.literal(importPath)
+    );
+    root.get().node.program.body.unshift(importDecl);
+  }
+
+  return replaced ? root.toSource({ quote: 'single' }) : null;
+};


### PR DESCRIPTION
## Summary
- add console-to-logger and cjs-to-esm codemods
- provide lightweight logger util with test
- wire up codemod scripts and doc section

## Testing
- `npm run lint` *(fails: Unexpected console statement and other lint errors)*
- `npm run format` *(fails: YAML syntax errors in workflow files)*
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm --prefix apps/web test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fd8dcbb483339e2c8a8b432e6d5a