### PR TITLE
chore: add security lint gate

### DIFF
--- a/.github/workflows/lint-security.yml
+++ b/.github/workflows/lint-security.yml
@@ -1,0 +1,26 @@
+name: lint-security
+
+on:
+  pull_request:
+
+jobs:
+  lint-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint:security
+      - name: Lint baseline
+        if: always()
+        run: |
+          mkdir -p reports
+          npm run lint:baseline
+      - name: Upload ESLint report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eslint-full
+          path: reports/eslint-full.json

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ npm run test:unit    # Unit tests only
 npm run test:e2e     # End-to-end tests
 npm run test:smoke   # Smoke tests for deployment validation
 npm run lint         # ESLint code quality checks
+npm run lint:security # Security-focused lint gate
+npm run lint:baseline # Generate full ESLint report
 npm run typecheck    # TypeScript type checking
 npm run format       # Prettier code formatting
 

--- a/SECURITY_LINT_WAIVERS.md
+++ b/SECURITY_LINT_WAIVERS.md
@@ -1,0 +1,9 @@
+# Security Lint Waivers
+
+Use this log to track temporary waivers for security lint rule violations. Each entry must include an owner and an expiry no more than 30 days out.
+
+| Rule | Count (baseline) | Example files | Risk | Owner | Expiry (≤30d) | Resolution Plan |
+|------|------------------|---------------|------|-------|---------------|-----------------|
+| _example_ | 1 | `apps/web/src/foo.ts` | RCE via eval | @owner | 2025-01-31 | Refactor to remove eval |
+
+> CI blocks **new** security rule violations on changed files. Waivers only apply to existing issues until resolved.

--- a/eslint.security.ci.json
+++ b/eslint.security.ci.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./eslint.config.js",
+  "rules": {
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    "no-new-func": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-member-access": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-var-requires": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "lint": "eslint . && ruff .",
     "lint:server": "cd server && npm run lint",
     "lint:client": "cd client && npm run lint",
+    "lint:security": "eslint -c eslint.security.ci.json \"apps/**/src/**/*.{ts,tsx,js}\" \"api/src/**/*.{ts,js,tsx}\" \"notify-api/src/**/*.{ts,js}\" \"audit-janitor/src/**/*.{ts,js}\" \"server/src/**/*.{ts,js}\"",
+    "lint:baseline": "eslint -f json . > reports/eslint-full.json",
     "typecheck": "tsc -b --pretty false",
     "typecheck:server": "cd server && tsc --noEmit",
     "typecheck:client": "cd client && tsc --noEmit",


### PR DESCRIPTION
## Summary
- add security-only ESLint config and waiver log
- wire up security lint workflow
- document how to run security lint gate

## Testing
- `npm run lint:security` *(fails: ERR_IMPORT_ATTRIBUTE_MISSING: Module needs an import attribute of "type: json")*
- `npm run lint:baseline`


------
https://chatgpt.com/codex/tasks/task_e_68a4fd7b68a8833393eef06b351bc10d