### PR TITLE
feat: add observability SLO dashboard

### DIFF
--- a/apps/observability/SLOs.md
+++ b/apps/observability/SLOs.md
@@ -1,0 +1,6 @@
+# Observability SLOs
+
+- **Ingest Rate:** 99% of scrapes show at least 50 events/sec.
+- **Entity Resolution Latency:** 95th percentile under 200 ms.
+- **Policy Evaluation:** 95th percentile under 100 ms.
+- **Query Latency Heatmap:** visualized client-side to spot hotspots.

--- a/apps/observability/docker-compose.yml
+++ b/apps/observability/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  metrics-publisher:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - ./metrics-publisher.py:/app/metrics-publisher.py
+    command: bash -c "pip install prometheus_client && python metrics-publisher.py"
+    expose:
+      - '8000'
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - '9090:9090'
+  dashboard:
+    image: nginx:alpine
+    volumes:
+      - .:/usr/share/nginx/html:ro
+    ports:
+      - '8080:80'

--- a/apps/observability/index.html
+++ b/apps/observability/index.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Observability SLO Dashboard</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 20px;
+      }
+      #charts {
+        display: flex;
+        gap: 20px;
+      }
+      svg {
+        border: 1px solid #ccc;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Observability SLO Dashboard</h1>
+    <div id="charts">
+      <svg id="ingest" width="200" height="100"></svg>
+      <svg id="er" width="200" height="100"></svg>
+      <svg id="policy" width="200" height="100"></svg>
+    </div>
+    <h2>Query Latency Heatmap</h2>
+    <svg id="heatmap" width="300" height="300"></svg>
+    <script>
+      async function fetchMetric(name) {
+        const res = await fetch(`http://localhost:9090/api/v1/query?query=${name}`);
+        const data = await res.json();
+        return parseFloat(data.data.result[0]?.value[1] || 0);
+      }
+      function drawBar(svgId, value, max) {
+        const svg = document.getElementById(svgId);
+        svg.innerHTML = '';
+        const h = svg.getAttribute('height');
+        const w = svg.getAttribute('width');
+        const barHeight = (value / max) * h;
+        const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        rect.setAttribute('x', 0);
+        rect.setAttribute('y', h - barHeight);
+        rect.setAttribute('width', w);
+        rect.setAttribute('height', barHeight);
+        rect.setAttribute('fill', '#4caf50');
+        svg.appendChild(rect);
+      }
+      async function update() {
+        const ingest = await fetchMetric('ingest_rate_total');
+        const er = await fetchMetric('er_latency_ms');
+        const policy = await fetchMetric('policy_eval_ms');
+        drawBar('ingest', ingest, 100);
+        drawBar('er', er, 200);
+        drawBar('policy', policy, 100);
+      }
+      function drawHeatmap() {
+        const svg = document.getElementById('heatmap');
+        const size = 10;
+        const cell = 30;
+        for (let x = 0; x < size; x++) {
+          for (let y = 0; y < size; y++) {
+            const latency = Math.random() * 200;
+            const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+            rect.setAttribute('x', x * cell);
+            rect.setAttribute('y', y * cell);
+            rect.setAttribute('width', cell);
+            rect.setAttribute('height', cell);
+            rect.setAttribute('fill', `rgba(255,0,0,${latency / 200})`);
+            svg.appendChild(rect);
+          }
+        }
+      }
+      update();
+      setInterval(update, 5000);
+      drawHeatmap();
+    </script>
+  </body>
+</html>

--- a/apps/observability/metrics-publisher.py
+++ b/apps/observability/metrics-publisher.py
@@ -1,0 +1,16 @@
+import random
+import time
+from prometheus_client import Counter, Gauge, start_http_server
+
+# Synthetic metrics
+ingest_rate = Counter('ingest_rate_total', 'Synthetic ingest rate')
+er_latency = Gauge('er_latency_ms', 'Entity resolution latency in ms')
+policy_eval = Gauge('policy_eval_ms', 'Policy evaluation time in ms')
+
+if __name__ == '__main__':
+    start_http_server(8000)
+    while True:
+        ingest_rate.inc(random.randint(1, 5))
+        er_latency.set(random.uniform(10, 200))
+        policy_eval.set(random.uniform(1, 100))
+        time.sleep(5)

--- a/apps/observability/prometheus.yml
+++ b/apps/observability/prometheus.yml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 5s
+scrape_configs:
+  - job_name: 'metrics-publisher'
+    static_configs:
+      - targets: ['metrics-publisher:8000']


### PR DESCRIPTION
## Summary
- add metrics publisher exposing Prometheus counters
- provide Docker compose stack with Prometheus and basic dashboard
- document SLO targets

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run format` *(fails: Map keys must be unique; "script" is repeated)*
- `npm test` *(fails: SyntaxError in workflow files)*
- `docker compose -f apps/observability/docker-compose.yml up -d` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a53b9c429083338ea7b12a7e0e6ed2