### PR TITLE
feat: add observability and ci pack

### DIFF
--- a/ops/AGENTS.md
+++ b/ops/AGENTS.md
@@ -1,0 +1,4 @@
+# Ops Guidelines
+- All YAML and config files use 2-space indentation.
+- Shell scripts must start with `#!/usr/bin/env bash` and `set -euo pipefail`.
+- Run `pre-commit run --files <files>` for touched files before committing.

--- a/ops/observability-ci/.editorconfig
+++ b/ops/observability-ci/.editorconfig
@@ -1,0 +1,8 @@
+root = false
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8

--- a/ops/observability-ci/.github/workflows/ci-node.yml
+++ b/ops/observability-ci/.github/workflows/ci-node.yml
@@ -1,0 +1,22 @@
+name: ci-node
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm test -- --coverage
+      - run: node "$GITHUB_WORKSPACE/ops/observability-ci/scripts/verify-coverage.js" "${{ inputs.working-directory }}"

--- a/ops/observability-ci/.github/workflows/ci-python.yml
+++ b/ops/observability-ci/.github/workflows/ci-python.yml
@@ -1,0 +1,26 @@
+name: ci-python
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: |
+          pip install pytest coverage black ruff mypy
+          black --check .
+          ruff .
+          mypy .
+          pytest --cov=. --cov-report=json:coverage-summary.json
+      - run: node "$GITHUB_WORKSPACE/ops/observability-ci/scripts/verify-coverage.js" "${{ inputs.working-directory }}"

--- a/ops/observability-ci/.github/workflows/container-scan.yml
+++ b/ops/observability-ci/.github/workflows/container-scan.yml
@@ -1,0 +1,15 @@
+name: container-scan
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aquasecurity/trivy-action@v0.12.0
+        with:
+          image-ref: ${{ inputs.image }}
+          format: table

--- a/ops/observability-ci/.github/workflows/e2e-webapp.yml
+++ b/ops/observability-ci/.github/workflows/e2e-webapp.yml
@@ -1,0 +1,22 @@
+name: e2e-webapp
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: true
+        type: string
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e

--- a/ops/observability-ci/.github/workflows/self-test.yml
+++ b/ops/observability-ci/.github/workflows/self-test.yml
@@ -1,0 +1,16 @@
+name: self-test
+on:
+  push:
+    paths:
+      - 'ops/observability-ci/**'
+  workflow_dispatch:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pre-commit
+      - run: pre-commit run --files $(git ls-files ops/observability-ci)

--- a/ops/observability-ci/.pre-commit-config.yaml
+++ b/ops/observability-ci/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black

--- a/ops/observability-ci/CODEOWNERS
+++ b/ops/observability-ci/CODEOWNERS
@@ -1,0 +1,1 @@
+* @platform-ops-team

--- a/ops/observability-ci/Makefile
+++ b/ops/observability-ci/Makefile
@@ -1,0 +1,10 @@
+.PHONY: up down smoke
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+smoke:
+	./scripts/smoke-test.sh

--- a/ops/observability-ci/README.md
+++ b/ops/observability-ci/README.md
@@ -1,0 +1,30 @@
+# Observability & CI Pack
+
+This package provides reusable CI workflows and observability helpers used across Intelgraph services.
+
+## OpenTelemetry Quickstart
+
+### Node.js
+```ts
+import { initTracing } from './otel/node-tracing';
+const tracer = initTracing('my-service');
+tracer.startSpan('startup').end();
+```
+
+### Python
+```python
+from otel.python_tracing import init_tracing
+tracer = init_tracing('my-service')
+with tracer.start_as_current_span('startup'):
+    pass
+```
+
+## Local Dev Stack
+
+Run Prometheus, Grafana, Neo4j, Redis, and OPA:
+
+```sh
+make up
+```
+
+Visit Grafana at http://localhost:3000 and Prometheus at http://localhost:9090.

--- a/ops/observability-ci/commitlint.config.cjs
+++ b/ops/observability-ci/commitlint.config.cjs
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/ops/observability-ci/docker-compose.yml
+++ b/ops/observability-ci/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  neo4j:
+    image: neo4j:5
+    ports:
+      - '7474:7474'
+      - '7687:7687'
+  redis:
+    image: redis:7
+    ports:
+      - '6379:6379'
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml
+    ports:
+      - '9090:9090'
+  grafana:
+    image: grafana/grafana:latest
+    volumes:
+      - ./grafana:/var/lib/grafana/dashboards
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - '3000:3000'
+  opa:
+    image: openpolicyagent/opa:latest
+    ports:
+      - '8181:8181'

--- a/ops/observability-ci/grafana/sample-dashboard.json
+++ b/ops/observability-ci/grafana/sample-dashboard.json
@@ -1,0 +1,16 @@
+{
+  "annotations": {"list": []},
+  "panels": [
+    {
+      "type": "graph",
+      "title": "HTTP Request Duration",
+      "targets": [
+        {
+          "expr": "rate(http_request_duration_seconds_sum[5m]) / rate(http_request_duration_seconds_count[5m])"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "title": "Sample Service Dashboard"
+}

--- a/ops/observability-ci/otel/node-tracing.ts
+++ b/ops/observability-ci/otel/node-tracing.ts
@@ -1,0 +1,12 @@
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+
+export function initTracing(serviceName: string) {
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+  provider.register();
+  registerInstrumentations({});
+  return provider.getTracer(serviceName);
+}

--- a/ops/observability-ci/otel/python_tracing.py
+++ b/ops/observability-ci/otel/python_tracing.py
@@ -1,0 +1,12 @@
+from opentelemetry import trace
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+
+def init_tracing(service_name: str):
+    provider = TracerProvider(resource=Resource.create({SERVICE_NAME: service_name}))
+    processor = SimpleSpanProcessor(ConsoleSpanExporter())
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+    return trace.get_tracer(service_name)

--- a/ops/observability-ci/prometheus/alerts.yml
+++ b/ops/observability-ci/prometheus/alerts.yml
@@ -1,0 +1,17 @@
+groups:
+  - name: service-alerts
+    rules:
+      - alert: HighErrorRate
+        expr: rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: High error rate
+      - alert: HighLatency
+        expr: histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) > 0.5
+        for: 5m
+        labels:
+          severity: page
+        annotations:
+          summary: High request latency

--- a/ops/observability-ci/prometheus/prometheus.yml
+++ b/ops/observability-ci/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+rule_files:
+  - alerts.yml
+scrape_configs:
+  - job_name: node
+    static_configs:
+      - targets: ['node:3000']
+  - job_name: python
+    static_configs:
+      - targets: ['python:8000']

--- a/ops/observability-ci/release.config.js
+++ b/ops/observability-ci/release.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  branches: ['main'],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator'
+  ]
+};

--- a/ops/observability-ci/scripts/smoke-test.sh
+++ b/ops/observability-ci/scripts/smoke-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose -f "$(dirname "$0")/../docker-compose.yml" config >/dev/null
+echo "docker-compose configuration OK"

--- a/ops/observability-ci/scripts/verify-coverage.js
+++ b/ops/observability-ci/scripts/verify-coverage.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const fs = require('fs');
+let ok = true;
+const dirs = process.argv.slice(2);
+if (dirs.length === 0) {
+  console.warn('No coverage directories provided');
+  process.exit(0);
+}
+for (const dir of dirs) {
+  const file = `${dir}/coverage-summary.json`;
+  if (!fs.existsSync(file)) {
+    console.error(`Missing coverage summary for ${dir}`);
+    ok = false;
+    continue;
+  }
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const pct = data.total.lines.pct;
+  if (pct < 90) {
+    console.error(`Coverage for ${dir} is ${pct}% (<90%)`);
+    ok = false;
+  }
+}
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary
- add reusable CI workflows for Node, Python, container scans, and webapp e2e tests
- provide OpenTelemetry helpers, Prometheus config, and Grafana dashboard
- include docker-compose dev stack with Makefile, smoke tests, and coverage checks

## Testing
- `pre-commit run --config ops/observability-ci/.pre-commit-config.yaml --files $(git ls-files ops/observability-ci)`
- `bash ops/observability-ci/scripts/smoke-test.sh` *(fails: docker: command not found)*
- `node ops/observability-ci/scripts/verify-coverage.js`


------
https://chatgpt.com/codex/tasks/task_e_68a53a4be5a88333aae11878ac9a7fab