### PR TITLE
feat: add oidc gateway with step-up auth

### DIFF
--- a/services/authz-gateway/oidc/README.md
+++ b/services/authz-gateway/oidc/README.md
@@ -1,0 +1,28 @@
+# OIDC Gateway
+
+A minimal authentication service that publishes a JSON Web Key Set (JWKS) and
+enforces Authentication Context Class Reference (ACR) based step-up
+requirements on protected routes.
+
+## Endpoints
+
+- `GET /.well-known/jwks.json` – public JWKS for verifying tokens.
+- `POST /token` – issues a demo token. Body accepts `{ "sub": "user", "acr": "urn:pwd" }`.
+- `GET /sensitive` – example protected route requiring `acr` of `urn:mfa`.
+
+## Running
+
+```bash
+npm install
+node server.js
+```
+
+Generate a token with MFA and access the sensitive route:
+
+```bash
+curl -X POST http://localhost:3000/token -H 'Content-Type: application/json' \
+  -d '{"sub":"alice","acr":"urn:mfa"}'
+# => { "token": "..." }
+
+curl http://localhost:3000/sensitive -H 'Authorization: Bearer <token>'
+```

--- a/services/authz-gateway/oidc/package.json
+++ b/services/authz-gateway/oidc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@intelgraph/authz-gateway-oidc",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "jose": "^5.2.0"
+  }
+}

--- a/services/authz-gateway/oidc/server.js
+++ b/services/authz-gateway/oidc/server.js
@@ -1,0 +1,61 @@
+import express from 'express';
+import { generateKeyPair, exportJWK, jwtVerify, SignJWT } from 'jose';
+
+const app = express();
+app.use(express.json());
+
+// Generate an RSA key pair at startup. In production, use persistent keys.
+const { publicKey, privateKey } = await generateKeyPair('RS256');
+const jwk = await exportJWK(publicKey);
+jwk.use = 'sig';
+jwk.kid = 'dev-key';
+
+// Publish the JWKS for clients to validate tokens.
+app.get('/.well-known/jwks.json', (req, res) => {
+  res.json({ keys: [jwk] });
+});
+
+// Issue a token for demonstration purposes. Accepts { sub, acr } in the body.
+app.post('/token', async (req, res) => {
+  const { sub = 'user', acr = 'urn:pwd' } = req.body || {};
+  const token = await new SignJWT({ sub, acr })
+    .setProtectedHeader({ alg: 'RS256', kid: jwk.kid })
+    .setIssuedAt()
+    .setExpirationTime('10m')
+    .sign(privateKey);
+  res.json({ token });
+});
+
+// Middleware enforcing step-up based on the acr claim.
+function requireAcr(requiredAcr) {
+  return async (req, res, next) => {
+    try {
+      const auth = req.headers.authorization;
+      if (!auth) return res.status(401).json({ error: 'missing token' });
+      const token = auth.replace('Bearer ', '');
+      const { payload } = await jwtVerify(token, publicKey, {
+        algorithms: ['RS256'],
+      });
+      if (payload.acr !== requiredAcr) {
+        return res.status(403).json({
+          error: 'step-up required',
+          requiredAcr,
+        });
+      }
+      req.user = payload;
+      next();
+    } catch {
+      res.status(401).json({ error: 'invalid token' });
+    }
+  };
+}
+
+// Example protected route requiring MFA-level assurance.
+app.get('/sensitive', requireAcr('urn:mfa'), (req, res) => {
+  res.json({ ok: true, sub: req.user.sub });
+});
+
+app.listen(3000, () => {
+  // eslint-disable-next-line no-console
+  console.log('OIDC gateway listening on port 3000');
+});


### PR DESCRIPTION
## Summary
- add minimal OIDC gateway that publishes JWKS and enforces ACR-based step-up authentication

## Testing
- `npx prettier -w services/authz-gateway/oidc`
- `npx eslint services/authz-gateway/oidc --ext .js`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5400b6d1c8333bca33185b7e1ccfa