### PR TITLE
feat(webapp): add tri-pane analyst shell

### DIFF
--- a/apps/webapp/.eslintrc.cjs
+++ b/apps/webapp/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: ['plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  plugins: ['react', '@typescript-eslint'],
+  env: {
+    browser: true,
+    es2021: true,
+    jest: true,
+  },
+  settings: {
+    react: { version: 'detect' },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/apps/webapp/.gitignore
+++ b/apps/webapp/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/apps/webapp/.prettierrc
+++ b/apps/webapp/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/apps/webapp/index.html
+++ b/apps/webapp/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Intelgraph Web App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/webapp/jest.config.ts
+++ b/apps/webapp/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jest-environment-jsdom',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
+};
+
+export default config;

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "webapp",
+  "version": "1.0.0",
+  "description": "Analyst tri-pane web app",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --no-eslintrc --config .eslintrc.cjs \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --check 'src/**/*.{ts,tsx,css,html}'",
+    "test": "jest",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.1",
+    "@mui/material": "^7.3.1",
+    "@reduxjs/toolkit": "^2.8.2",
+    "cytoscape": "^3.33.1",
+    "jquery": "^3.7.1",
+    "mapbox-gl": "^3.14.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "react-redux": "^9.2.0",
+    "react-router-dom": "^7.8.1",
+    "socket.io-client": "^4.8.1",
+    "vis-timeline": "^8.3.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.2",
+    "@testing-library/jest-dom": "^6.7.0",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest": "^30.0.0",
+    "@types/jquery": "^3.5.32",
+    "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
+    "@typescript-eslint/eslint-plugin": "^8.40.0",
+    "@typescript-eslint/parser": "^8.40.0",
+    "@vitejs/plugin-react": "^5.0.1",
+    "eslint": "^9.33.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react": "^7.37.5",
+    "jest": "^30.0.5",
+    "jest-environment-jsdom": "^30.0.5",
+    "prettier": "^3.6.2",
+    "ts-jest": "^29.4.1",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.3"
+  }
+}

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -1,0 +1,12 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+  testDir: 'tests',
+};
+
+export default config;

--- a/apps/webapp/src/App.test.tsx
+++ b/apps/webapp/src/App.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { App } from './App';
+import { store, selectNode } from './store';
+
+jest.mock('cytoscape', () => () => ({
+  on: () => {},
+  container: () => document.createElement('div'),
+}));
+
+jest.mock('vis-timeline/standalone', () => ({
+  DataSet: class {
+    add() {}
+  },
+  Timeline: class {
+    on() {}
+    getWindow() {
+      return { start: new Date(), end: new Date() };
+    }
+    setSelection() {}
+    dom = { center: document.createElement('div') };
+  },
+}));
+
+jest.mock('mapbox-gl', () => ({
+  Map: class {
+    flyTo() {}
+  },
+  Marker: class {
+    setLngLat() {
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+  },
+  accessToken: '',
+}));
+
+test('renders panes', () => {
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>,
+  );
+  expect(screen.getByLabelText('toggle theme')).toBeInTheDocument();
+});
+
+test('selection updates store', () => {
+  store.dispatch(selectNode('a'));
+  expect(store.getState().selection.selectedNodeId).toBe('a');
+});

--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,0 +1,72 @@
+import { useMemo, useState } from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import {
+  ThemeProvider,
+  createTheme,
+  CssBaseline,
+  IconButton,
+  Box,
+} from '@mui/material';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+import { Provider } from 'react-redux';
+import { store } from './store';
+import { GraphPane } from './panes/GraphPane';
+import { TimelinePane } from './panes/TimelinePane';
+import { MapPane } from './panes/MapPane';
+import { CommandPalette } from './components/CommandPalette';
+
+export function App() {
+  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+
+  const toggleMode = () => setMode((m) => (m === 'light' ? 'dark' : 'light'));
+
+  return (
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <BrowserRouter>
+          <CommandPalette />
+          <Box display="flex" justifyContent="flex-end" p={1}>
+            <IconButton
+              onClick={toggleMode}
+              color="inherit"
+              aria-label="toggle theme"
+            >
+              {mode === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
+            </IconButton>
+          </Box>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <Box
+                  display="grid"
+                  gridTemplateColumns="2fr 1fr"
+                  gridTemplateRows="1fr 1fr"
+                  gridTemplateAreas="'graph timeline' 'graph map'"
+                  height="calc(100vh - 48px)"
+                >
+                  <Box gridArea="graph" borderRight={1} borderColor="divider">
+                    <GraphPane />
+                  </Box>
+                  <Box
+                    gridArea="timeline"
+                    borderBottom={1}
+                    borderColor="divider"
+                  >
+                    <TimelinePane />
+                  </Box>
+                  <Box gridArea="map">
+                    <MapPane />
+                  </Box>
+                </Box>
+              }
+            />
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
+    </Provider>
+  );
+}

--- a/apps/webapp/src/components/CommandPalette.tsx
+++ b/apps/webapp/src/components/CommandPalette.tsx
@@ -1,0 +1,23 @@
+import { Dialog } from '@mui/material';
+import { useEffect, useState } from 'react';
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <Dialog open={open} onClose={() => setOpen(false)}>
+      <div style={{ padding: 20 }}>Command palette</div>
+    </Dialog>
+  );
+}

--- a/apps/webapp/src/data/mockGraph.ts
+++ b/apps/webapp/src/data/mockGraph.ts
@@ -1,0 +1,33 @@
+export interface NodeData {
+  id: string;
+  label: string;
+  timestamp: number;
+  coords: [number, number];
+}
+
+export interface EdgeData {
+  id: string;
+  source: string;
+  target: string;
+}
+
+export interface GraphData {
+  nodes: NodeData[];
+  edges: EdgeData[];
+}
+
+const mockGraph: GraphData = {
+  nodes: [
+    { id: 'a', label: 'A', timestamp: 1710000000000, coords: [-122.4, 37.8] },
+    { id: 'b', label: 'B', timestamp: 1710003600000, coords: [-73.9, 40.7] },
+    { id: 'c', label: 'C', timestamp: 1710007200000, coords: [2.35, 48.85] },
+  ],
+  edges: [
+    { id: 'ab', source: 'a', target: 'b' },
+    { id: 'bc', source: 'b', target: 'c' },
+  ],
+};
+
+export async function fetchGraph(): Promise<GraphData> {
+  return Promise.resolve(mockGraph);
+}

--- a/apps/webapp/src/featureFlags.ts
+++ b/apps/webapp/src/featureFlags.ts
@@ -1,0 +1,1 @@
+export const useMockData = true;

--- a/apps/webapp/src/main.tsx
+++ b/apps/webapp/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+import { store } from './store';
+
+// Expose store for tests
+(window as any).store = store;
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/webapp/src/panes/GraphPane.tsx
+++ b/apps/webapp/src/panes/GraphPane.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import cytoscape from 'cytoscape';
+import $ from 'jquery';
+import { useDispatch } from 'react-redux';
+import { fetchGraph } from '../data/mockGraph';
+import { selectNode } from '../store';
+
+export function GraphPane() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    fetchGraph().then((data) => {
+      const cy = cytoscape({
+        container: containerRef.current!,
+        elements: [
+          ...data.nodes.map((n) => ({ data: { id: n.id, label: n.label } })),
+          ...data.edges.map((e) => ({
+            data: { id: e.id, source: e.source, target: e.target },
+          })),
+        ],
+        style: [{ selector: 'node', style: { label: 'data(label)' } }],
+        layout: { name: 'grid' },
+      });
+
+      cy.on('select', (evt) => dispatch(selectNode(evt.target.id())));
+      cy.on('unselect', () => dispatch(selectNode(null)));
+
+      // jQuery drag stub
+      $(cy.container() as HTMLElement).on('mousedown', () => {
+        $(document).on('mouseup.graphDrag', () => {
+          $(document).off('.graphDrag');
+        });
+      });
+
+      // jQuery context menu stub
+      $(cy.container() as HTMLElement).on('contextmenu', (e: JQuery.Event) => {
+        e.preventDefault();
+      });
+    });
+  }, [dispatch]);
+
+  return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />;
+}

--- a/apps/webapp/src/panes/MapPane.tsx
+++ b/apps/webapp/src/panes/MapPane.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
+import { useSelector } from 'react-redux';
+import { fetchGraph, GraphData } from '../data/mockGraph';
+import type { RootState } from '../store';
+
+mapboxgl.accessToken = 'no-token';
+
+export function MapPane() {
+  const mapContainer = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<mapboxgl.Map | null>(null);
+  const selectedNode = useSelector(
+    (s: RootState) => s.selection.selectedNodeId,
+  );
+  const graphDataRef = useRef<GraphData | null>(null);
+
+  useEffect(() => {
+    const map = new mapboxgl.Map({
+      container: mapContainer.current!,
+      style: 'https://demotiles.maplibre.org/style.json',
+      center: [0, 0],
+      zoom: 1,
+    });
+    mapRef.current = map;
+    fetchGraph().then((data) => {
+      graphDataRef.current = data;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!mapRef.current || !graphDataRef.current) return;
+    const map = mapRef.current;
+    (map as any).__marker?.remove();
+    if (selectedNode) {
+      const node = graphDataRef.current.nodes.find(
+        (n) => n.id === selectedNode,
+      );
+      if (node) {
+        (map as any).__marker = new mapboxgl.Marker()
+          .setLngLat(node.coords)
+          .addTo(map);
+        map.flyTo({ center: node.coords, zoom: 3 });
+      }
+    }
+  }, [selectedNode]);
+
+  return <div ref={mapContainer} style={{ width: '100%', height: '100%' }} />;
+}

--- a/apps/webapp/src/panes/TimelinePane.tsx
+++ b/apps/webapp/src/panes/TimelinePane.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import { DataSet, Timeline } from 'vis-timeline/standalone';
+import $ from 'jquery';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchGraph } from '../data/mockGraph';
+import { RootState, selectNode, setTimeRange } from '../store';
+
+export function TimelinePane() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const timelineRef = useRef<Timeline | null>(null);
+  const dispatch = useDispatch();
+  const selectedNode = useSelector(
+    (s: RootState) => s.selection.selectedNodeId,
+  );
+
+  useEffect(() => {
+    fetchGraph().then((data) => {
+      const items = new DataSet(
+        data.nodes.map((n) => ({
+          id: n.id,
+          content: n.label,
+          start: n.timestamp,
+        })),
+      );
+      const timeline = new Timeline(containerRef.current!, items, {});
+      timelineRef.current = timeline;
+
+      timeline.on('select', (props) => {
+        const id = props.items[0];
+        dispatch(selectNode(id ?? null));
+      });
+
+      // jQuery time-brushing stub
+      $((timeline as any).dom.center).on('mouseup', () => {
+        const range = timeline.getWindow();
+        dispatch(setTimeRange([range.start.valueOf(), range.end.valueOf()]));
+      });
+    });
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (timelineRef.current) {
+      (timelineRef.current as any).setSelection(
+        selectedNode ? [selectedNode] : [],
+        {
+          focus: true,
+          animation: false,
+        },
+      );
+    }
+  }, [selectedNode]);
+
+  return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />;
+}

--- a/apps/webapp/src/socket.ts
+++ b/apps/webapp/src/socket.ts
@@ -1,0 +1,6 @@
+import { io, Socket } from 'socket.io-client';
+
+export function createSocket(): Socket {
+  // Stub without real connection
+  return io('', { autoConnect: false });
+}

--- a/apps/webapp/src/store.ts
+++ b/apps/webapp/src/store.ts
@@ -1,0 +1,30 @@
+import { configureStore, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface SelectionState {
+  selectedNodeId: string | null;
+  timeRange: [number, number] | null;
+}
+
+const initialState: SelectionState = { selectedNodeId: null, timeRange: null };
+
+const selectionSlice = createSlice({
+  name: 'selection',
+  initialState,
+  reducers: {
+    selectNode(state, action: PayloadAction<string | null>) {
+      state.selectedNodeId = action.payload;
+    },
+    setTimeRange(state, action: PayloadAction<[number, number] | null>) {
+      state.timeRange = action.payload;
+    },
+  },
+});
+
+export const { selectNode, setTimeRange } = selectionSlice.actions;
+
+export const store = configureStore({
+  reducer: { selection: selectionSlice.reducer },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/apps/webapp/src/test/setup.ts
+++ b/apps/webapp/src/test/setup.ts
@@ -1,0 +1,4 @@
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+(globalThis as any).TextEncoder = TextEncoder;
+(globalThis as any).TextDecoder = TextDecoder as any;

--- a/apps/webapp/tests/e2e.spec.ts
+++ b/apps/webapp/tests/e2e.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test('load graph and select node', async ({ page }) => {
+  await page.goto('http://localhost:5173/');
+  await expect(page.getByLabel('toggle theme')).toBeVisible();
+  // dispatch selection via exposed store
+  await page.evaluate(() => {
+    (window as any).store.dispatch({
+      type: 'selection/selectNode',
+      payload: 'a',
+    });
+  });
+  const selected = await page.evaluate(
+    () => (window as any).store.getState().selection.selectedNodeId,
+  );
+  expect(selected).toBe('a');
+});

--- a/apps/webapp/tsconfig.json
+++ b/apps/webapp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest", "jquery", "node"]
+  },
+  "include": ["src"]
+}

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold webapp with Redux state, routing, and dark/light theme toggle
- integrate Cytoscape graph, timeline, and Mapbox map panes with mock data
- add command palette and basic unit/e2e test setup
- remove package lock and ignore binary artifacts

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a539ec781c8333aa3c7e8335481466