### PR TITLE
feat(exporter): add deterministic export bundles

### DIFF
--- a/services/exporter/.eslintrc.cjs
+++ b/services/exporter/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2021: true,
+    jest: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {},
+};

--- a/services/exporter/.gitignore
+++ b/services/exporter/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+coverage
+dist
+*.zip
+*.pdf
+package-lock.json

--- a/services/exporter/.prettierrc
+++ b/services/exporter/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 80
+}

--- a/services/exporter/jest.config.js
+++ b/services/exporter/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/services/exporter/package.json
+++ b/services/exporter/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@intelgraph/exporter",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "jest",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.cjs .",
+    "format": "prettier --check ."
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.0.0",
+    "json-stable-stringify": "^1.0.1",
+    "jszip": "^3.10.1",
+    "pdf-lib": "^1.17.1",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^18.17.0",
+    "@types/uuid": "^10.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.14.0",
+    "@typescript-eslint/parser": "^6.14.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^8.8.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.0.0",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/services/exporter/src/exporter.ts
+++ b/services/exporter/src/exporter.ts
@@ -1,0 +1,94 @@
+import JSZip from 'jszip';
+import stringify from 'json-stable-stringify';
+import { v5 as uuidv5 } from 'uuid';
+import { applyRedactions, RedactRule } from './redact';
+import { createPdf } from './pdf';
+import { sha256, sortObject } from './utils';
+
+export interface ExportRequest {
+  entities: Record<string, unknown>[];
+  edges: Record<string, unknown>[];
+  redactRules: RedactRule[];
+  format: Array<'json' | 'csv' | 'pdf'>;
+}
+
+const NAMESPACE = uuidv5.URL;
+const fixedDate = new Date('2000-01-01T00:00:00Z');
+
+const toCsv = (data: Record<string, unknown>[]): string => {
+  if (data.length === 0) return '';
+  const headers = Array.from(
+    new Set(data.flatMap((d) => Object.keys(d))),
+  ).sort();
+  const escape = (val: unknown) => {
+    const str = val == null ? '' : String(val);
+    if (/[",\n]/.test(str)) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+  const rows = data
+    .map((row) =>
+      headers.map((h) => escape((row as Record<string, unknown>)[h])),
+    )
+    .map((r) => r.join(','));
+  return [headers.join(','), ...rows].join('\n');
+};
+
+export const createExport = async (req: ExportRequest): Promise<Buffer> => {
+  const files: { path: string; content: Buffer }[] = [];
+  const redactionLog: string[] = [];
+
+  const entities = applyRedactions(req.entities, req.redactRules, redactionLog);
+  const edges = applyRedactions(req.edges, req.redactRules, redactionLog);
+
+  if (req.format.includes('json')) {
+    const entStr = stringify(sortObject(entities)) as string;
+    files.push({ path: 'data/entities.json', content: Buffer.from(entStr) });
+    const edgeStr = stringify(sortObject(edges)) as string;
+    files.push({ path: 'data/edges.json', content: Buffer.from(edgeStr) });
+  }
+
+  if (req.format.includes('csv')) {
+    const entCsv = toCsv(entities);
+    files.push({ path: 'data/entities.csv', content: Buffer.from(entCsv) });
+    const edgeCsv = toCsv(edges);
+    files.push({ path: 'data/edges.csv', content: Buffer.from(edgeCsv) });
+  }
+
+  if (req.format.includes('pdf')) {
+    const pdfBuf = await createPdf(entities.length, edges.length);
+    files.push({ path: 'figures/graph.pdf', content: pdfBuf });
+  }
+
+  if (redactionLog.length) {
+    files.push({
+      path: 'redaction.log',
+      content: Buffer.from(redactionLog.join('\n')),
+    });
+  }
+
+  const manifestEntries = files.map((f) => ({
+    path: f.path,
+    sha256: sha256(f.content),
+    uuid: uuidv5(f.path, NAMESPACE),
+  }));
+
+  const manifest = {
+    generatedAt: fixedDate.toISOString(),
+    chainOfCustody: [{ event: 'export', timestamp: fixedDate.toISOString() }],
+    files: manifestEntries.sort((a, b) => a.path.localeCompare(b.path)),
+  };
+  const manifestStr = stringify(manifest) as string;
+  files.push({ path: 'manifest.json', content: Buffer.from(manifestStr) });
+
+  const zip = new JSZip();
+  for (const f of files.sort((a, b) => a.path.localeCompare(b.path))) {
+    zip.file(f.path, f.content, { date: fixedDate });
+  }
+  return await zip.generateAsync({
+    type: 'nodebuffer',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 9 },
+  });
+};

--- a/services/exporter/src/index.ts
+++ b/services/exporter/src/index.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import helmet from 'helmet';
+import { createExport, ExportRequest } from './exporter';
+
+const app = express();
+app.use(express.json());
+app.use(helmet());
+
+app.post('/export', async (req, res) => {
+  const body = req.body as ExportRequest;
+  try {
+    const zip = await createExport(body);
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', 'attachment; filename="export.zip"');
+    res.send(zip);
+  } catch (err) {
+    res.status(400).json({ error: 'export_failed' });
+  }
+});
+
+export default app;
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => console.log(`Exporter listening on ${port}`));
+}

--- a/services/exporter/src/pdf.ts
+++ b/services/exporter/src/pdf.ts
@@ -1,0 +1,30 @@
+import { PDFDocument, StandardFonts, rgb, PDFHexString } from 'pdf-lib';
+
+export const createPdf = async (
+  entitiesLen: number,
+  edgesLen: number,
+): Promise<Buffer> => {
+  const pdfDoc = await PDFDocument.create();
+  const fixedDate = new Date('2000-01-01T00:00:00Z');
+  pdfDoc.setCreationDate(fixedDate);
+  pdfDoc.setModificationDate(fixedDate);
+  const id = pdfDoc.context.obj([
+    PDFHexString.fromText('0000000000000000'),
+    PDFHexString.fromText('0000000000000000'),
+  ]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (pdfDoc.context.trailerInfo as any).ID = id;
+  const page = pdfDoc.addPage();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const { height } = page.getSize();
+  const text = `Graph Snapshot\nEntities: ${entitiesLen}\nEdges: ${edgesLen}`;
+  page.drawText(text, {
+    x: 50,
+    y: height - 50,
+    size: 12,
+    font,
+    color: rgb(0, 0, 0),
+  });
+  const pdfBytes = await pdfDoc.save({ useObjectStreams: false });
+  return Buffer.from(pdfBytes);
+};

--- a/services/exporter/src/redact.ts
+++ b/services/exporter/src/redact.ts
@@ -1,0 +1,30 @@
+export interface RedactRule {
+  field: string;
+  action: 'drop' | 'mask';
+}
+
+export const applyRedactions = (
+  data: Record<string, unknown>[],
+  rules: RedactRule[],
+  log: string[],
+): Record<string, unknown>[] => {
+  return data.map((item) => {
+    const clone: Record<string, unknown> = JSON.parse(JSON.stringify(item));
+    for (const rule of rules) {
+      if (
+        rule.action === 'drop' &&
+        Object.prototype.hasOwnProperty.call(clone, rule.field)
+      ) {
+        delete clone[rule.field];
+        log.push(`drop:${rule.field}`);
+      } else if (
+        rule.action === 'mask' &&
+        Object.prototype.hasOwnProperty.call(clone, rule.field)
+      ) {
+        clone[rule.field] = 'REDACTED';
+        log.push(`mask:${rule.field}`);
+      }
+    }
+    return clone;
+  });
+};

--- a/services/exporter/src/utils.ts
+++ b/services/exporter/src/utils.ts
@@ -1,0 +1,22 @@
+import { createHash } from 'crypto';
+
+export const sha256 = (buf: Buffer): string =>
+  createHash('sha256').update(buf).digest('hex');
+
+export const sortObject = (obj: unknown): unknown => {
+  if (Array.isArray(obj)) {
+    return obj
+      .map((v) => sortObject(v))
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  }
+  if (obj && typeof obj === 'object') {
+    const sorted: Record<string, unknown> = {};
+    Object.keys(obj as Record<string, unknown>)
+      .sort()
+      .forEach((k) => {
+        sorted[k] = sortObject((obj as Record<string, unknown>)[k]);
+      });
+    return sorted;
+  }
+  return obj;
+};

--- a/services/exporter/tests/exporter.test.ts
+++ b/services/exporter/tests/exporter.test.ts
@@ -1,0 +1,34 @@
+import { createExport, ExportRequest } from '../src/exporter';
+import JSZip from 'jszip';
+import { createHash } from 'crypto';
+
+const sample: ExportRequest = {
+  entities: [{ id: '1', name: 'Alice', secret: 's1' }],
+  edges: [{ source: '1', target: '2', weight: 5, secret: 'e1' }],
+  redactRules: [{ field: 'secret', action: 'drop' }],
+  format: ['json', 'csv', 'pdf'],
+};
+
+describe('exporter', () => {
+  it('creates manifest with correct hashes', async () => {
+    const zipBuf = await createExport(sample);
+    const zip = await JSZip.loadAsync(zipBuf);
+    const manifestStr = await zip.file('manifest.json')!.async('string');
+    const manifest = JSON.parse(manifestStr);
+    for (const file of manifest.files) {
+      const content = await zip.file(file.path)!.async('nodebuffer');
+      const hash = createHash('sha256').update(content).digest('hex');
+      expect(hash).toBe(file.sha256);
+    }
+    const entitiesJson = await zip.file('data/entities.json')!.async('string');
+    expect(entitiesJson).toBe('[{"id":"1","name":"Alice"}]');
+  });
+
+  it('produces identical zip for same input', async () => {
+    const z1 = await createExport(sample);
+    const z2 = await createExport(sample);
+    const h1 = createHash('sha256').update(z1).digest('hex');
+    const h2 = createHash('sha256').update(z2).digest('hex');
+    expect(h1).toBe(h2);
+  });
+});

--- a/services/exporter/tsconfig.json
+++ b/services/exporter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- add exporter service to build deterministic zip bundles with manifest and redaction
- support json, csv, and pdf outputs with stable UUIDv5 hashes
- ensure identical input yields identical archive via tests
- inline manifest snapshot in unit tests to avoid snapshot files
- ignore generated zip/pdf and lock files so binary artifacts are not committed
- remove committed lockfile from exporter service

## Testing
- `npm run lint` (services/exporter)
- `npm run format` (services/exporter)
- `npm test` (services/exporter)
- `npm run lint` (fails: Cannot find package 'typescript-eslint')
- `npm run format` (fails: Map keys must be unique in workflow YAML)
- `npm test` (fails: jest-environment-jsdom cannot be found)


------
https://chatgpt.com/codex/tasks/task_e_68a53a21cd7c8333958166b61b92e7f4