### PR TITLE
feat: improve entity normalization

### DIFF
--- a/server/src/tests/entityResolution.normalization.test.ts
+++ b/server/src/tests/entityResolution.normalization.test.ts
@@ -1,0 +1,23 @@
+import { EntityResolutionService } from '../services/EntityResolutionService';
+
+describe('EntityResolutionService normalization', () => {
+  const svc = new EntityResolutionService();
+  const normalize = (input: any) => (svc as any).normalizeEntityProperties(input);
+  const key = (input: any) => (svc as any).generateCanonicalKey(normalize(input));
+
+  it('normalizes emails and aliases', () => {
+    const props = normalize({ email: 'User.Name+spam@Gmail.com ' });
+    expect(props.email).toBe('username@gmail.com');
+  });
+
+  it('normalizes urls', () => {
+    const props = normalize({ url: 'https://Example.com/Path/?utm=1' });
+    expect(props.url).toBe('example.com/path');
+  });
+
+  it('creates same key for equivalent values', () => {
+    const k1 = key({ name: 'José Ángel', email: 'USER@EXAMPLE.com' });
+    const k2 = key({ name: 'José  Angel', email: 'user@example.com' });
+    expect(k1).toBe(k2);
+  });
+});


### PR DESCRIPTION
## Summary
- enhance entity property normalization with unicode, email alias, and URL handling
- generate canonical keys via sorted normalized fields
- add unit tests for normalization edge cases

## Testing
- `npx eslint server/src/services/EntityResolutionService.ts server/src/tests/entityResolution.normalization.test.ts` *(fails: Cannot find package 'typescript-eslint')*
- `cd server && npm test` *(fails: jest-junit missing; `npm install` failed building canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68a55b757e948333b65f2cf7915f343f