### PR TITLE
feat: enrich provenance metadata

### DIFF
--- a/prov-ledger/app/api.py
+++ b/prov-ledger/app/api.py
@@ -33,7 +33,15 @@ async def extract(submit: SubmitText, _: None = Depends(api_key_auth)):
 @router.post("/evidence/register", response_model=Evidence)
 async def register_evidence(e: Evidence, _: None = Depends(api_key_auth)):
     check_request(e.title or "")
-    evid = evidence.register_evidence(e.kind, url=e.url, title=e.title)
+    evid = evidence.register_evidence(
+        e.kind,
+        url=e.url,
+        title=e.title,
+        source_uri=e.source_uri,
+        connector=e.connector,
+        transforms=e.transforms,
+        actor=e.actor or "system",
+    )
     provenance.add_evidence(evid)
     return Evidence(**evid)
 

--- a/prov-ledger/app/claims.py
+++ b/prov-ledger/app/claims.py
@@ -1,8 +1,10 @@
 from datetime import datetime
-from typing import Dict
+from typing import Dict, List, Optional
 import uuid
+from io import BytesIO
 
 from .nlp.embedder import embed
+from .hashing import sha256_digest
 
 STOPWORDS = {"the", "a", "an", "of", "and", "to"}
 
@@ -14,16 +16,29 @@ def normalize(text: str) -> str:
     return " ".join(tokens)
 
 
-def create_claim(text: str) -> dict:
+def create_claim(
+    text: str,
+    source_uri: Optional[str] = None,
+    connector: Optional[str] = None,
+    transforms: Optional[List[str]] = None,
+    actor: str = "system",
+) -> dict:
+    """Create a claim with provenance metadata."""
     cid = str(uuid.uuid4())
     norm = normalize(text)
     emb = embed(norm)
+    payload_hash, _ = sha256_digest(BytesIO(text.encode("utf-8")))
     claim = {
         "id": cid,
         "text": text,
         "normalized": norm,
         "embedding": emb,
         "created_at": datetime.utcnow().isoformat(),
+        "source_uri": source_uri,
+        "connector": connector,
+        "transforms": transforms or [],
+        "payload_hash": payload_hash,
+        "actor": actor,
         "evidence": [],
     }
     _claims[cid] = claim

--- a/prov-ledger/app/evidence.py
+++ b/prov-ledger/app/evidence.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict
+from typing import Dict, List, Optional
 import uuid
 from io import BytesIO
 
@@ -9,7 +9,18 @@ from .signatures import verify_signature
 _evidence: Dict[str, dict] = {}
 
 
-def register_evidence(kind: str, url: str | None = None, content: bytes | None = None, title: str | None = None, signature: bytes | None = None, public_key: str | None = None) -> dict:
+def register_evidence(
+    kind: str,
+    url: Optional[str] = None,
+    content: bytes | None = None,
+    title: Optional[str] = None,
+    signature: bytes | None = None,
+    public_key: str | None = None,
+    source_uri: Optional[str] = None,
+    connector: Optional[str] = None,
+    transforms: Optional[List[str]] = None,
+    actor: str = "system",
+) -> dict:
     evid_id = str(uuid.uuid4())
     data = content or (url or "").encode()
     h, length = sha256_digest(BytesIO(data))
@@ -27,6 +38,10 @@ def register_evidence(kind: str, url: str | None = None, content: bytes | None =
         "created_at": datetime.utcnow().isoformat(),
         "signed": signed,
         "signer_fp": signer_fp,
+        "source_uri": source_uri,
+        "connector": connector,
+        "transforms": transforms or [],
+        "actor": actor,
     }
     _evidence[evid_id] = evid
     return evid

--- a/prov-ledger/app/provenance.py
+++ b/prov-ledger/app/provenance.py
@@ -1,5 +1,6 @@
 import networkx as nx
 from typing import Dict
+from datetime import datetime
 
 _graph = nx.DiGraph()
 
@@ -14,7 +15,12 @@ def add_evidence(evid: dict) -> None:
 
 def attach(claim_id: str, evidence_id: str, agent: str = "system") -> None:
     act_id = f"attach:{claim_id}:{evidence_id}"
-    _graph.add_node(act_id, type="activity", agent=agent)
+    _graph.add_node(
+        act_id,
+        type="activity",
+        agent=agent,
+        timestamp=datetime.utcnow().isoformat(),
+    )
     _graph.add_edge(act_id, claim_id)
     _graph.add_edge(act_id, evidence_id)
 

--- a/prov-ledger/app/schemas.py
+++ b/prov-ledger/app/schemas.py
@@ -14,6 +14,11 @@ class Claim(BaseModel):
     normalized: str
     embedding: Optional[List[float]] = None
     created_at: str
+    source_uri: Optional[str] = None
+    connector: Optional[str] = None
+    transforms: List[str] = []
+    payload_hash: Optional[str] = None
+    actor: Optional[str] = None
 
 
 class Evidence(BaseModel):
@@ -26,6 +31,10 @@ class Evidence(BaseModel):
     created_at: Optional[str] = None
     signed: Optional[bool] = False
     signer_fp: Optional[str] = None
+    source_uri: Optional[str] = None
+    connector: Optional[str] = None
+    transforms: List[str] = []
+    actor: Optional[str] = None
 
 
 class AttachEvidenceRequest(BaseModel):

--- a/prov-ledger/tests/test_claim_evidence_metadata.py
+++ b/prov-ledger/tests/test_claim_evidence_metadata.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app import claims, evidence, provenance
+
+
+def test_claim_and_evidence_metadata():
+    claim = claims.create_claim(
+        "Test claim",
+        source_uri="http://src",
+        connector="csv",
+        transforms=["trim"],
+        actor="tester",
+    )
+    evid = evidence.register_evidence(
+        "url",
+        url="http://evid",
+        source_uri="http://src",
+        connector="csv",
+        transforms=["download"],
+        actor="tester",
+    )
+    provenance.add_claim(claim)
+    provenance.add_evidence(evid)
+    provenance.attach(claim["id"], evid["id"], agent="tester")
+    assert claim["source_uri"] == "http://src"
+    assert evid["connector"] == "csv"
+    sg = provenance.subgraph_for_claim(claim["id"])
+    act_nodes = [n for n, d in sg.nodes(data=True) if d.get("type") == "activity"]
+    assert act_nodes, "activity node missing"
+    act = sg.nodes[act_nodes[0]]
+    assert act["agent"] == "tester"
+    assert act["timestamp"]


### PR DESCRIPTION
## Summary
- capture source, connector, transform chain, and actor when creating claims and evidence
- timestamp provenance attachment events
- add unit test covering provenance metadata

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run format` *(fails: SyntaxError in workflow YAML)*
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `cd prov-ledger && pytest -c pyproject.toml`


------
https://chatgpt.com/codex/tasks/task_e_68a55b95e64c83338282dec712ab2ca5