### PR TITLE
feat: integrate graph-xai explanations

### DIFF
--- a/apps/web/src/components/panels/EntityDrawer.tsx
+++ b/apps/web/src/components/panels/EntityDrawer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { X, ExternalLink, Edit3, Trash2, Tag, Calendar, User, MapPin } from 'lucide-react'
+import { X, ExternalLink, Edit3, Trash2, Tag, Calendar, User, MapPin, HelpCircle } from 'lucide-react'
 import {
   Drawer,
   DrawerContent,
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip'
 import { formatDate, getRiskColor, capitalizeFirst } from '@/lib/utils'
 import type { Entity, Relationship, PanelProps } from '@/types'
+import { ExplainDrawer } from './ExplainDrawer'
 
 interface EntityDrawerProps extends PanelProps<Entity[]> {
   open: boolean
@@ -34,6 +35,7 @@ export function EntityDrawer({
   relationships = [],
 }: EntityDrawerProps) {
   const selectedEntity = entities.find(e => e.id === selectedEntityId)
+  const [explainOpen, setExplainOpen] = React.useState(false)
 
   const getEntityIcon = (type: string) => {
     switch (type) {
@@ -82,6 +84,7 @@ export function EntityDrawer({
   }
 
   return (
+    <>
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent side="right" className="w-96">
         <DrawerHeader>
@@ -137,6 +140,19 @@ export function EntityDrawer({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Export entity</TooltipContent>
+              </Tooltip>
+
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setExplainOpen(true)}
+                  >
+                    <HelpCircle className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Explain</TooltipContent>
               </Tooltip>
             </div>
           </div>
@@ -293,6 +309,13 @@ export function EntityDrawer({
         </div>
       </DrawerContent>
     </Drawer>
+    <ExplainDrawer
+      sourceId={selectedEntity.id}
+      targetId={relatedEntities[0]?.id || selectedEntity.id}
+      open={explainOpen}
+      onOpenChange={setExplainOpen}
+    />
+    </>
   )
 }
 

--- a/apps/web/src/components/panels/ExplainDrawer.tsx
+++ b/apps/web/src/components/panels/ExplainDrawer.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react'
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/Drawer'
+import { Badge } from '@/components/ui/Badge'
+import { gql, useQuery } from '@apollo/client'
+import ethics from '../../../../../graph-xai/docs/ETHICS.md?raw'
+
+const EXPLAIN_QUERY = gql`
+  query ExplainConnection($sourceId: ID!, $targetId: ID!) {
+    explainConnection(sourceId: $sourceId, targetId: $targetId) {
+      traceId
+      paths { nodes edges }
+      featureAttributions { feature importance }
+      fairnessFlags
+      limitations
+    }
+  }
+`
+
+interface ExplainDrawerProps {
+  sourceId: string
+  targetId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ExplainDrawer({ sourceId, targetId, open, onOpenChange }: ExplainDrawerProps) {
+  const { data, loading } = useQuery(EXPLAIN_QUERY, { variables: { sourceId, targetId }, skip: !open })
+  const explanation = data?.explainConnection
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent side="right" className="w-96 p-4 space-y-4">
+        <DrawerHeader>
+          <DrawerTitle>Explanation</DrawerTitle>
+        </DrawerHeader>
+        {loading && <div>Loading…</div>}
+        {explanation && (
+          <div className="space-y-3 overflow-y-auto">
+            <div>
+              <h4 className="font-medium">Top Paths</h4>
+              {explanation.paths.map((p: any, i: number) => (
+                <div key={i} className="text-sm mt-1">
+                  {p.nodes.join(' → ')}
+                </div>
+              ))}
+            </div>
+            <div>
+              <h4 className="font-medium">Feature Attribution</h4>
+              {explanation.featureAttributions.map((f: any) => (
+                <div key={f.feature} className="flex items-center gap-2 text-sm">
+                  <span className="flex-1">{f.feature}</span>
+                  <Badge variant="secondary">{(f.importance * 100).toFixed(1)}%</Badge>
+                </div>
+              ))}
+            </div>
+            {explanation.fairnessFlags?.length > 0 && (
+              <div>
+                <h4 className="font-medium">Fairness</h4>
+                {explanation.fairnessFlags.map((f: string) => (
+                  <Badge key={f} variant="destructive" className="mr-1">{f}</Badge>
+                ))}
+              </div>
+            )}
+            {explanation.limitations?.length > 0 && (
+              <div className="text-xs text-muted-foreground">
+                {explanation.limitations.join(' ')}
+              </div>
+            )}
+            <div className="text-xs text-muted-foreground whitespace-pre-wrap">{ethics}</div>
+          </div>
+        )}
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/graph-xai/app/main.py
+++ b/graph-xai/app/main.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, HTTPException
 
 from .api import router
 
 app = FastAPI(title="Graph XAI")
 app.include_router(router)
+
+MAX_BODY = 1_000_000
+
+@app.middleware("http")
+async def limit_body(request: Request, call_next):
+    body = await request.body()
+    if len(body) > MAX_BODY:
+        raise HTTPException(status_code=413, detail="Request too large")
+    request._body = body
+    return await call_next(request)

--- a/graph-xai/infra/Dockerfile
+++ b/graph-xai/infra/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY .. /app
 RUN pip install .
 EXPOSE 8090
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8090"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8090", "--timeout-keep-alive", "5", "--limit-concurrency", "100"]

--- a/graph-xai/infra/helm/graph-xai/templates/deployment.yaml
+++ b/graph-xai/infra/helm/graph-xai/templates/deployment.yaml
@@ -17,3 +17,22 @@ spec:
           image: {{ .Values.image }}
           ports:
             - containerPort: 8090
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8090
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -125,6 +125,7 @@ export const createApp = async () => {
     "./graphql/plugins/auditLogger.js"
   );
   const { depthLimit } = await import("./graphql/validation/depthLimit.js");
+  const { rateLimiting } = await import('./graphql/middleware/rateLimiting.js');
 
   const apollo = new ApolloServer({
     schema,
@@ -178,8 +179,9 @@ export const createApp = async () => {
 
   app.use(
     "/graphql",
-    express.json(),
+    express.json({ limit: '1mb' }),
     authenticateToken, // WAR-GAMED SIMULATION - Add authentication middleware here
+    rateLimiting,
     expressMiddleware(apollo, { context: getContext }),
   );
 

--- a/server/src/controllers/MLController.js
+++ b/server/src/controllers/MLController.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const { getNeo4jDriver, getPostgresPool } = require('../config/database');
+const { advancedMLService } = require('../services/AdvancedMLService.js');
 
 class MLController {
   async trainModel(req, res) {
@@ -97,6 +98,24 @@ class MLController {
       }
     } catch (e) {
       return res.status(500).json({ success: false, error: e.message });
+    }
+  }
+
+  async getExplanations(req, res) {
+    try {
+      const { sourceId, targetId, edgeId, mode = 'why' } = req.query || {};
+      const data = await advancedMLService.getExplanations({
+        sourceId,
+        targetId,
+        edgeId,
+        mode
+      });
+      if (data.traceId) {
+        res.set('x-trace-id', data.traceId);
+      }
+      return res.json(data);
+    } catch (e) {
+      return res.status(500).json({ error: e.message });
     }
   }
 }

--- a/server/src/graphql/middleware/rateLimiting.ts
+++ b/server/src/graphql/middleware/rateLimiting.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express'
+
+interface Bucket { count: number; expires: number }
+const buckets = new Map<string, Bucket>()
+const WINDOW = 60_000
+const MAX = 100
+
+export function rateLimiting(req: Request, res: Response, next: NextFunction) {
+  const user = (req as any).user?.id || req.ip
+  const now = Date.now()
+  const bucket = buckets.get(user)
+  if (!bucket || bucket.expires < now) {
+    buckets.set(user, { count: 1, expires: now + WINDOW })
+    return next()
+  }
+  if (bucket.count >= MAX) {
+    return res.status(429).json({ error: 'Rate limit exceeded' })
+  }
+  bucket.count++
+  next()
+}

--- a/server/src/graphql/resolvers-combined.ts
+++ b/server/src/graphql/resolvers-combined.ts
@@ -4,6 +4,7 @@ const copilotResolvers = require('./resolvers.copilot.js');
 const graphResolvers = require('./resolvers.graphops.js');
 const aiResolvers = require('./resolvers.ai.js');
 const annotationsResolvers = require('./resolvers.annotations.js');
+import { advancedMLService } from '../services/AdvancedMLService.js';
 import { v4 as uuidv4 } from 'uuid';
 
 interface User {
@@ -66,6 +67,28 @@ export const resolvers = {
       return investigationId
         ? goals.filter(g => g.investigationId === String(investigationId))
         : goals;
+    },
+    explainConnection: async (_: any, { sourceId, targetId }: any, ctx: Context) => {
+      const start = Date.now();
+      const result = await advancedMLService.getExplanations({ sourceId, targetId, mode: 'why' });
+      ctx.audit = {
+        action: 'explanation_requested',
+        traceId: result.traceId,
+        input: { sourceId, targetId },
+        latency: Date.now() - start
+      };
+      return result;
+    },
+    counterfactualEdge: async (_: any, { edgeId, target }: any, ctx: Context) => {
+      const start = Date.now();
+      const result = await advancedMLService.getExplanations({ edgeId, target, mode: 'counterfactual' });
+      ctx.audit = {
+        action: 'explanation_requested',
+        traceId: result.traceId,
+        input: { edgeId, target },
+        latency: Date.now() - start
+      };
+      return result;
     }
   },
 

--- a/server/src/graphql/schema.js
+++ b/server/src/graphql/schema.js
@@ -4,6 +4,7 @@ const { graphTypeDefs } = require('./schema.graphops.js');
 const { aiTypeDefs } = require('./schema.ai.js');
 const { annotationsTypeDefs } = require('./schema.annotations.js');
 const graphragTypes = require('./types/graphragTypes.js');
+const { explanationTypeDefs } = require('./typeDefs/explanations.js');
 
 const base = gql`
   scalar JSON
@@ -13,4 +14,4 @@ const base = gql`
   type Subscription { _empty: String }
 `;
 
-export const typeDefs = [base, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs, annotationsTypeDefs];
+export const typeDefs = [base, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs, annotationsTypeDefs, explanationTypeDefs];

--- a/server/src/graphql/typeDefs/explanations.js
+++ b/server/src/graphql/typeDefs/explanations.js
@@ -1,0 +1,38 @@
+const gql = require('graphql-tag');
+
+const explanationTypeDefs = gql`
+  type ExplanationPath {
+    nodes: [ID!]!
+    edges: [ID!]!
+  }
+
+  type FeatureAttribution {
+    feature: String!
+    importance: Float!
+  }
+
+  type Explanation {
+    paths: [ExplanationPath!]!
+    featureAttributions: [FeatureAttribution!]!
+    fairnessFlags: [String!]
+    limitations: [String!]
+    traceId: ID!
+  }
+
+  type CounterfactualChange {
+    edgeId: ID!
+    action: String!
+  }
+
+  type Counterfactual {
+    changes: [CounterfactualChange!]!
+    traceId: ID!
+  }
+
+  extend type Query {
+    explainConnection(sourceId: ID!, targetId: ID!): Explanation!
+    counterfactualEdge(edgeId: ID!, target: Float!): Counterfactual!
+  }
+`;
+
+module.exports = { explanationTypeDefs };

--- a/server/src/monitoring/metrics.js
+++ b/server/src/monitoring/metrics.js
@@ -49,6 +49,13 @@ const graphqlErrors = new client.Counter({
   labelNames: ["operation", "error_type"],
 });
 
+// Explanation service metrics
+const explanationRequestDuration = new client.Histogram({
+  name: 'explanation_request_duration_seconds',
+  help: 'Latency of explanation requests',
+  buckets: [0.1, 0.5, 1, 1.5, 2, 5]
+});
+
 // Tenant isolation violations
 const tenantScopeViolationsTotal = new client.Counter({
   name: "tenant_scope_violations_total",
@@ -193,6 +200,7 @@ register.registerMetric(httpRequestsTotal);
 register.registerMetric(graphqlRequestDuration);
 register.registerMetric(graphqlRequestsTotal);
 register.registerMetric(graphqlErrors);
+register.registerMetric(explanationRequestDuration);
 register.registerMetric(tenantScopeViolationsTotal);
 register.registerMetric(dbConnectionsActive);
 register.registerMetric(dbQueryDuration);
@@ -338,6 +346,7 @@ export {
   graphqlRequestDuration,
   graphqlRequestsTotal,
   graphqlErrors,
+  explanationRequestDuration,
   dbConnectionsActive,
   dbQueryDuration,
   dbQueriesTotal,

--- a/server/src/services/CacheService.ts
+++ b/server/src/services/CacheService.ts
@@ -1,0 +1,24 @@
+interface Entry { value: string; expires: number }
+
+export class CacheService {
+  private store: Map<string, Entry> = new Map();
+  constructor(private ttlMs = 900000) {}
+
+  async get(key: string): Promise<string | undefined> {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expires) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: any, ttlMs?: number): Promise<void> {
+    const ttl = ttlMs ?? this.ttlMs;
+    this.store.set(key, {
+      value: typeof value === 'string' ? value : JSON.stringify(value),
+      expires: Date.now() + ttl,
+    });
+  }
+}

--- a/server/tests/explain-resolver.test.ts
+++ b/server/tests/explain-resolver.test.ts
@@ -1,0 +1,42 @@
+import request from 'supertest'
+import { createApp } from '../src/app'
+import { advancedMLService } from '../src/services/AdvancedMLService'
+
+jest.spyOn(advancedMLService, 'getExplanations').mockResolvedValue({
+  paths: [{ nodes: ['a', 'b'], edges: [] }],
+  featureAttributions: [{ feature: 'f', importance: 0.9 }],
+  fairnessFlags: [],
+  limitations: [],
+  traceId: 'test-trace'
+})
+
+describe('explainConnection resolver', () => {
+  let server: any
+  beforeAll(async () => {
+    const app = await createApp()
+    server = app.listen(0)
+  })
+  afterAll(async () => {
+    await server.close()
+  })
+
+  it('returns explanation data', async () => {
+    const res = await request(server)
+      .post('/graphql')
+      .set('Authorization', 'Bearer dev-token')
+      .send({
+        query: `
+          query($s: ID!, $t: ID!) {
+            explainConnection(sourceId: $s, targetId: $t) {
+              traceId
+              paths { nodes }
+              featureAttributions { feature importance }
+            }
+          }
+        `,
+        variables: { s: 'a', t: 'b' }
+      })
+    expect(res.status).toBe(200)
+    expect(res.body.data.explainConnection.traceId).toBe('test-trace')
+  })
+})


### PR DESCRIPTION
## Summary
- add Graph-XAI explanation endpoint with caching, trace IDs and Neo4j fallback
- expose explanation and counterfactual queries with rate limiting and audit logging
- surface explanation drawer in web UI and harden Graph-XAI service container

## Testing
- `npm run lint --silent -- server/src/services/AdvancedMLService.ts server/src/controllers/MLController.js server/src/graphql/resolvers-combined.ts server/src/graphql/typeDefs/explanations.js server/src/graphql/schema.js server/src/graphql/middleware/rateLimiting.ts server/src/graphql/plugins/auditLogger.ts server/src/monitoring/metrics.js apps/web/src/components/panels/EntityDrawer.tsx apps/web/src/components/panels/ExplainDrawer.tsx server/src/app.ts server/tests/explain-resolver.test.ts` (fails: Cannot find package 'typescript-eslint')
- `npm test --silent server/tests/explain-resolver.test.ts` (fails: Test environment jest-environment-jsdom cannot be found)


------
https://chatgpt.com/codex/tasks/task_e_68a55c6f4c4883338dbad642c78edd21