### PR TITLE
feat: scaffold ingest job spec and graphql endpoints

### DIFF
--- a/server/data-pipelines/contracts/ingest_job_spec.py
+++ b/server/data-pipelines/contracts/ingest_job_spec.py
@@ -1,0 +1,45 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, validator
+
+
+class MaskingStrategy(str, Enum):
+    REDACTION = "REDACTION"
+    TOKENIZATION = "TOKENIZATION"
+    HASHING = "HASHING"
+    ENCRYPTION = "ENCRYPTION"
+    PARTIAL_MASK = "PARTIAL_MASK"
+    SYNTHETIC = "SYNTHETIC"
+    NULLIFICATION = "NULLIFICATION"
+
+
+class FieldMapping(BaseModel):
+    """Mapping for an individual field with optional masking strategy."""
+
+    source: str
+    target: str
+    masking_mode: Optional[MaskingStrategy] = None
+
+    @validator("masking_mode", pre=True)
+    def _coerce_strategy(cls, v):
+        if v is None or isinstance(v, MaskingStrategy):
+            return v
+        try:
+            return MaskingStrategy[v.upper()]
+        except KeyError as exc:
+            raise ValueError(f"Unknown masking mode: {v}") from exc
+
+
+class IngestJobSpec(BaseModel):
+    """Contract defining an ingestion job."""
+
+    source: Dict[str, Any]
+    mapping: List[FieldMapping]
+    policyTags: List[str] = []
+
+    @validator("policyTags", pre=True, always=True)
+    def _default_policy_tags(cls, v):
+        return v or []
+
+
+__all__ = ["IngestJobSpec", "FieldMapping", "MaskingStrategy"]

--- a/server/data-pipelines/tests/test_ingest_job_spec.py
+++ b/server/data-pipelines/tests/test_ingest_job_spec.py
@@ -1,0 +1,25 @@
+import pytest
+
+from contracts.ingest_job_spec import IngestJobSpec
+from contracts.ingest_job_spec import MaskingStrategy
+
+
+def test_ingest_job_spec_parses_masking_strategy():
+    spec = IngestJobSpec(
+        source={"type": "csv", "path": "data.csv"},
+        mapping=[
+            {"source": "email", "target": "email", "masking_mode": "REDACTION"},
+            {"source": "name", "target": "name", "masking_mode": MaskingStrategy.SYNTHETIC},
+        ],
+        policyTags=["public"],
+    )
+    assert spec.mapping[0].masking_mode == MaskingStrategy.REDACTION
+    assert spec.mapping[1].masking_mode == MaskingStrategy.SYNTHETIC
+
+
+def test_ingest_job_spec_invalid_masking_mode():
+    with pytest.raises(ValueError):
+        IngestJobSpec(
+            source={"type": "csv"},
+            mapping=[{"source": "a", "target": "b", "masking_mode": "UNKNOWN"}],
+        )

--- a/server/src/graphql/resolvers.ingest.js
+++ b/server/src/graphql/resolvers.ingest.js
@@ -1,0 +1,40 @@
+const Joi = require('joi');
+const { v4: uuid } = require('uuid');
+
+const jobs = new Map();
+
+const startSchema = Joi.object({
+  spec: Joi.object({
+    source: Joi.object().required(),
+    mapping: Joi.array()
+      .items(
+        Joi.object({
+          source: Joi.string().required(),
+          target: Joi.string().required(),
+          maskingMode: Joi.string().optional(),
+        }),
+      )
+      .required(),
+    policyTags: Joi.array().items(Joi.string()).default([]),
+  }).required(),
+});
+
+module.exports = {
+  Mutation: {
+    startIngest: async (_, args) => {
+      const { value, error } = startSchema.validate(args);
+      if (error) {
+        const err = new Error(`Invalid input: ${error.message}`);
+        err.code = 'BAD_USER_INPUT';
+        throw err;
+      }
+      const id = uuid();
+      const job = { id, status: 'PENDING', metrics: null, lineageURI: null, policyFindings: [] };
+      jobs.set(id, job);
+      return job;
+    },
+    ingestStatus: async (_, { id }) => {
+      return jobs.get(id) || null;
+    },
+  },
+};

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -3,6 +3,7 @@ const copilotResolvers = require('./resolvers.copilot');
 const graphOpsResolvers = require('./resolvers.graphops');
 const aiResolvers = require('./resolvers.ai');
 const annotationsResolvers = require('./resolvers.annotations'); // My new resolvers
+const ingestResolvers = require('./resolvers.ingest');
 
 // Merge all resolvers
 const resolvers = {
@@ -11,24 +12,28 @@ const resolvers = {
     ...(graphOpsResolvers.Query || {}),
     ...(aiResolvers.Query || {}),
     ...(annotationsResolvers.Query || {}), // Add annotations queries if any
+    ...(ingestResolvers.Query || {}),
   },
   Mutation: {
     ...(copilotResolvers.Mutation || {}),
     ...(graphOpsResolvers.Mutation || {}),
     ...(aiResolvers.Mutation || {}),
     ...(annotationsResolvers.Mutation || {}), // Add annotations mutations
+    ...(ingestResolvers.Mutation || {}),
   },
   Subscription: {
     ...(copilotResolvers.Subscription || {}),
     ...(graphOpsResolvers.Subscription || {}),
     ...(aiResolvers.Subscription || {}),
     ...(annotationsResolvers.Subscription || {}), // Add annotations subscriptions if any
+    ...(ingestResolvers.Subscription || {}),
   },
   // Custom types (like Entity, Edge, etc.)
   Entity: {
     ...(annotationsResolvers.Entity || {}), // Add Entity resolvers from annotations
   },
-  Edge: { // Add Edge resolvers
+  Edge: {
+    // Add Edge resolvers
     ...(annotationsResolvers.Edge || {}),
   },
   // Add other custom type resolvers as needed from other files

--- a/server/src/graphql/schema.ts
+++ b/server/src/graphql/schema.ts
@@ -397,7 +397,11 @@ input SemanticSearchFilter {
   
   input EntityInput { type: String!, props: JSON }
   input RelationshipInput { from: ID!, to: ID!, type: String!, props: JSON }
-  
+
+  input FieldMappingInput { source: String!, target: String!, maskingMode: String }
+  input IngestJobSpec { source: JSON!, mapping: [FieldMappingInput!]!, policyTags: [String!] }
+  type IngestJob { id: ID!, status: String!, metrics: JSON, lineageURI: String, policyFindings: [String!] }
+
   type Mutation {
     createEntity(input: EntityInput!): Entity!
     updateEntity(id: ID!, input: EntityInput!): Entity!
@@ -437,6 +441,9 @@ input SemanticSearchFilter {
     Useful when investigation data has changed significantly.
     """
     clearGraphRAGCache(investigationId: ID!): CacheOperationResult!
+
+    startIngest(spec: IngestJobSpec!): IngestJob!
+    ingestStatus(id: ID!): IngestJob!
   }
   
   type Subscription {


### PR DESCRIPTION
## Summary
- define IngestJobSpec contract with field-level masking modes
- stub startIngest GraphQL mutation and resolver
- unit tests for IngestJobSpec validation

## Testing
- `npm run lint` (fails: Cannot find package 'typescript-eslint')
- `npm run format` (fails: SyntaxError in workflow YAML)
- `npm test` (fails: jest-environment-jsdom cannot be found)
- `PYTHONPATH=server/data-pipelines pytest server/data-pipelines/tests/test_ingest_job_spec.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a562862f7483338ca2da343b38aba7