### PR TITLE
feat: add NL to Cypher preview route

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,7 @@ import { pinoHttp } from "pino-http";
 import { auditLogger } from "./middleware/audit-logger.js";
 import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
+import nl2cypherRouter from "./routes/nl2cypher.js";
 import { register } from "./monitoring/metrics.js";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
@@ -40,6 +41,7 @@ export const createApp = async () => {
   // Rate limiting (exempt monitoring endpoints)
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
+  app.use("/api/nl2cypher", nl2cypherRouter);
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", register.contentType);
     res.end(await register.metrics());

--- a/server/src/routes/nl2cypher.ts
+++ b/server/src/routes/nl2cypher.ts
@@ -1,0 +1,55 @@
+import express from 'express';
+import { ensureAuthenticated } from '../middleware/auth.js';
+import { writeAudit } from '../utils/audit.js';
+
+const router = express.Router();
+
+router.use(ensureAuthenticated);
+
+router.post('/preview', (req, res) => {
+  const { text } = req.body || {};
+  if (!text || typeof text !== 'string') {
+    return res.status(400).json({ error: 'text required' });
+  }
+  const cypher = 'MATCH (n) RETURN n LIMIT 10';
+  const rationale = 'Demo rationale for generated Cypher';
+  const risk = 'low';
+  res.json({ cypher, rationale, risk });
+});
+
+function checkPolicy(query: string): { allow: boolean; reason?: string } {
+  if (/\bDELETE\b/i.test(query)) {
+    return { allow: false, reason: 'Delete operations are not permitted' };
+  }
+  return { allow: true };
+}
+
+router.post('/run', async (req, res) => {
+  const { cypher, confirm } = req.body || {};
+  if (!confirm) {
+    return res.status(400).json({ error: 'confirmation required' });
+  }
+  if (!cypher || typeof cypher !== 'string') {
+    return res.status(400).json({ error: 'cypher required' });
+  }
+  const decision = checkPolicy(cypher);
+  if (!decision.allow) {
+    await writeAudit({
+      userId: req.user?.id,
+      action: 'RUN_CYPHER_DENIED',
+      resourceType: 'cypher',
+      details: { cypher, reason: decision.reason },
+    });
+    return res.status(403).json({ error: decision.reason });
+  }
+  const result = { rows: [] };
+  await writeAudit({
+    userId: req.user?.id,
+    action: 'RUN_CYPHER',
+    resourceType: 'cypher',
+    details: { cypher },
+  });
+  res.json({ result, auditId: 'placeholder' });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add stubbed NL to Cypher preview and run endpoints with policy check
- wire route into express app

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run format` *(fails: YAML syntax error in workflow)*
- `cd server && npm test` *(fails: Module jest-junit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5625a924c8333b9ca598498795a8f