### PR TITLE
feat: add http ingestor

### DIFF
--- a/ingestion/ingestors/__init__.py
+++ b/ingestion/ingestors/__init__.py
@@ -2,5 +2,12 @@ from .base import Ingestor
 from .rss import RSSIngestor
 from .twitter import TwitterIngestor
 from .pastebin import PastebinIngestor
+from .http import HTTPIngestor
 
-__all__ = ["Ingestor", "RSSIngestor", "TwitterIngestor", "PastebinIngestor"]
+__all__ = [
+    "Ingestor",
+    "RSSIngestor",
+    "TwitterIngestor",
+    "PastebinIngestor",
+    "HTTPIngestor",
+]

--- a/ingestion/ingestors/http.py
+++ b/ingestion/ingestors/http.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from typing import Any, Dict, Iterable, List
+import requests
+from .base import Ingestor
+
+
+class HTTPIngestor(Ingestor):
+    """Fetch JSON items from HTTP endpoints."""
+
+    def __init__(self, producer: Any, topic: str, urls: Iterable[str]):
+        super().__init__(producer, topic)
+        self.urls: List[str] = list(urls)
+
+    def fetch(self) -> Iterable[Dict[str, Any]]:
+        for url in self.urls:
+            resp = requests.get(url, timeout=10)
+            data = resp.json()
+            if isinstance(data, list):
+                for item in data:
+                    yield item
+            else:
+                yield data
+
+    def normalize(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "id": item.get("id") or hash(str(item)),
+            "platform": "http",
+            "timestamp": item.get("timestamp"),
+            "text": item.get("text", ""),
+            "metadata": {"source": item.get("source")},
+        }

--- a/ingestion/requirements.txt
+++ b/ingestion/requirements.txt
@@ -4,3 +4,4 @@ redis
 sentence-transformers
 hdbscan
 prometheus-client
+requests

--- a/tests/ingestion/test_http_ingestor.py
+++ b/tests/ingestion/test_http_ingestor.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock, patch
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from ingestion.ingestors.http import HTTPIngestor
+
+
+def test_http_ingestor_runs():
+    producer = Mock()
+    urls = ["http://example.com/data"]
+    sample = [{"id": "1", "text": "hello", "timestamp": "2024-01-01"}]
+    with patch("ingestion.ingestors.http.requests.get") as mock_get:
+        mock_get.return_value.json.return_value = sample
+        ingestor = HTTPIngestor(producer, "topic", urls)
+        ingestor.run()
+    producer.send.assert_called_once()
+    sent = producer.send.call_args.kwargs["value"]
+    assert sent["text"] == "hello"
+    assert sent["platform"] == "http"


### PR DESCRIPTION
## Summary
- add HTTPIngestor to fetch JSON items from URLs
- cover HTTP ingestor with unit test

## Testing
- `pytest tests/ingestion/test_http_ingestor.py tests/ingest/test_ingest.py`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run format` *(fails: multiple syntax errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a561147c288333bffbc6284ea5abdc