### PR TITLE
feat: add hashing and dedupe to ingestion

### DIFF
--- a/ingestion/ingestors/base.py
+++ b/ingestion/ingestors/base.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, Dict
+from typing import Any, Dict, Iterable
+
+from ingestion.utils import compute_hash
+
 
 class Ingestor(ABC):
     """Base class for OSINT ingestion modules."""
@@ -8,6 +11,7 @@ class Ingestor(ABC):
     def __init__(self, producer: Any, topic: str):
         self.producer = producer
         self.topic = topic
+        self._seen_hashes = set()
 
     @abstractmethod
     def fetch(self) -> Iterable[Dict[str, Any]]:
@@ -26,5 +30,12 @@ class Ingestor(ABC):
 
     def run(self) -> None:
         for raw in self.fetch():
+            raw_hash = compute_hash(raw)
+            if raw_hash in self._seen_hashes:
+                continue
             normalized = self.normalize(raw)
+            normalized_hash = compute_hash(normalized)
+            normalized["content_hash"] = raw_hash
+            normalized["normalized_hash"] = normalized_hash
+            self._seen_hashes.add(raw_hash)
             self.emit(normalized)

--- a/ingestion/ingestors/pastebin.py
+++ b/ingestion/ingestors/pastebin.py
@@ -11,8 +11,10 @@ class PastebinIngestor(Ingestor):
             yield paste
 
     def normalize(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        external_id = item.get("key")
         return {
-            "id": item.get("key"),
+            "id": external_id,
+            "external_id": external_id,
             "platform": "pastebin",
             "timestamp": item.get("date"),
             "text": item.get("content", ""),

--- a/ingestion/ingestors/rss.py
+++ b/ingestion/ingestors/rss.py
@@ -14,8 +14,10 @@ class RSSIngestor(Ingestor):
                 yield entry
 
     def normalize(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        external_id = item.get("id", item.get("link"))
         return {
-            "id": item.get("id", item.get("link")),
+            "id": external_id,
+            "external_id": external_id,
             "platform": "rss",
             "timestamp": item.get("published_parsed"),
             "text": item.get("title", ""),

--- a/ingestion/ingestors/twitter.py
+++ b/ingestion/ingestors/twitter.py
@@ -12,8 +12,10 @@ class TwitterIngestor(Ingestor):
             yield tweet
 
     def normalize(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        external_id = item.get("id_str")
         return {
-            "id": item.get("id_str"),
+            "id": external_id,
+            "external_id": external_id,
             "platform": "twitter",
             "timestamp": item.get("created_at"),
             "text": item.get("text", ""),

--- a/ingestion/utils.py
+++ b/ingestion/utils.py
@@ -1,0 +1,19 @@
+import hashlib
+import json
+from typing import Any
+
+
+def compute_hash(value: Any) -> str:
+    """Compute deterministic SHA-256 hash of a value.
+
+    Handles dicts/lists by JSON serializing with sorted keys, normalizes newlines,
+    and ensures consistent UTF-8 encoding. Bytes and strings are supported.
+    """
+    if isinstance(value, (dict, list)):
+        canonical = json.dumps(value, sort_keys=True, ensure_ascii=False)
+    elif isinstance(value, bytes):
+        canonical = value.decode("utf-8")
+    else:
+        canonical = str(value)
+    canonical = canonical.replace("\r\n", "\n").encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "utils", Path(__file__).resolve().parents[1] / "ingestion" / "utils.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+compute_hash = module.compute_hash
+
+
+def test_hash_stability_newlines():
+    text1 = "hello\nworld"
+    text2 = "hello\r\nworld"
+    assert compute_hash(text1) == compute_hash(text2)
+
+
+def test_hash_stability_bytes():
+    text = "café"
+    assert compute_hash(text) == compute_hash(text.encode('utf-8'))


### PR DESCRIPTION
## Summary
- add deterministic SHA-256 hashing utility
- dedupe ingested items using content hash
- test hashing stability across newlines and encoding

## Testing
- `npm run lint` *(fails: eslint: not found)*
- `npm run format` *(fails: prettier: not found)*
- `npm test` *(fails: jest: not found)*
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a55c885a688333b87478b52aaca0d8