### PR TITLE
feat: scaffold watchlist and alert framework

### DIFF
--- a/apps/web/src/components/watchlists/AlertInbox.tsx
+++ b/apps/web/src/components/watchlists/AlertInbox.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function AlertInbox() {
+  return <div>Alert inbox placeholder</div>
+}

--- a/apps/web/src/components/watchlists/DigestSettings.tsx
+++ b/apps/web/src/components/watchlists/DigestSettings.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function DigestSettings() {
+  return <div>Digest settings placeholder</div>
+}

--- a/apps/web/src/components/watchlists/WatchlistEditor.tsx
+++ b/apps/web/src/components/watchlists/WatchlistEditor.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function WatchlistEditor() {
+  return <div>Watchlist editor placeholder</div>
+}

--- a/apps/web/src/pages/WatchlistsPage.tsx
+++ b/apps/web/src/pages/WatchlistsPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { AlertInbox } from '@/components/watchlists/AlertInbox'
+import { WatchlistEditor } from '@/components/watchlists/WatchlistEditor'
+import { DigestSettings } from '@/components/watchlists/DigestSettings'
+
+export default function WatchlistsPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Watchlists</h1>
+      <WatchlistEditor />
+      <AlertInbox />
+      <DigestSettings />
+    </div>
+  )
+}

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -2,6 +2,7 @@ import entityResolvers from './entity';
 import relationshipResolvers from './relationship';
 import userResolvers from './user';
 import investigationResolvers from './investigation';
+import watchlistResolvers from './watchlists';
 import { WargameResolver } from '../../resolvers/WargameResolver.js'; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
 
 // Instantiate the WargameResolver
@@ -12,11 +13,13 @@ const resolvers = {
     ...entityResolvers.Query,
     ...userResolvers.Query,
     ...investigationResolvers.Query,
+    ...watchlistResolvers.Query,
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     getCrisisTelemetry: wargameResolver.getCrisisTelemetry.bind(wargameResolver),
     getAdversaryIntentEstimates: wargameResolver.getAdversaryIntentEstimates.bind(wargameResolver),
     getNarrativeHeatmapData: wargameResolver.getNarrativeHeatmapData.bind(wargameResolver),
-    getStrategicResponsePlaybooks: wargameResolver.getStrategicResponsePlaybooks.bind(wargameResolver),
+    getStrategicResponsePlaybooks:
+      wargameResolver.getStrategicResponsePlaybooks.bind(wargameResolver),
     getCrisisScenario: wargameResolver.getCrisisScenario.bind(wargameResolver),
     getAllCrisisScenarios: wargameResolver.getAllCrisisScenarios.bind(wargameResolver),
   },
@@ -25,6 +28,7 @@ const resolvers = {
     ...relationshipResolvers.Mutation,
     ...userResolvers.Mutation,
     ...investigationResolvers.Mutation,
+    ...watchlistResolvers.Mutation,
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     runWarGameSimulation: wargameResolver.runWarGameSimulation.bind(wargameResolver),
     updateCrisisScenario: wargameResolver.updateCrisisScenario.bind(wargameResolver),
@@ -33,4 +37,3 @@ const resolvers = {
 };
 
 export default resolvers;
-

--- a/server/src/graphql/resolvers/watchlists.ts
+++ b/server/src/graphql/resolvers/watchlists.ts
@@ -1,0 +1,19 @@
+import { watchlistService } from '../../services/WatchlistService';
+
+const watchlistResolvers = {
+  Query: {
+    watchlists: async () => {
+      return await watchlistService.listWatchlists();
+    },
+  },
+  Mutation: {
+    createWatchlist: async (_: any, { input }: any) => {
+      return await watchlistService.createWatchlist(input.name);
+    },
+    addWatchlistRule: async (_: any, { input }: any) => {
+      return await watchlistService.addRule(input.watchlistId, input.spec);
+    },
+  },
+};
+
+export default watchlistResolvers;

--- a/server/src/graphql/schema.js
+++ b/server/src/graphql/schema.js
@@ -3,14 +3,29 @@ const { copilotTypeDefs } = require('./schema.copilot.js');
 const { graphTypeDefs } = require('./schema.graphops.js');
 const { aiTypeDefs } = require('./schema.ai.js');
 const { annotationsTypeDefs } = require('./schema.annotations.js');
+const { watchlistTypeDefs } = require('./schema.watchlists.js');
 const graphragTypes = require('./types/graphragTypes.js');
 
 const base = gql`
   scalar JSON
-  
-  type Query { _empty: String }
-  type Mutation { _empty: String }
-  type Subscription { _empty: String }
+
+  type Query {
+    _empty: String
+  }
+  type Mutation {
+    _empty: String
+  }
+  type Subscription {
+    _empty: String
+  }
 `;
 
-export const typeDefs = [base, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs, annotationsTypeDefs];
+export const typeDefs = [
+  base,
+  copilotTypeDefs,
+  graphTypeDefs,
+  graphragTypes,
+  aiTypeDefs,
+  annotationsTypeDefs,
+  watchlistTypeDefs,
+];

--- a/server/src/graphql/schema.watchlists.js
+++ b/server/src/graphql/schema.watchlists.js
@@ -1,0 +1,34 @@
+const gql = require('graphql-tag');
+
+const watchlistTypeDefs = gql`
+  type WatchlistRule {
+    id: ID!
+    spec: JSON
+  }
+
+  type Watchlist {
+    id: ID!
+    name: String!
+    rules: [WatchlistRule!]!
+  }
+
+  input CreateWatchlistInput {
+    name: String!
+  }
+
+  input AddWatchlistRuleInput {
+    watchlistId: ID!
+    spec: JSON
+  }
+
+  extend type Query {
+    watchlists: [Watchlist!]!
+  }
+
+  extend type Mutation {
+    createWatchlist(input: CreateWatchlistInput!): Watchlist!
+    addWatchlistRule(input: AddWatchlistRuleInput!): WatchlistRule
+  }
+`;
+
+module.exports = { watchlistTypeDefs };

--- a/server/src/services/RuleEngine.ts
+++ b/server/src/services/RuleEngine.ts
@@ -1,0 +1,13 @@
+export interface Rule {
+  id: string;
+  spec: any;
+}
+
+export class RuleEngine {
+  async evaluate(rule: Rule): Promise<any[]> {
+    // Placeholder evaluator: real implementation would query Neo4j and PGVector
+    return [];
+  }
+}
+
+export const ruleEngine = new RuleEngine();

--- a/server/src/services/WatchlistService.ts
+++ b/server/src/services/WatchlistService.ts
@@ -1,0 +1,36 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export interface WatchlistRule {
+  id: string;
+  spec: any;
+}
+
+export interface Watchlist {
+  id: string;
+  name: string;
+  rules: WatchlistRule[];
+}
+
+export class WatchlistService {
+  private watchlists: Watchlist[] = [];
+
+  async createWatchlist(name: string): Promise<Watchlist> {
+    const watchlist: Watchlist = { id: uuidv4(), name, rules: [] };
+    this.watchlists.push(watchlist);
+    return watchlist;
+  }
+
+  async listWatchlists(): Promise<Watchlist[]> {
+    return this.watchlists;
+  }
+
+  async addRule(watchlistId: string, spec: any): Promise<WatchlistRule | null> {
+    const watchlist = this.watchlists.find((w) => w.id === watchlistId);
+    if (!watchlist) return null;
+    const rule: WatchlistRule = { id: uuidv4(), spec };
+    watchlist.rules.push(rule);
+    return rule;
+  }
+}
+
+export const watchlistService = new WatchlistService();


### PR DESCRIPTION
## Summary
- add in-memory watchlist service and rule engine stubs
- expose watchlists via GraphQL schema and resolvers
- scaffold placeholder watchlist UI components

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run format` *(fails: SyntaxError in workflow yaml)*
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a55d36a514833385432906e727e04a