### PR TITLE
feat: add canonical entity types and link analysis canvas skeleton

### DIFF
--- a/client/src/ui/components/LinkAnalysisCanvas.test.tsx
+++ b/client/src/ui/components/LinkAnalysisCanvas.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import LinkAnalysisCanvas from './LinkAnalysisCanvas';
+
+describe('LinkAnalysisCanvas', () => {
+  it('renders timeline, map and graph panes', () => {
+    render(<LinkAnalysisCanvas />);
+    expect(screen.getByLabelText('timeline')).toBeInTheDocument();
+    expect(screen.getByLabelText('map')).toBeInTheDocument();
+    expect(screen.getByLabelText('graph')).toBeInTheDocument();
+  });
+});

--- a/client/src/ui/components/LinkAnalysisCanvas.tsx
+++ b/client/src/ui/components/LinkAnalysisCanvas.tsx
@@ -1,0 +1,50 @@
+import { FC, useState } from 'react';
+
+interface TimeRange {
+  start: number;
+  end: number;
+}
+
+const LinkAnalysisCanvas: FC = () => {
+  const [range, setRange] = useState<TimeRange>({ start: 0, end: 100 });
+
+  const handleStartChange = (value: number) => {
+    setRange((r) => ({ ...r, start: value }));
+  };
+
+  const handleEndChange = (value: number) => {
+    setRange((r) => ({ ...r, end: value }));
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100%' }}>
+      <div style={{ flex: 2, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ flex: 1 }} aria-label="timeline">
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={range.start}
+            onChange={(e) => handleStartChange(Number(e.target.value))}
+          />
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={range.end}
+            onChange={(e) => handleEndChange(Number(e.target.value))}
+          />
+        </div>
+        <div style={{ flex: 2 }} aria-label="map">
+          {/* Map placeholder with time/space filters */}
+        </div>
+      </div>
+      <div style={{ flex: 3 }} aria-label="graph">
+        {/* Graph placeholder with pivot/expand and pinboard support */}
+        <div>{`Time range: ${range.start} - ${range.end}`}</div>
+      </div>
+    </div>
+  );
+};
+
+export default LinkAnalysisCanvas;

--- a/server/src/types/canonical-entities.ts
+++ b/server/src/types/canonical-entities.ts
@@ -1,0 +1,74 @@
+export type EntityType =
+  | 'person'
+  | 'organization'
+  | 'asset'
+  | 'account'
+  | 'location'
+  | 'event'
+  | 'document';
+
+export interface ERConfidence {
+  /** Deterministic score between 0 and 1 */
+  deterministic?: number;
+  /** Probabilistic confidence between 0 and 1 */
+  probability?: number;
+  /** Optional explanation or scorecard reference */
+  explanation?: string;
+}
+
+export interface GeoTemporal {
+  /** Start of validity window */
+  validFrom?: Date;
+  /** End of validity window */
+  validTo?: Date;
+  /** Optional geographic coordinates */
+  location?: {
+    lat: number;
+    lon: number;
+  };
+}
+
+export interface BaseEntity extends GeoTemporal {
+  id: string;
+  type: EntityType;
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+  confidence?: ERConfidence;
+}
+
+export interface Person extends BaseEntity {
+  type: 'person';
+  firstName?: string;
+  lastName?: string;
+}
+
+export interface Organization extends BaseEntity {
+  type: 'organization';
+  name: string;
+}
+
+export interface Asset extends BaseEntity {
+  type: 'asset';
+  name: string;
+}
+
+export interface Account extends BaseEntity {
+  type: 'account';
+  provider?: string;
+}
+
+export interface Location extends BaseEntity {
+  type: 'location';
+  address?: string;
+}
+
+export interface Event extends BaseEntity {
+  type: 'event';
+  description?: string;
+}
+
+export interface Document extends BaseEntity {
+  type: 'document';
+  title?: string;
+}


### PR DESCRIPTION
## Summary
- define canonical entity interfaces with geo-temporal and confidence metadata
- add LinkAnalysisCanvas component with tri-pane timeline, map, and graph placeholders
- basic test for LinkAnalysisCanvas rendering

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint', 2653 problems)*
- `npm run format` *(fails: SyntaxError in .github/workflows/cd-deploy.yml)*
- `npm test` *(fails: 97 failed, 10 passed, missing modules such as uuid and supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68a57cce506c83338bf9bd2abda3502c