### PR TITLE
feat: add basic geospatial services and map UI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "graphql": "^16.11.0",
     "graphql-ws": "^6.0.6",
     "lucide-react": "^0.292.0",
+    "maplibre-gl": "^3.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.47.0",

--- a/apps/web/src/components/map/ClusterLayer.tsx
+++ b/apps/web/src/components/map/ClusterLayer.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import type maplibregl from 'maplibre-gl'
+
+interface Props {
+  map?: maplibregl.Map
+  sourceId: string
+}
+
+export default function ClusterLayer({ map, sourceId }: Props) {
+  useEffect(() => {
+    if (!map) return
+    if (map.getSource(sourceId)) return
+    map.addSource(sourceId, {
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features: [] },
+      cluster: true,
+      clusterRadius: 50,
+    })
+    map.addLayer({
+      id: `${sourceId}-clusters`,
+      type: 'circle',
+      source: sourceId,
+      filter: ['has', 'point_count'],
+      paint: {
+        'circle-color': '#0d6efd',
+        'circle-radius': ['step', ['get', 'point_count'], 20, 100, 30, 750, 40],
+      },
+    })
+    map.addLayer({
+      id: `${sourceId}-cluster-count`,
+      type: 'symbol',
+      source: sourceId,
+      filter: ['has', 'point_count'],
+      layout: {
+        'text-field': ['get', 'point_count_abbreviated'],
+        'text-size': 12,
+      },
+    })
+  }, [map, sourceId])
+  return null
+}

--- a/apps/web/src/components/map/EntityPin.tsx
+++ b/apps/web/src/components/map/EntityPin.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+import type maplibregl from 'maplibre-gl'
+
+interface Props {
+  map?: maplibregl.Map
+  id: string
+  lon: number
+  lat: number
+}
+
+export default function EntityPin({ map, lon, lat }: Props) {
+  useEffect(() => {
+    if (!map) return
+    const el = document.createElement('div')
+    el.className = 'w-2 h-2 bg-red-500 rounded-full'
+    const marker = new maplibregl.Marker(el).setLngLat([lon, lat]).addTo(map)
+    return () => marker.remove()
+  }, [map, lon, lat])
+  return null
+}

--- a/apps/web/src/components/map/LayerToggles.tsx
+++ b/apps/web/src/components/map/LayerToggles.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export default function LayerToggles() {
+  const [cluster, setCluster] = useState(true)
+  const [heatmap, setHeatmap] = useState(false)
+  return (
+    <div className="bg-white p-2 rounded shadow text-xs space-y-1">
+      <label className="flex items-center space-x-1">
+        <input
+          type="checkbox"
+          checked={cluster}
+          onChange={() => setCluster(!cluster)}
+        />
+        <span>Clusters</span>
+      </label>
+      <label className="flex items-center space-x-1">
+        <input
+          type="checkbox"
+          checked={heatmap}
+          onChange={() => setHeatmap(!heatmap)}
+        />
+        <span>Heatmap</span>
+      </label>
+    </div>
+  )
+}

--- a/apps/web/src/components/map/MapView.tsx
+++ b/apps/web/src/components/map/MapView.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react'
+import maplibregl from 'maplibre-gl'
+import 'maplibre-gl/dist/maplibre-gl.css'
+import LayerToggles from './LayerToggles'
+import TimeSlider from './TimeSlider'
+
+export default function MapView() {
+  const mapContainer = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!mapContainer.current) return
+    const map = new maplibregl.Map({
+      container: mapContainer.current,
+      style: 'https://demotiles.maplibre.org/style.json',
+      center: [0, 0],
+      zoom: 2,
+    })
+    return () => map.remove()
+  }, [])
+
+  return (
+    <div className="relative w-full h-full">
+      <div ref={mapContainer} className="w-full h-full" />
+      <div className="absolute top-2 left-2 space-y-2">
+        <LayerToggles />
+        <TimeSlider />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/map/TimeSlider.tsx
+++ b/apps/web/src/components/map/TimeSlider.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react'
+
+export default function TimeSlider() {
+  const [value, setValue] = useState(0)
+  return (
+    <div className="bg-white p-2 rounded shadow text-xs">
+      <input
+        type="range"
+        min={0}
+        max={100}
+        value={value}
+        onChange={e => setValue(Number(e.target.value))}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/map/index.ts
+++ b/apps/web/src/components/map/index.ts
@@ -1,0 +1,5 @@
+export { default as MapView } from './MapView';
+export { default as LayerToggles } from './LayerToggles';
+export { default as TimeSlider } from './TimeSlider';
+export { default as ClusterLayer } from './ClusterLayer';
+export { default as EntityPin } from './EntityPin';

--- a/ingestion/geocoders/esri.ts
+++ b/ingestion/geocoders/esri.ts
@@ -1,0 +1,17 @@
+import { GeocoderProvider, GeocodeResult } from '../../server/src/services/GeocodingService.js';
+
+export default class EsriGeocoder implements GeocoderProvider {
+  async geocode(query: string): Promise<GeocodeResult[]> {
+    const url = `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?f=json&singleLine=${encodeURIComponent(query)}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    if (!data.candidates) return [];
+    return data.candidates.map((c: any) => ({
+      lat: c.location.y,
+      lon: c.location.x,
+      displayName: c.address,
+      confidence: c.score / 100,
+      provider: 'esri',
+    }));
+  }
+}

--- a/ingestion/geocoders/index.ts
+++ b/ingestion/geocoders/index.ts
@@ -1,0 +1,2 @@
+export { default as NominatimGeocoder } from './nominatim';
+export { default as EsriGeocoder } from './esri';

--- a/ingestion/geocoders/nominatim.ts
+++ b/ingestion/geocoders/nominatim.ts
@@ -1,0 +1,17 @@
+import { GeocoderProvider, GeocodeResult } from '../../server/src/services/GeocodingService.js';
+
+export default class NominatimGeocoder implements GeocoderProvider {
+  async geocode(query: string): Promise<GeocodeResult[]> {
+    const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}`;
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'intelgraph-geocoder' },
+    });
+    const data = await res.json();
+    return data.map((d: any) => ({
+      lat: parseFloat(d.lat),
+      lon: parseFloat(d.lon),
+      displayName: d.display_name,
+      provider: 'nominatim',
+    }));
+  }
+}

--- a/server/db/migrations/postgres/2025-08-16_postgis.sql
+++ b/server/db/migrations/postgres/2025-08-16_postgis.sql
@@ -1,0 +1,14 @@
+-- Enable PostGIS extension and add geospatial columns
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+-- Add geospatial fields to entities table
+ALTER TABLE entities
+  ADD COLUMN IF NOT EXISTS geom GEOGRAPHY(Point,4326),
+  ADD COLUMN IF NOT EXISTS place_accuracy TEXT,
+  ADD COLUMN IF NOT EXISTS country_code TEXT,
+  ADD COLUMN IF NOT EXISTS admin1 TEXT,
+  ADD COLUMN IF NOT EXISTS admin2 TEXT,
+  ADD COLUMN IF NOT EXISTS admin3 TEXT;
+
+-- Create spatial index
+CREATE INDEX IF NOT EXISTS entities_geom_gix ON entities USING GIST (geom);

--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -135,6 +135,9 @@ async function createPostgresTables(): Promise<void> {
   const client = await postgresPool.connect();
 
   try {
+    // Ensure PostGIS extension is available
+    await client.query("CREATE EXTENSION IF NOT EXISTS postgis");
+
     // Users table
     await client.query(`
       CREATE TABLE IF NOT EXISTS users (

--- a/server/src/graphql/resolvers/geo.ts
+++ b/server/src/graphql/resolvers/geo.ts
@@ -1,0 +1,21 @@
+import GeoSpatialService from '../../services/GeoSpatialService.js';
+
+const geoResolvers = {
+  Query: {
+    entitiesInBbox: (_: unknown, { bbox }: { bbox: [number, number, number, number] }) =>
+      GeoSpatialService.entitiesInBbox({
+        minLon: bbox[0],
+        minLat: bbox[1],
+        maxLon: bbox[2],
+        maxLat: bbox[3],
+      }),
+    nearbyEntities: (
+      _: unknown,
+      { lat, lon, radiusMeters }: { lat: number; lon: number; radiusMeters: number },
+    ) => GeoSpatialService.nearbyEntities(lat, lon, radiusMeters),
+    pathsBetween: (_: unknown, { entityIds }: { entityIds: string[] }) =>
+      GeoSpatialService.pathsBetween(entityIds),
+  },
+};
+
+export default geoResolvers;

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -2,6 +2,7 @@ import entityResolvers from './entity';
 import relationshipResolvers from './relationship';
 import userResolvers from './user';
 import investigationResolvers from './investigation';
+import geoResolvers from './geo';
 import { WargameResolver } from '../../resolvers/WargameResolver.js'; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
 
 // Instantiate the WargameResolver
@@ -12,6 +13,7 @@ const resolvers = {
     ...entityResolvers.Query,
     ...userResolvers.Query,
     ...investigationResolvers.Query,
+    ...geoResolvers.Query,
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     getCrisisTelemetry: wargameResolver.getCrisisTelemetry.bind(wargameResolver),
     getAdversaryIntentEstimates: wargameResolver.getAdversaryIntentEstimates.bind(wargameResolver),

--- a/server/src/graphql/schema.ts
+++ b/server/src/graphql/schema.ts
@@ -1,4 +1,10 @@
-export const typeDefs = `
+import fs from 'fs';
+import path from 'path';
+
+const geoSchema = fs.readFileSync(path.join(__dirname, 'schema/geo.graphql'), 'utf8');
+
+export const typeDefs =
+  `
   scalar JSON
   scalar DateTime
   type Entity { id: ID!, type: String!, props: JSON, createdAt: DateTime!, updatedAt: DateTime, canonicalId: ID }
@@ -445,4 +451,4 @@ input SemanticSearchFilter {
     entityDeleted: ID!
     aiRecommendationUpdated: AIRecommendation!
   }
-`;
+` + geoSchema;

--- a/server/src/graphql/schema/geo.graphql
+++ b/server/src/graphql/schema/geo.graphql
@@ -1,0 +1,18 @@
+type GeoEntity {
+  id: ID!
+  type: String
+  name: String
+  geom: String
+}
+
+type PathResult {
+  fromId: ID!
+  toId: ID!
+  distanceM: Float!
+}
+
+type Query {
+  entitiesInBbox(bbox: [Float!]!): [GeoEntity!]!
+  nearbyEntities(lat: Float!, lon: Float!, radiusMeters: Float!): [GeoEntity!]!
+  pathsBetween(entityIds: [ID!]!): [PathResult!]!
+}

--- a/server/src/services/GeoSpatialService.ts
+++ b/server/src/services/GeoSpatialService.ts
@@ -1,0 +1,54 @@
+import { Pool } from 'pg';
+import { getPostgresPool } from '../config/database.js';
+
+interface BBox {
+  minLon: number;
+  minLat: number;
+  maxLon: number;
+  maxLat: number;
+}
+
+class GeoSpatialService {
+  private pool: Pool;
+
+  constructor() {
+    this.pool = getPostgresPool();
+  }
+
+  async entitiesInBbox(bbox: BBox) {
+    const { minLon, minLat, maxLon, maxLat } = bbox;
+    const result = await this.pool.query(
+      `SELECT id, type, name, geom
+       FROM entities
+       WHERE geom && ST_MakeEnvelope($1,$2,$3,$4,4326)`,
+      [minLon, minLat, maxLon, maxLat],
+    );
+    return result.rows;
+  }
+
+  async nearbyEntities(lat: number, lon: number, radiusMeters: number) {
+    const result = await this.pool.query(
+      `SELECT id, type, name, geom,
+              ST_DistanceSphere(geom, ST_MakePoint($2,$1)) AS distance
+       FROM entities
+       WHERE ST_DWithin(geom, ST_MakePoint($2,$1)::geography, $3)
+       ORDER BY distance ASC`,
+      [lat, lon, radiusMeters],
+    );
+    return result.rows;
+  }
+
+  async pathsBetween(entityIds: string[]) {
+    if (entityIds.length < 2) return [];
+    const result = await this.pool.query(
+      `SELECT a.id AS from_id, b.id AS to_id,
+              ST_DistanceSphere(a.geom, b.geom) AS distance_m
+       FROM entities a, entities b
+       WHERE a.id = ANY($1) AND b.id = ANY($1) AND a.id <> b.id`,
+      [entityIds],
+    );
+    return result.rows;
+  }
+}
+
+export default new GeoSpatialService();

--- a/server/src/services/GeocodingService.ts
+++ b/server/src/services/GeocodingService.ts
@@ -1,0 +1,26 @@
+export interface GeocodeResult {
+  lat: number;
+  lon: number;
+  displayName: string;
+  confidence?: number;
+  provider: string;
+}
+
+export interface GeocoderProvider {
+  geocode(query: string): Promise<GeocodeResult[]>;
+}
+
+export class GeocodingService {
+  private cache = new Map<string, GeocodeResult[]>();
+
+  constructor(private provider: GeocoderProvider) {}
+
+  async geocode(query: string): Promise<GeocodeResult[]> {
+    if (this.cache.has(query)) {
+      return this.cache.get(query)!;
+    }
+    const results = await this.provider.geocode(query);
+    this.cache.set(query, results);
+    return results;
+  }
+}

--- a/server/src/services/TileService.ts
+++ b/server/src/services/TileService.ts
@@ -1,0 +1,7 @@
+class TileService {
+  getTileURL(z: number, x: number, y: number): string {
+    return `/tiles/${z}/${x}/${y}.pbf`;
+  }
+}
+
+export default new TileService();


### PR DESCRIPTION
## Summary
- add PostGIS migration and enable extension
- implement GeoSpatial and Geocoding services with GraphQL queries
- introduce MapLibre-based map components for web UI
- remove unintended package-lock update

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run format` *(fails: .github/workflows/cd-deploy.yml: SyntaxError: Map keys must be unique; "script" is repeated (10:3))*
- `npm test` *(fails: client/src/components/graph/AdvancedGraphView.jsx: SyntaxError: Unexpected token (371:2))*

------
https://chatgpt.com/codex/tasks/task_e_68a55d4bff748333abbef8815f9b8ac9