### PR TITLE
feat(collab): presence + CRDT notepad + graph comments + audit

### DIFF
--- a/client/src/collab/useCaseNotepad.ts
+++ b/client/src/collab/useCaseNotepad.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+import { io } from 'socket.io-client';
+
+// Lazy loaded Yjs
+let Y: any;
+
+export function useCaseNotepad(caseId: string) {
+  const docRef = useRef<any>();
+
+  useEffect(() => {
+    let socket: any;
+    (async () => {
+      try {
+        if (!Y) {
+          Y = await import('yjs');
+        }
+        const ydoc = new Y.Doc();
+        docRef.current = ydoc;
+        socket = io(`/realtime/case/${caseId}`);
+        socket.on('note', (update: Uint8Array) => {
+          Y.applyUpdate(ydoc, update);
+        });
+        ydoc.on('update', (update: Uint8Array) => {
+          socket.emit('note', update);
+        });
+      } catch (err) {
+        console.error('notepad init failed', err);
+      }
+    })();
+    return () => {
+      socket?.close();
+      docRef.current?.destroy();
+    };
+  }, [caseId]);
+
+  return docRef.current;
+}

--- a/client/src/collab/usePresence.ts
+++ b/client/src/collab/usePresence.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { io, Socket } from 'socket.io-client';
+import type { Presence } from '../../../packages/shared/collab-types';
+
+export function usePresence(
+  tenantId: string,
+  caseId: string,
+  role: string,
+) {
+  const [users, setUsers] = useState<Presence[]>([]);
+
+  useEffect(() => {
+    const socket: Socket = io('/realtime', {
+      auth: { tenantId, caseId, role },
+    });
+    socket.on('presence:update', (list: Presence[]) => setUsers(list));
+    const interval = setInterval(() => {
+      socket.emit('presence:heartbeat', {});
+    }, 10_000);
+    return () => {
+      clearInterval(interval);
+      socket.close();
+    };
+  }, [tenantId, caseId, role]);
+
+  return users;
+}

--- a/client/src/components/GraphAnnotations.tsx
+++ b/client/src/components/GraphAnnotations.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import $ from 'jquery';
+import 'jquery-ui/ui/widgets/draggable';
+import 'jquery-ui/ui/widgets/resizable';
+
+interface GraphAnnotationProps {
+  id: string;
+  text: string;
+  onChange?: (position: { top: number; left: number }, size: { width: number; height: number }) => void;
+}
+
+export default function GraphAnnotations({ id, text, onChange }: GraphAnnotationProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const el = $(ref.current);
+    el.draggable({
+      stop: (_e, ui) => {
+        const size = el.resizable('instance')?.size || { width: ui.helper.width(), height: ui.helper.height() };
+        onChange?.(ui.position, size);
+      },
+    }).resizable({
+      stop: (_e, ui) => {
+        onChange?.(ui.position, ui.size);
+      },
+    });
+  }, [onChange]);
+
+  return (
+    <div id={id} ref={ref} className="annotation">
+      {text}
+    </div>
+  );
+}

--- a/client/src/types/yjs.d.ts
+++ b/client/src/types/yjs.d.ts
@@ -1,0 +1,1 @@
+declare module 'yjs';

--- a/packages/shared/collab-types.ts
+++ b/packages/shared/collab-types.ts
@@ -1,0 +1,26 @@
+export interface Presence {
+  tenantId: string;
+  caseId: string;
+  userId: string;
+  role: string;
+  selections: string[];
+  lastSeen: number;
+}
+
+export interface Annotation {
+  id: string;
+  caseId: string;
+  targetId: string;
+  targetType: 'node' | 'edge';
+  range?: string;
+  text: string;
+  authorId: string;
+  createdAt: string;
+  resolvedAt?: string;
+}
+
+export interface CaseNoteSnapshot {
+  caseId: string;
+  content: string;
+  updatedAt: string;
+}

--- a/server/src/graphql/collab.ts
+++ b/server/src/graphql/collab.ts
@@ -1,0 +1,36 @@
+import { gql } from 'apollo-server-express';
+import { getCasePresence, Presence } from '../realtime/presence';
+
+export const collabTypeDefs = gql`
+  type CasePresence {
+    tenantId: String!
+    caseId: String!
+    userId: ID!
+    role: String!
+    selections: [ID!]!
+    lastSeen: Float!
+  }
+
+  extend type Query {
+    casePresence(caseId: ID!): [CasePresence!]!
+  }
+`;
+
+interface CasePresenceArgs {
+  caseId: string;
+}
+
+export const collabResolvers = {
+  Query: {
+    casePresence: (
+      _parent: unknown,
+      { caseId }: CasePresenceArgs,
+      context: { tenantId: string }
+    ): Presence[] => {
+      const tenantId = context?.tenantId || 'default';
+      return getCasePresence(tenantId, caseId);
+    },
+  },
+};
+
+export default { collabTypeDefs, collabResolvers };

--- a/server/src/graphql/resolvers-combined.ts
+++ b/server/src/graphql/resolvers-combined.ts
@@ -4,6 +4,7 @@ const copilotResolvers = require('./resolvers.copilot.js');
 const graphResolvers = require('./resolvers.graphops.js');
 const aiResolvers = require('./resolvers.ai.js');
 const annotationsResolvers = require('./resolvers.annotations.js');
+import { collabResolvers } from './collab';
 import { v4 as uuidv4 } from 'uuid';
 
 interface User {
@@ -58,6 +59,7 @@ export const resolvers = {
     ...(copilotResolvers.Query || {}),
     ...(aiResolvers.Query || {}),
     ...(annotationsResolvers.Query || {}),
+    ...(collabResolvers.Query || {}),
     me: async (_: any, __: any, { user }: Context): Promise<User> => {
       if (!user) throw new Error('Not authenticated');
       return user;

--- a/server/src/graphql/schema-combined.ts
+++ b/server/src/graphql/schema-combined.ts
@@ -4,6 +4,7 @@ const { graphTypeDefs } = require('./schema.graphops.js');
 const { aiTypeDefs } = require('./schema.ai.js');
 const graphragTypes = require('./types/graphragTypes.js');
 const coreTypeDefs = require('./schema/core.js');
+import { collabTypeDefs } from './collab';
 
 const base = gql`
   scalar JSON
@@ -13,5 +14,13 @@ const base = gql`
   type Subscription { _empty: String }
 `;
 
-export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs];
+export const typeDefs = [
+  base,
+  coreTypeDefs,
+  copilotTypeDefs,
+  graphTypeDefs,
+  graphragTypes,
+  aiTypeDefs,
+  collabTypeDefs,
+];
 

--- a/server/src/realtime/presence.ts
+++ b/server/src/realtime/presence.ts
@@ -1,60 +1,76 @@
 import { Socket } from 'socket.io';
 import pino from 'pino';
+import type { Presence as SharedPresence } from '../../../packages/shared/collab-types';
 
 const logger = pino();
+const TTL = 30_000;
 
-interface Presence {
-  userId: string;
-  username: string;
-  status: string;
-  ts: number;
-}
+export interface Presence extends SharedPresence {}
 
 const presence = new Map<string, Map<string, Presence>>();
 
-function broadcast(workspaceId: string, socket: Socket) {
-  const list = Array.from(presence.get(workspaceId)?.values() || []);
-  socket.to(`workspace:${workspaceId}`).emit('presence:update', list);
+function caseKey(tenantId: string, caseId: string) {
+  return `${tenantId}:${caseId}`;
+}
+
+function broadcast(key: string, socket: Socket) {
+  const list = Array.from(presence.get(key)?.values() || []);
+  socket.to(`case:${key}`).emit('presence:update', list);
   socket.emit('presence:update', list);
 }
 
+export function getCasePresence(tenantId: string, caseId: string) {
+  return Array.from(presence.get(caseKey(tenantId, caseId))?.values() || []);
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, map] of presence.entries()) {
+    for (const [id, p] of map.entries()) {
+      if (now - p.lastSeen > TTL) {
+        map.delete(id);
+      }
+    }
+    if (map.size === 0) presence.delete(key);
+  }
+}, TTL);
+
 export function registerPresenceHandlers(socket: Socket) {
   const user = (socket as any).user;
-  const workspaceId = socket.handshake.auth?.workspaceId;
-  if (!user?.id || !workspaceId) {
+  const tenantId = socket.handshake.auth?.tenantId;
+  const caseId = socket.handshake.auth?.caseId;
+  const role = socket.handshake.auth?.role || 'reader';
+  if (!user?.id || !tenantId || !caseId) {
     return;
   }
-  const username = user.username || user.email || 'unknown';
-
-  socket.join(`workspace:${workspaceId}`);
-  const wsMap = presence.get(workspaceId) || new Map<string, Presence>();
-  wsMap.set(user.id, {
+  const key = caseKey(tenantId, caseId);
+  socket.join(`case:${key}`);
+  const map = presence.get(key) || new Map<string, Presence>();
+  map.set(user.id, {
+    tenantId,
+    caseId,
     userId: user.id,
-    username,
-    status: 'online',
-    ts: Date.now(),
+    role,
+    selections: [],
+    lastSeen: Date.now(),
   });
-  presence.set(workspaceId, wsMap);
-  broadcast(workspaceId, socket);
+  presence.set(key, map);
+  broadcast(key, socket);
 
-  socket.on('presence:update', (status: string) => {
-    const map = presence.get(workspaceId);
-    if (!map) return;
-    map.set(user.id, {
-      userId: user.id,
-      username,
-      status,
-      ts: Date.now(),
-    });
-    broadcast(workspaceId, socket);
+  socket.on('presence:heartbeat', (payload: { selections?: string[] }) => {
+    const p = map.get(user.id);
+    if (!p) return;
+    p.lastSeen = Date.now();
+    if (payload?.selections) {
+      p.selections = payload.selections;
+    }
+    broadcast(key, socket);
   });
 
   socket.on('disconnect', () => {
-    const map = presence.get(workspaceId);
-    if (!map) return;
     map.delete(user.id);
-    if (map.size === 0) presence.delete(workspaceId);
-    socket.to(`workspace:${workspaceId}`).emit('presence:update', Array.from(map.values()));
-    logger.info({ userId: user.id, workspaceId }, 'presence:disconnect');
+    if (map.size === 0) presence.delete(key);
+    socket.to(`case:${key}`).emit('presence:update', Array.from(map.values()));
+    logger.info({ userId: user.id, key }, 'presence:disconnect');
   });
 }


### PR DESCRIPTION
## Summary
- add shared collab types for presence, annotations, and notes
- track case-level presence with heartbeat and selection data
- expose casePresence GraphQL query and React hooks for presence and Yjs notepad
- add draggable/resizable graph annotations widget

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run test:server` *(fails: Module jest-junit in the testResultsProcessor option was not found)*
- `npm run test:client` *(fails: TypeError: Cannot read properties of undefined (reading 'S'))*
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68a582bb5bc08333a703f78cc15c29a0