### PR TITLE
feat: add explainable entity resolution scoring

### DIFF
--- a/entity_resolution.py
+++ b/entity_resolution.py
@@ -5,6 +5,8 @@ import redis
 from sentence_transformers import SentenceTransformer
 import hdbscan
 from prometheus_client import Counter, Gauge
+from difflib import SequenceMatcher
+import math
 
 
 class EntityResolutionEngine:
@@ -39,3 +41,36 @@ class EntityResolutionEngine:
                 self.neo4j.create_or_update_entity("Entity", {"canonical_id": canonical_id, "name": entity["name"]})
         self.dedup_counter.inc(len(set(mapping.values())))
         return mapping
+
+
+def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Compute great-circle distance between two points in kilometers."""
+    radius = 6371.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    return 2 * radius * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def explain(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+    """Return feature scores and a final weighted score for two entities."""
+    weights = {
+        "email_match": 0.4,
+        "phone_match": 0.3,
+        "name_dob_similarity": 0.2,
+        "geo_proximity": 0.1,
+    }
+    features: Dict[str, float] = {}
+    features["email_match"] = 1.0 if a.get("email") and a.get("email") == b.get("email") else 0.0
+    features["phone_match"] = 1.0 if a.get("phone") and a.get("phone") == b.get("phone") else 0.0
+    name_score = SequenceMatcher(None, a.get("name", ""), b.get("name", "")).ratio()
+    dob_score = 1.0 if a.get("dob") and a.get("dob") == b.get("dob") else 0.0
+    features["name_dob_similarity"] = (name_score + dob_score) / 2
+    if all(k in a for k in ("lat", "lon")) and all(k in b for k in ("lat", "lon")):
+        dist = _haversine(a["lat"], a["lon"], b["lat"], b["lon"])
+        features["geo_proximity"] = max(0.0, 1 - min(dist / 200.0, 1.0))
+    else:
+        features["geo_proximity"] = 0.0
+    score = sum(features[k] * weights[k] for k in weights)
+    return {"features": features, "score": score}

--- a/python/tests/test_entity_resolution_explain.py
+++ b/python/tests/test_entity_resolution_explain.py
@@ -1,0 +1,52 @@
+import entity_resolution as er
+import pytest
+
+
+def test_explain_all_features_match():
+    a = {
+        "email": "a@example.com",
+        "phone": "123",
+        "name": "Alice",
+        "dob": "1990-01-01",
+        "lat": 0,
+        "lon": 0,
+    }
+    b = {
+        "email": "a@example.com",
+        "phone": "123",
+        "name": "Alice",
+        "dob": "1990-01-01",
+        "lat": 0,
+        "lon": 0,
+    }
+    result = er.explain(a, b)
+    assert result["features"]["email_match"] == 1.0
+    assert result["features"]["phone_match"] == 1.0
+    assert result["features"]["name_dob_similarity"] == 1.0
+    assert result["features"]["geo_proximity"] == 1.0
+    assert result["score"] == pytest.approx(1.0)
+
+
+def test_explain_no_features_match():
+    a = {
+        "email": "a@example.com",
+        "phone": "123",
+        "name": "Alice",
+        "dob": "1990-01-01",
+        "lat": 0,
+        "lon": 0,
+    }
+    b = {
+        "email": "b@example.com",
+        "phone": "999",
+        "name": "Bob",
+        "dob": "1980-01-01",
+        "lat": 10,
+        "lon": 10,
+    }
+    result = er.explain(a, b)
+    assert result["features"]["email_match"] == 0.0
+    assert result["features"]["phone_match"] == 0.0
+    assert result["features"]["name_dob_similarity"] == 0.0
+    assert result["features"]["geo_proximity"] == 0.0
+    assert result["score"] == 0.0


### PR DESCRIPTION
## Summary
- add explain(a,b) helper to compute feature-level scores for entity resolution
- cover explain scoring with unit tests

## Testing
- `npm run lint` *(fails: 2664 problems)*
- `npm run format -- --check` *(fails: SyntaxError in .github/workflows files)*
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `python -m pytest python/tests/test_entity_resolution_engine.py python/tests/test_entity_resolution_explain.py`


------
https://chatgpt.com/codex/tasks/task_e_68a584a70170833380087f112c447e28