### PR TITLE
feat: scaffold plugin manifest and ts sdk

### DIFF
--- a/docs/plugins/manifest-and-sdk.md
+++ b/docs/plugins/manifest-and-sdk.md
@@ -1,0 +1,33 @@
+# Plugin Manifest and TypeScript SDK
+
+This document describes the experimental plugin manifest format and the TypeScript utilities that third-party extensions can use to interact with the IntelGraph platform.
+
+## Manifest (`plugin.json`)
+
+Plugins declare metadata and capabilities in a `plugin.json` file. The schema is defined in [`plugins/plugin.schema.json`](../../plugins/plugin.schema.json) and supports the following fields:
+
+- `id`, `name`, `version`
+- `permissions`: list of requested permission scopes
+- `entrypoints`: paths to job and UI entry modules
+- `panels`: optional UI panels exposed to the host application
+- `settings`: plugin-specific configuration schema
+
+## TypeScript SDK
+
+The SDK exposes helpers for calling the GraphQL API, registering UI panels, and emitting telemetry events.
+
+```ts
+import { createGraphClient, registerPanel, emitTelemetry } from '../../plugins/sdk/ts';
+
+const client = createGraphClient('/graphql');
+
+registerPanel({
+  id: 'sample-panel',
+  name: 'Sample Panel',
+  component: {}, // host will replace with runtime component
+});
+
+emitTelemetry('plugin-loaded', { id: 'sample-plugin' });
+```
+
+These APIs are placeholders pending the full sandboxed runtime and should not be used in production.

--- a/plugins/plugin.schema.json
+++ b/plugins/plugin.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IntelGraph Plugin Manifest",
+  "type": "object",
+  "required": ["id", "name", "version", "entrypoints"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique plugin identifier"
+    },
+    "name": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Requested permission scopes"
+    },
+    "entrypoints": {
+      "type": "object",
+      "properties": {
+        "job": {
+          "type": "string",
+          "description": "Path to job entry module"
+        },
+        "ui": {
+          "type": "string",
+          "description": "Path to UI entry module"
+        }
+      },
+      "additionalProperties": false
+    },
+    "panels": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "component"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "component": { "type": "string" }
+        }
+      }
+    },
+    "settings": {
+      "type": "object",
+      "description": "Plugin-specific configuration schema"
+    }
+  },
+  "additionalProperties": false
+}

--- a/plugins/sample-plugin/plugin.json
+++ b/plugins/sample-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../plugin.schema.json",
+  "id": "sample-plugin",
+  "name": "Sample Plugin",
+  "version": "0.1.0",
+  "permissions": ["graph:read"],
+  "entrypoints": {
+    "job": "job.js",
+    "ui": "panel.js"
+  },
+  "panels": [
+    {
+      "id": "sample-panel",
+      "name": "Sample Panel",
+      "component": "SamplePanel"
+    }
+  ],
+  "settings": {}
+}

--- a/plugins/sdk/ts/index.ts
+++ b/plugins/sdk/ts/index.ts
@@ -1,0 +1,31 @@
+export interface PanelDefinition {
+  id: string;
+  name: string;
+  component: unknown;
+}
+
+export interface GraphClient {
+  query<T = unknown>(query: string, variables?: Record<string, unknown>): Promise<T>;
+}
+
+export function createGraphClient(apiUrl: string): GraphClient {
+  return {
+    async query<T = unknown>(query: string, variables?: Record<string, unknown>): Promise<T> {
+      const res = await fetch(apiUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables }),
+      });
+      return res.json() as Promise<T>;
+    },
+  };
+}
+
+export function registerPanel(panel: PanelDefinition): void {
+  // In the real runtime this would register the panel with the host application.
+  console.debug(`registering panel ${panel.id}`);
+}
+
+export function emitTelemetry(event: string, data: Record<string, unknown>): void {
+  console.debug(`telemetry:${event}`, data);
+}


### PR DESCRIPTION
## Summary
- add experimental plugin manifest schema and sample plugin
- stub TypeScript SDK utilities
- document plugin manifest and SDK usage

## Testing
- `npm run lint` *(fails: 2655 problems)*
- `npm run format` *(fails: SyntaxError in workflow files)*
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57f48cb388333ae4de7d85732434b