### PR TITLE
feat(authz-gateway): add Node-based AuthN/Z proxy with OPA policy

### DIFF
--- a/services/authz-gateway/.npmrc
+++ b/services/authz-gateway/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/services/authz-gateway/.prettierrc.json
+++ b/services/authz-gateway/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/services/authz-gateway/AGENTS.md
+++ b/services/authz-gateway/AGENTS.md
@@ -1,0 +1,4 @@
+# AuthZ Gateway Guidelines
+
+- Run `npm test` from this directory for tests.
+- Run `npm run lint` and `npm run format` before committing.

--- a/services/authz-gateway/CODEOWNERS
+++ b/services/authz-gateway/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BrianCLong

--- a/services/authz-gateway/README.md
+++ b/services/authz-gateway/README.md
@@ -1,0 +1,14 @@
+# AuthZ Gateway
+
+Node-based authentication and authorization reverse proxy that issues JWTs, exposes JWKS, and enforces OPA policies.
+
+## Observability
+
+The gateway emits structured logs via Pino, exports Prometheus metrics on `/metrics`, and initializes OpenTelemetry tracing.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/services/authz-gateway/eslint.config.mjs
+++ b/services/authz-gateway/eslint.config.mjs
@@ -1,0 +1,10 @@
+import js from '@eslint/js';
+import * as tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+
+export default [
+  { ignores: ['dist', 'jest.config.cjs'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettier,
+];

--- a/services/authz-gateway/jest.config.cjs
+++ b/services/authz-gateway/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coverageThreshold: {
+    global: { lines: 90 }
+  }
+};

--- a/services/authz-gateway/package.json
+++ b/services/authz-gateway/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "authz-gateway",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "test": "jest --coverage"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "express": "^4.18.2",
+    "http-proxy-middleware": "^2.0.6",
+    "jose": "^4.14.4",
+    "pino": "^9.9.0",
+    "pino-http": "^10.5.0",
+    "prom-client": "^15.1.3",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.203.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.62.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.203.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/http-proxy-middleware": "^1.0.0",
+    "@types/jest": "^29.5.5",
+    "@types/node": "^18.18.0",
+    "@types/supertest": "^2.0.12",
+    "eslint": "^9.33.0",
+    "eslint-config-prettier": "^9.0.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.0.3",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "typescript-eslint": "^8.40.0"
+  }
+}

--- a/services/authz-gateway/src/audit.ts
+++ b/services/authz-gateway/src/audit.ts
@@ -1,0 +1,15 @@
+import { appendFileSync } from 'fs';
+
+export interface AuditEntry {
+  subject: string;
+  action: string;
+  resource: string;
+  tenantId: string;
+  allowed: boolean;
+  reason: string;
+}
+
+export function log(entry: AuditEntry) {
+  const record = { ...entry, ts: new Date().toISOString() };
+  appendFileSync('audit.log', JSON.stringify(record) + '\n');
+}

--- a/services/authz-gateway/src/auth.ts
+++ b/services/authz-gateway/src/auth.ts
@@ -1,0 +1,55 @@
+import { SignJWT, jwtVerify } from 'jose';
+import { getPrivateKey, getPublicKey } from './keys';
+import { log } from './audit';
+
+interface User {
+  username: string;
+  password: string;
+  sub: string;
+  tenantId: string;
+  roles: string[];
+  clearance: string;
+}
+
+const users: Record<string, User> = {
+  alice: {
+    username: 'alice',
+    password: 'password123',
+    sub: 'alice',
+    tenantId: 'tenantA',
+    roles: ['reader'],
+    clearance: 'confidential',
+  },
+};
+
+export async function login(username: string, password: string) {
+  const user = users[username];
+  if (!user || user.password !== password) {
+    throw new Error('invalid_credentials');
+  }
+  const token = await new SignJWT({
+    sub: user.sub,
+    tenantId: user.tenantId,
+    roles: user.roles,
+    clearance: user.clearance,
+    acr: 'loa1',
+  })
+    .setProtectedHeader({ alg: 'RS256', kid: 'authz-gateway-1' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(getPrivateKey());
+  await log({
+    subject: user.sub,
+    action: 'login',
+    resource: 'self',
+    tenantId: user.tenantId,
+    allowed: true,
+    reason: 'login',
+  });
+  return token;
+}
+
+export async function introspect(token: string) {
+  const { payload } = await jwtVerify(token, getPublicKey());
+  return payload;
+}

--- a/services/authz-gateway/src/index.ts
+++ b/services/authz-gateway/src/index.ts
@@ -1,0 +1,89 @@
+import express from 'express';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import pino from 'pino';
+import pinoHttp from 'pino-http';
+import { initKeys, getPublicJwk, getPrivateKey } from './keys';
+import { login, introspect } from './auth';
+import { requireAuth } from './middleware';
+import { startObservability, metricsHandler } from './observability';
+
+export async function createApp() {
+  await initKeys();
+  await startObservability();
+  const app = express();
+  const logger = pino();
+  app.use(pinoHttp({ logger }));
+  app.use(express.json());
+
+  app.get('/metrics', metricsHandler);
+
+  app.post('/auth/login', async (req, res) => {
+    try {
+      const { username, password } = req.body;
+      const token = await login(username, password);
+      res.json({ token });
+    } catch {
+      res.status(401).json({ error: 'invalid_credentials' });
+    }
+  });
+
+  app.get('/.well-known/jwks.json', (_req, res) => {
+    res.json({ keys: [getPublicJwk()] });
+  });
+
+  app.post('/auth/introspect', async (req, res) => {
+    try {
+      const { token } = req.body;
+      const payload = await introspect(token);
+      res.json(payload);
+    } catch {
+      res.status(401).json({ error: 'invalid_token' });
+    }
+  });
+
+  app.post(
+    '/auth/step-up',
+    requireAuth({ action: 'step-up' }),
+    async (_req, res) => {
+      // issue new token with higher ACR
+      try {
+        const user = (_req as import('./middleware').AuthenticatedRequest).user;
+        const { SignJWT } = await import('jose');
+        const token = await new SignJWT({
+          ...user,
+          acr: 'loa2',
+        })
+          .setProtectedHeader({ alg: 'RS256', kid: 'authz-gateway-1' })
+          .setIssuedAt()
+          .setExpirationTime('1h')
+          .sign(getPrivateKey());
+        res.json({ token });
+      } catch {
+        res.status(500).json({ error: 'step_up_failed' });
+      }
+    },
+  );
+
+  const upstream = process.env.UPSTREAM || 'http://localhost:4001';
+  app.use(
+    '/protected',
+    requireAuth({ action: 'read' }),
+    createProxyMiddleware({
+      target: upstream,
+      changeOrigin: true,
+      pathRewrite: { '^/protected': '' },
+    }),
+  );
+
+  return app;
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  createApp().then((app) => {
+    const port = process.env.PORT || 4000;
+    app.listen(port, () => {
+      const logger = pino();
+      logger.info(`AuthZ Gateway listening on ${port}`);
+    });
+  });
+}

--- a/services/authz-gateway/src/keys.ts
+++ b/services/authz-gateway/src/keys.ts
@@ -1,0 +1,27 @@
+import { generateKeyPair, exportJWK, JWK, KeyLike } from 'jose';
+
+let privateKey: KeyLike;
+let publicKey: KeyLike;
+let publicJwk: JWK;
+
+export async function initKeys() {
+  const { publicKey: pub, privateKey: priv } = await generateKeyPair('RS256');
+  privateKey = priv;
+  publicKey = pub;
+  publicJwk = await exportJWK(pub);
+  publicJwk.alg = 'RS256';
+  publicJwk.use = 'sig';
+  publicJwk.kid = 'authz-gateway-1';
+}
+
+export function getPrivateKey() {
+  return privateKey;
+}
+
+export function getPublicKey() {
+  return publicKey;
+}
+
+export function getPublicJwk() {
+  return publicJwk;
+}

--- a/services/authz-gateway/src/middleware.ts
+++ b/services/authz-gateway/src/middleware.ts
@@ -1,0 +1,64 @@
+import { jwtVerify, type JWTPayload } from 'jose';
+import { getPublicKey } from './keys';
+import { authorize } from './policy';
+import { log } from './audit';
+import type { Request, Response, NextFunction } from 'express';
+
+interface Options {
+  action: string;
+  requiredAcr?: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: JWTPayload;
+}
+
+export function requireAuth(options: Options) {
+  return async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const auth = req.headers.authorization;
+    if (!auth) {
+      return res.status(401).json({ error: 'missing_token' });
+    }
+    try {
+      const token = auth.replace('Bearer ', '');
+      const { payload } = await jwtVerify(token, getPublicKey());
+      if (options.requiredAcr && payload.acr !== options.requiredAcr) {
+        return res
+          .status(401)
+          .set('WWW-Authenticate', `acr=${options.requiredAcr}`)
+          .json({ error: 'step_up_required' });
+      }
+      const resource = {
+        tenantId: String(req.headers['x-tenant-id'] || ''),
+        needToKnow: String(req.headers['x-needtoknow'] || ''),
+      };
+      const { allowed, reason } = await authorize(
+        {
+          tenantId: String(payload.tenantId),
+          roles: (payload.roles as string[]) || [],
+        },
+        resource,
+        options.action,
+      );
+      await log({
+        subject: String(payload.sub),
+        action: options.action,
+        resource: JSON.stringify(resource),
+        tenantId: String(payload.tenantId),
+        allowed,
+        reason,
+      });
+      if (!allowed) {
+        return res.status(403).json({ error: 'forbidden' });
+      }
+      req.user = payload;
+      return next();
+    } catch {
+      return res.status(401).json({ error: 'invalid_token' });
+    }
+  };
+}

--- a/services/authz-gateway/src/observability.ts
+++ b/services/authz-gateway/src/observability.ts
@@ -1,0 +1,32 @@
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Registry, collectDefaultMetrics } from 'prom-client';
+import type { Request, Response } from 'express';
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter(),
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+let started = false;
+
+export async function startObservability() {
+  if (started) return;
+  await sdk.start();
+  started = true;
+}
+
+export async function stopObservability() {
+  if (!started) return;
+  await sdk.shutdown();
+  started = false;
+}
+
+export const registry = new Registry();
+collectDefaultMetrics({ register: registry });
+
+export async function metricsHandler(_req: Request, res: Response) {
+  res.setHeader('Content-Type', registry.contentType);
+  res.end(await registry.metrics());
+}

--- a/services/authz-gateway/src/policy.ts
+++ b/services/authz-gateway/src/policy.ts
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+function opaUrl() {
+  return process.env.OPA_URL || 'http://localhost:8181/v1/data/authz/allow';
+}
+
+export interface UserContext {
+  tenantId: string;
+  roles: string[];
+}
+
+export interface ResourceContext {
+  tenantId: string;
+  needToKnow?: string;
+}
+
+export async function authorize(
+  user: UserContext,
+  resource: ResourceContext,
+  action: string,
+): Promise<{ allowed: boolean; reason: string }> {
+  try {
+    const res = await axios.post(opaUrl(), {
+      input: { user, resource, action },
+    });
+    const result = res.data?.result;
+    if (typeof result === 'boolean') {
+      return { allowed: result, reason: result ? 'allow' : 'deny' };
+    }
+    return { allowed: !!result?.allow, reason: result?.reason || 'deny' };
+  } catch {
+    return { allowed: false, reason: 'opa_error' };
+  }
+}

--- a/services/authz-gateway/tests/auth.test.ts
+++ b/services/authz-gateway/tests/auth.test.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import request from 'supertest';
+import { createApp } from '../src/index';
+import { stopObservability } from '../src/observability';
+import type { AddressInfo } from 'net';
+
+describe('token lifecycle', () => {
+  afterAll(async () => {
+    await stopObservability();
+  });
+  it('logs in and introspects', async () => {
+    process.env.OPA_URL = 'http://localhost:8181/v1/data/authz/allow'; // unused in this test
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ username: 'alice', password: 'password123' });
+    expect(loginRes.status).toBe(200);
+    const token = loginRes.body.token;
+    const introspectRes = await request(app)
+      .post('/auth/introspect')
+      .send({ token });
+    expect(introspectRes.status).toBe(200);
+    expect(introspectRes.body.sub).toBe('alice');
+  });
+
+  it('serves JWKS', async () => {
+    const app = await createApp();
+    const res = await request(app).get('/.well-known/jwks.json');
+    expect(res.status).toBe(200);
+    expect(res.body.keys[0].kty).toBe('RSA');
+  });
+
+  it('rejects invalid introspection token', async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post('/auth/introspect')
+      .send({ token: 'bad' });
+    expect(res.status).toBe(401);
+  });
+
+  it('performs step-up authentication', async () => {
+    const opa = express();
+    opa.use(express.json());
+    opa.post('/v1/data/authz/allow', (_req, res) => res.json({ result: true }));
+    const opaServer = opa.listen(0);
+    const opaPort = (opaServer.address() as AddressInfo).port;
+    process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ username: 'alice', password: 'password123' });
+    const token = loginRes.body.token;
+    const step = await request(app)
+      .post('/auth/step-up')
+      .set('Authorization', `Bearer ${token}`);
+    expect(step.status).toBe(200);
+    const introspectRes = await request(app)
+      .post('/auth/introspect')
+      .send({ token: step.body.token });
+    expect(introspectRes.status).toBe(200);
+    expect(introspectRes.body.acr).toBe('loa2');
+    opaServer.close();
+  });
+});

--- a/services/authz-gateway/tests/metrics.test.ts
+++ b/services/authz-gateway/tests/metrics.test.ts
@@ -1,0 +1,16 @@
+import request from 'supertest';
+import { createApp } from '../src/index';
+import { stopObservability } from '../src/observability';
+
+describe('metrics', () => {
+  afterAll(async () => {
+    await stopObservability();
+  });
+
+  it('exposes prometheus metrics', async () => {
+    const app = await createApp();
+    const res = await request(app).get('/metrics');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('process_cpu_user_seconds_total');
+  });
+});

--- a/services/authz-gateway/tests/proxy.test.ts
+++ b/services/authz-gateway/tests/proxy.test.ts
@@ -1,0 +1,70 @@
+import express from 'express';
+import request from 'supertest';
+import { createApp } from '../src/index';
+import { stopObservability } from '../src/observability';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+
+let upstreamServer: Server;
+let opaServer: Server;
+
+beforeAll((done) => {
+  const upstream = express();
+  upstream.get('/resource', (_req, res) => res.json({ data: 'ok' }));
+  upstreamServer = upstream.listen(0, () => {
+    const port = (upstreamServer.address() as AddressInfo).port;
+    process.env.UPSTREAM = `http://localhost:${port}`;
+    const opa = express();
+    opa.use(express.json());
+    opa.post('/v1/data/authz/allow', (req, res) => {
+      const { user, resource } = req.body.input;
+      if (user.tenantId !== resource.tenantId) {
+        return res.json({ result: false });
+      }
+      if (resource.needToKnow && !user.roles.includes(resource.needToKnow)) {
+        return res.json({ result: false });
+      }
+      return res.json({ result: true });
+    });
+    opaServer = opa.listen(0, () => {
+      const opaPort = (opaServer.address() as AddressInfo).port;
+      process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
+      done();
+    });
+  });
+});
+
+afterAll(async () => {
+  upstreamServer.close();
+  opaServer.close();
+  await stopObservability();
+});
+
+describe('proxy', () => {
+  it('allows same-tenant access', async () => {
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ username: 'alice', password: 'password123' });
+    const token = loginRes.body.token;
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantA');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBe('ok');
+  });
+
+  it('blocks cross-tenant access', async () => {
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ username: 'alice', password: 'password123' });
+    const token = loginRes.body.token;
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantB');
+    expect(res.status).toBe(403);
+  });
+});

--- a/services/authz-gateway/tests/security.test.ts
+++ b/services/authz-gateway/tests/security.test.ts
@@ -1,0 +1,90 @@
+import express from 'express';
+import request from 'supertest';
+import { createApp } from '../src/index';
+import { stopObservability } from '../src/observability';
+import { SignJWT } from 'jose';
+import { getPrivateKey } from '../src/keys';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+
+let opaServer: Server;
+let upstreamServer: Server;
+
+beforeAll((done) => {
+  const upstream = express();
+  upstream.get('/resource', (_req, res) => res.json({ data: 'ok' }));
+  upstreamServer = upstream.listen(0, () => {
+    const port = (upstreamServer.address() as AddressInfo).port;
+    process.env.UPSTREAM = `http://localhost:${port}`;
+    const opa = express();
+    opa.use(express.json());
+    opa.post('/v1/data/authz/allow', (req, res) => {
+      const { user, resource } = req.body.input;
+      if (user.tenantId !== resource.tenantId) {
+        return res.json({ result: false });
+      }
+      if (resource.needToKnow && !user.roles.includes(resource.needToKnow)) {
+        return res.json({ result: false });
+      }
+      return res.json({ result: true });
+    });
+    opaServer = opa.listen(0, () => {
+      const opaPort = (opaServer.address() as AddressInfo).port;
+      process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
+      done();
+    });
+  });
+});
+
+afterAll(async () => {
+  upstreamServer.close();
+  opaServer.close();
+  await stopObservability();
+});
+
+describe('security', () => {
+  it('rejects tampered token', async () => {
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ username: 'alice', password: 'password123' });
+    const token = loginRes.body.token + 'tampered';
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantA');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects expired token', async () => {
+    const app = await createApp();
+    const token = await new SignJWT({
+      sub: 'alice',
+      tenantId: 'tenantA',
+      roles: ['reader'],
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'authz-gateway-1' })
+      .setIssuedAt()
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 1)
+      .sign(getPrivateKey());
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantA');
+    expect(res.status).toBe(401);
+  });
+
+  it('prevents role escalation', async () => {
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ username: 'alice', password: 'password123' });
+    const token = loginRes.body.token;
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantA')
+      .set('x-needtoknow', 'admin');
+    expect(res.status).toBe(403);
+  });
+});

--- a/services/authz-gateway/tsconfig.json
+++ b/services/authz-gateway/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold authz-gateway service with Express reverse proxy
- issue and introspect JWTs, expose JWKS
- enforce OPA policy and log access events
- replace legacy ESLint config to lint TypeScript sources
- drop sqlite dependency in favor of plain-text audit log
- instrument gateway with Pino logging, OpenTelemetry tracing, and Prometheus `/metrics`
- disable npm lockfile to avoid pulling native binaries

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56fe64adc8333872d9939bcf66204