### PR TITLE
feat: enforce authority context and audit

### DIFF
--- a/server/policies/access.rego
+++ b/server/policies/access.rego
@@ -1,0 +1,17 @@
+package intelgraph.access
+
+import future.keywords.if
+
+default allow = false
+
+allow if {
+  input.user.tenant == input.resource.tenant
+  input.user.clearance >= input.resource.sensitivity
+  input.purpose in input.resource.purpose_allowed
+  input.authority in input.resource.authorities
+}
+
+deny_reason[msg] if {
+  not allow
+  msg := "Policy denies: tenant/sensitivity/purpose/authority mismatch"
+}

--- a/server/policies/tests/access_test.rego
+++ b/server/policies/tests/access_test.rego
@@ -1,0 +1,32 @@
+package intelgraph.access
+
+import future.keywords.if
+
+test_allow_valid if {
+  allow with input as {
+    "user": {"tenant": "t1", "clearance": 3},
+    "resource": {
+      "tenant": "t1",
+      "sensitivity": 2,
+      "purpose_allowed": ["investigation"],
+      "authorities": ["warrant-123"]
+    },
+    "purpose": "investigation",
+    "authority": "warrant-123"
+  }
+}
+
+test_deny_invalid_authority if {
+  deny_reason[msg] with input as {
+    "user": {"tenant": "t1", "clearance": 3},
+    "resource": {
+      "tenant": "t1",
+      "sensitivity": 2,
+      "purpose_allowed": ["investigation"],
+      "authorities": ["warrant-123"]
+    },
+    "purpose": "investigation",
+    "authority": "bad-warrant"
+  }
+  msg == "Policy denies: tenant/sensitivity/purpose/authority mismatch"
+}

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -1,13 +1,12 @@
-import { GraphQLError } from "graphql";
-import jwt from "jsonwebtoken";
-import { getPostgresPool } from "../db/postgres.js";
-import pino from "pino";
-import { v4 as uuidv4 } from "uuid";
+import { GraphQLError } from 'graphql';
+import jwt from 'jsonwebtoken';
+import { getPostgresPool } from '../db/postgres.js';
+import pino from 'pino';
+import { v4 as uuidv4 } from 'uuid';
 
 const logger = pino();
 const JWT_SECRET =
-  process.env.JWT_SECRET ||
-  "dev_jwt_secret_12345_very_long_secret_for_development";
+  process.env.JWT_SECRET || 'dev_jwt_secret_12345_very_long_secret_for_development';
 
 interface User {
   id: string;
@@ -20,42 +19,48 @@ interface AuthContext {
   user?: User;
   isAuthenticated: boolean;
   requestId: string;
+  authority: string;
+  purpose: string;
+  reason: string;
 }
 
-export const getContext = async ({
-  req,
-}: {
-  req: any;
-}): Promise<AuthContext> => {
+export const getContext = async ({ req }: { req: any }): Promise<AuthContext> => {
   const requestId = uuidv4();
+  const authority = req.headers['x-authority'] as string | undefined;
+  const purpose = req.headers['x-purpose'] as string | undefined;
+  const reason = req.headers['x-reason'] as string | undefined;
+
+  if (!authority || !purpose || !reason) {
+    throw new GraphQLError('Missing required access control headers', {
+      extensions: { code: 'BAD_REQUEST', http: { status: 400 } },
+    });
+  }
+
   try {
     const token = extractToken(req);
     if (!token) {
-      logger.info({ requestId }, "Unauthenticated request");
-      return { isAuthenticated: false, requestId };
+      logger.info({ requestId }, 'Unauthenticated request');
+      return { isAuthenticated: false, requestId, authority, purpose, reason };
     }
 
     const user = await verifyToken(token);
-    logger.info({ requestId, userId: user.id }, "Authenticated request");
-    return { user, isAuthenticated: true, requestId };
+    logger.info({ requestId, userId: user.id }, 'Authenticated request');
+    return { user, isAuthenticated: true, requestId, authority, purpose, reason };
   } catch (error) {
-    logger.warn(
-      { requestId, error: (error as Error).message },
-      "Authentication failed",
-    );
-    return { isAuthenticated: false, requestId };
+    logger.warn({ requestId, error: (error as Error).message }, 'Authentication failed');
+    return { isAuthenticated: false, requestId, authority, purpose, reason };
   }
 };
 
 export const verifyToken = async (token: string): Promise<User> => {
   try {
     // For development, accept a simple test token
-    if (process.env.NODE_ENV === "development" && token === "dev-token") {
+    if (process.env.NODE_ENV === 'development' && token === 'dev-token') {
       return {
-        id: "dev-user-1",
-        email: "developer@intelgraph.com",
-        username: "developer",
-        role: "ADMIN",
+        id: 'dev-user-1',
+        email: 'developer@intelgraph.com',
+        username: 'developer',
+        role: 'ADMIN',
       };
     }
 
@@ -64,20 +69,19 @@ export const verifyToken = async (token: string): Promise<User> => {
 
     // Get user from database
     const pool = getPostgresPool();
-    const result = await pool.query(
-      "SELECT id, email, username, role FROM users WHERE id = $1",
-      [decoded.userId],
-    );
+    const result = await pool.query('SELECT id, email, username, role FROM users WHERE id = $1', [
+      decoded.userId,
+    ]);
 
     if (result.rows.length === 0) {
-      throw new Error("User not found");
+      throw new Error('User not found');
     }
 
     return result.rows[0];
   } catch (error) {
-    throw new GraphQLError("Invalid or expired token", {
+    throw new GraphQLError('Invalid or expired token', {
       extensions: {
-        code: "UNAUTHENTICATED",
+        code: 'UNAUTHENTICATED',
         http: { status: 401 },
       },
     });
@@ -92,15 +96,15 @@ export const generateToken = (user: User): string => {
       role: user.role,
     },
     JWT_SECRET,
-    { expiresIn: "1h" },
+    { expiresIn: '1h' },
   );
 };
 
 export const requireAuth = (context: AuthContext): User => {
   if (!context.isAuthenticated || !context.user) {
-    throw new GraphQLError("Authentication required", {
+    throw new GraphQLError('Authentication required', {
       extensions: {
-        code: "UNAUTHENTICATED",
+        code: 'UNAUTHENTICATED',
         http: { status: 401 },
       },
     });
@@ -108,15 +112,12 @@ export const requireAuth = (context: AuthContext): User => {
   return context.user;
 };
 
-export const requireRole = (
-  context: AuthContext,
-  requiredRole: string,
-): User => {
+export const requireRole = (context: AuthContext, requiredRole: string): User => {
   const user = requireAuth(context);
-  if (user.role !== requiredRole && user.role !== "ADMIN") {
-    throw new GraphQLError("Insufficient permissions", {
+  if (user.role !== requiredRole && user.role !== 'ADMIN') {
+    throw new GraphQLError('Insufficient permissions', {
       extensions: {
-        code: "FORBIDDEN",
+        code: 'FORBIDDEN',
         http: { status: 403 },
       },
     });
@@ -126,7 +127,7 @@ export const requireRole = (
 
 function extractToken(req: any): string | null {
   const authHeader = req.headers?.authorization;
-  if (authHeader?.startsWith("Bearer ")) {
+  if (authHeader?.startsWith('Bearer ')) {
     return authHeader.substring(7);
   }
   return null;

--- a/server/src/middleware/audit-logger.ts
+++ b/server/src/middleware/audit-logger.ts
@@ -1,21 +1,23 @@
-import { Request, Response, NextFunction } from "express";
-import { writeAudit } from "../utils/audit.js";
+import { Request, Response, NextFunction } from 'express';
+import { writeAudit } from '../utils/audit.js';
 
-export function auditLogger(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): void {
+export function auditLogger(req: Request, res: Response, next: NextFunction): void {
   const start = Date.now();
-  res.on("finish", () => {
+  res.on('finish', () => {
     const userId = (req as any).user?.id;
     writeAudit({
       userId,
       action: `${req.method} ${req.originalUrl}`,
-      resourceType: "http",
-      details: { status: res.statusCode, durationMs: Date.now() - start },
+      resourceType: 'http',
+      details: {
+        status: res.statusCode,
+        durationMs: Date.now() - start,
+        authority: req.get('x-authority'),
+        purpose: req.get('x-purpose'),
+        reason: req.get('x-reason'),
+      },
       ip: req.ip,
-      userAgent: req.get("user-agent"),
+      userAgent: req.get('user-agent'),
     });
   });
   next();


### PR DESCRIPTION
## Summary
- add GraphQL context enforcement for `x-authority`, `x-purpose`, and `x-reason`
- log authority, purpose, and reason in audit middleware
- introduce Rego policy and tests for authority-bound ABAC

## Testing
- `./opa test server/policies` *(fails: rego parse errors in existing policies)*
- `npm run format` *(fails: YAML parse errors in workflow files)*
- `npm run lint` *(fails: syntax errors in existing sources)*
- `npm test` *(fails: jest environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a65dc009f48333baaa5f15ef67874e