### PR TITLE
feat: add merkle manifest to provenance exports

### DIFF
--- a/prov-ledger/app/exporters/prov_json.py
+++ b/prov-ledger/app/exporters/prov_json.py
@@ -1,6 +1,13 @@
 import networkx as nx
 
+from ..manifest import build_manifest
+
+
 def export(graph: nx.DiGraph) -> dict:
     nodes = [{"id": n, **graph.nodes[n]} for n in graph.nodes]
     edges = [{"source": u, "target": v} for u, v in graph.edges]
-    return {"nodes": nodes, "edges": edges, "metadata": {}}
+    evidence = [
+        graph.nodes[n]["data"] for n in graph.nodes if graph.nodes[n].get("type") == "evidence"
+    ]
+    manifest = build_manifest(evidence)
+    return {"nodes": nodes, "edges": edges, "metadata": {}, "manifest": manifest}

--- a/prov-ledger/app/manifest.py
+++ b/prov-ledger/app/manifest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from typing import Any
+
+
+def _parent(h1: bytes, h2: bytes) -> bytes:
+    """Compute parent hash for two children."""
+    return sha256(h1 + h2).digest()
+
+
+def _merkle_root(leaves: list[bytes]) -> bytes:
+    if not leaves:
+        return b""
+    current = leaves
+    while len(current) > 1:
+        if len(current) % 2 == 1:
+            current.append(current[-1])
+        current = [_parent(current[i], current[i + 1]) for i in range(0, len(current), 2)]
+    return current[0]
+
+
+def build_manifest(evidence: list[dict[str, str]]) -> dict[str, Any]:
+    """Build a simple manifest with Merkle root over evidence hashes."""
+    leaves = [bytes.fromhex(e["hash"]) for e in evidence if e.get("hash")]
+    root = _merkle_root(leaves)
+    chain = [{"id": e["id"], "hash": e["hash"]} for e in evidence if e.get("hash")]
+    return {"version": "1.0", "root": root.hex() if root else "", "chain": chain}

--- a/prov-ledger/app/schemas.py
+++ b/prov-ledger/app/schemas.py
@@ -1,5 +1,6 @@
-from typing import Dict, List, Optional
-from pydantic import BaseModel, Field
+from typing import Optional
+
+from pydantic import BaseModel
 
 
 class SubmitText(BaseModel):
@@ -12,7 +13,7 @@ class Claim(BaseModel):
     id: str
     text: str
     normalized: str
-    embedding: Optional[List[float]] = None
+    embedding: Optional[list[float]] = None
     created_at: str
 
 
@@ -35,12 +36,24 @@ class AttachEvidenceRequest(BaseModel):
 
 class Corroboration(BaseModel):
     claim_id: str
-    evidence_ids: List[str]
+    evidence_ids: list[str]
     score: float
-    breakdown: Dict[str, float]
+    breakdown: dict[str, float]
+
+
+class ManifestEntry(BaseModel):
+    id: str
+    hash: str
+
+
+class Manifest(BaseModel):
+    version: str
+    root: str
+    chain: list[ManifestEntry]
 
 
 class ProvExport(BaseModel):
-    nodes: List[dict]
-    edges: List[dict]
-    metadata: Dict[str, str]
+    nodes: list[dict]
+    edges: list[dict]
+    metadata: dict[str, str]
+    manifest: Manifest


### PR DESCRIPTION
## Summary
- build simple Merkle manifest for evidence
- include manifest in provenance exports
- add Manifest schema types

## Testing
- `ruff check --fix prov-ledger/app/manifest.py prov-ledger/app/exporters/prov_json.py prov-ledger/app/schemas.py`
- `black prov-ledger/app/manifest.py prov-ledger/app/exporters/prov_json.py prov-ledger/app/schemas.py`
- `mypy prov-ledger/app/manifest.py prov-ledger/app/exporters/prov_json.py prov-ledger/app/schemas.py --follow-imports skip`
- `cd prov-ledger && pytest` *(fails: Module apps was never imported)*
- `pre-commit run --files prov-ledger/app/manifest.py prov-ledger/app/exporters/prov_json.py prov-ledger/app/schemas.py prov-ledger/tests/test_provenance.py` *(fails: InvalidManifestError: .../.pre-commit-hooks.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a65d8ae340833395d9bb3ba70fa3e2