### PR TITLE
chore: add sprint 07 bootstrap workflows and issue seeding script

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature
+about: Plan and track a deliverable
+labels: type:feature, sprint-07
+---
+
+
+## Summary
+
+
+## Acceptance Criteria
+- [ ]
+
+
+## Notes
+- Risks:
+- Rollback:
+- Flags:
+
+
+## Validation
+- [ ] Unit/contract tests ≥90% coverage (if applicable)
+- [ ] E2E covered (Playwright) (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+
+## What & Why
+
+
+## Acceptance Criteria
+- [ ] Tests passing (unit/integration/E2E)
+- [ ] Security checks (OWASP/ZAP passive) clean
+- [ ] Docs/ADR updated
+
+
+## Screenshots/Artifacts
+
+
+## Risk & Rollback
+
+
+## Checklist
+- [ ] Feature flag documented
+- [ ] Observability (traces/metrics) added
+- [ ] OPA policies updated/tested (if access control touches)

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,14 @@
+[
+  {"name": "sprint-07", "color": "8A2BE2", "description": "Sprint 07 (Aug 25–Sep 5, 2025)"},
+  {"name": "area:frontend", "color": "1f77b4"},
+  {"name": "area:backend", "color": "ff7f0e"},
+  {"name": "area:graph", "color": "2ca02c"},
+  {"name": "area:ai", "color": "d62728"},
+  {"name": "area:devx", "color": "9467bd"},
+  {"name": "area:qa", "color": "17becf"},
+  {"name": "type:feature", "color": "0366d6"},
+  {"name": "type:test", "color": "0e8a16"},
+  {"name": "type:infra", "color": "b60205"},
+  {"name": "priority:p0", "color": "b60205"},
+  {"name": "priority:p1", "color": "d93f0b"}
+]

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -1,0 +1,17 @@
+name: Perf — k6
+on:
+  workflow_dispatch: {}
+  schedule: [{ cron: "0 9 * * 1-5" }]
+jobs:
+  k6:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run k6
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: tests/perf/nl2cypher_preview_test.js
+      - uses: actions/upload-artifact@v4
+        with:
+          name: k6-summary
+          path: tests/perf/output/**

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -1,0 +1,17 @@
+name: Policy — OPA
+on:
+  push:
+    branches: [ develop, main ]
+    paths: [ "policies/**" ]
+  pull_request:
+    paths: [ "policies/**" ]
+jobs:
+  opa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup OPA
+        uses: open-policy-agent/setup-opa@v2
+      - name: Unit test policies
+        run: |
+          opa test policies -v

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,29 @@
+name: E2E — Playwright
+on:
+  push:
+    branches: [ develop, main ]
+    paths: [ "apps/**", "packages/**", "tests/e2e/**", "package.json", "pnpm-lock.yaml" ]
+  pull_request:
+    paths: [ "apps/**", "packages/**", "tests/e2e/**" ]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 18 }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps
+      - name: Start app (web)
+        run: |
+          nohup pnpm --filter web start &
+          sleep 10
+      - name: Run Playwright
+        run: pnpm exec playwright test --reporter=line
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report

--- a/openapi/copilot.yml
+++ b/openapi/copilot.yml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info: { title: IntelGraph Copilot, version: 0.1.0 }
+paths:
+  /copilot/preview:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object, properties: { prompt: { type: string } }, required: [prompt] }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cypher: { type: string }
+                  estimate: { type: object, properties: { rows: { type: integer }, cost: { type: number } } }

--- a/policies/exports.rego
+++ b/policies/exports.rego
@@ -1,0 +1,18 @@
+package intelgraph.exports
+
+
+# Deny export when user lacks purpose/legal basis or policy label forbids
+deny[msg] {
+  input.action == "export_bundle"
+  not input.context.purpose
+  msg := "Missing purpose for processing"
+}
+
+
+deny[msg] {
+  input.action == "export_bundle"
+  some n
+  input.selection[n].policy == "classified"
+  not input.context.has_clearance
+  msg := sprintf("Node %v requires clearance", [input.selection[n].id])
+}

--- a/policies/tests/exports_test.rego
+++ b/policies/tests/exports_test.rego
@@ -1,0 +1,19 @@
+package intelgraph.exports
+
+
+test_missing_purpose_deny {
+  deny[msg] with input as {
+    "action": "export_bundle",
+    "context": {"purpose": ""},
+    "selection": []
+  }
+}
+
+
+test_classified_node_deny {
+  deny[msg] with input as {
+    "action": "export_bundle",
+    "context": {"purpose": "investigation", "has_clearance": false},
+    "selection": [{"id": "n1", "policy": "classified"}]
+  }
+}

--- a/scripts/seed_issues.sh
+++ b/scripts/seed_issues.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO=${REPO:-BrianCLong/intelgraph}
+
+
+# Milestone
+MILESTONE_TITLE="Sprint 07 (Aug 25–Sep 5, 2025)"
+MILESTONE_ID=$(gh api -X GET repos/$REPO/milestones | jq -r \
+  ".[] | select(.title==\"$MILESTONE_TITLE\") | .number" || true)
+if [[ -z "$MILESTONE_ID" ]]; then
+  MILESTONE_ID=$(gh api -X POST repos/$REPO/milestones -f title="$MILESTONE_TITLE" -f state=open | jq -r .number)
+fi
+
+
+echo "Milestone #$MILESTONE_ID"
+
+
+# Labels
+if [[ -f .github/labels.json ]]; then
+  while IFS= read -r row; do
+    NAME=$(echo "$row" | jq -r .name); COLOR=$(echo "$row" | jq -r .color); DESC=$(echo "$row" | jq -r .description // "")
+    gh label create "$NAME" --color "$COLOR" --description "$DESC" -R "$REPO" 2>/dev/null || gh label edit "$NAME" --color "$COLOR" --description "$DESC" -R "$REPO"
+  done < <(jq -c '.[]' .github/labels.json)
+fi
+
+
+create_issue(){
+  local TITLE="$1"; local BODY="$2"; local LABELS="$3";
+  gh issue create -R "$REPO" \
+    --title "$TITLE" \
+    --body "$BODY" \
+    --milestone "$MILESTONE_TITLE" \
+    --label "$LABELS"
+}
+
+
+# Backlog items (subset from Sprint 07 Backlog)
+create_issue "IG-721 — CSV Ingest Wizard" $'AC:\n- Navigate next/back, draft persists\n- Mapping validators block invalid\n- PII flags + license stored\nExit: nodes/edges contain PII+license attrs.' "type:feature,sprint-07,area:frontend,area:backend"
+
+
+create_issue "IG-722 — NL→Cypher Preview" $'AC:\n- ≥95% syntactic validity\n- Returns cypher + cost/row estimate\n- No writes in preview' "type:feature,sprint-07,area:ai,area:graph,area:backend"
+
+
+create_issue "IG-723 — Sandbox & Tri‑Pane UI" $'AC:\n- Read‑only sandbox w/ timeouts\n- Cytoscape + timeline + map sync ≤100ms' "type:feature,sprint-07,area:frontend,area:backend"
+
+
+create_issue "IG-724 — Provenance & Claim Ledger" $'AC:\n- Claim/Evidence schema + indexes\n- Manifest export passes external verifier' "type:feature,sprint-07,area:backend,area:graph"
+
+
+create_issue "IG-725 — Disclosure Bundle Export" $'AC:\n- GET /bundles/:id/export returns manifest + files\n- UI shows size/hash/license summary' "type:feature,sprint-07,area:frontend,area:backend"
+
+
+create_issue "IG-726 — ABAC/OPA + Policy Labels" $'AC:\n- Deny/allow with human‑readable reason\n- Policy labels on nodes/edges; audit trail' "type:feature,sprint-07,area:backend,area:graph"
+
+
+create_issue "IG-727 — Observability & Cost Guards" $'AC:\n- OTEL traces across gateway→copilot→graph\n- Grafana SLO p95 panel\n- Slow query killer + audit entries' "type:infra,sprint-07,area:devx,area:backend"
+
+
+# Subtasks (illustrative — add more as needed)
+create_issue "IG-721-1 — Wizard scaffold (FE)" $'AC:\n- Stepper nav, draft persistence' "sprint-07,area:frontend"
+create_issue "IG-722-3 — Cost/row estimator (Graph)" $'AC:\n- Estimates within ±20% on 10 queries' "sprint-07,area:graph"
+create_issue "IG-723-2 — Cytoscape wiring (FE)" $'AC:\n- Selections/brush sync across panes' "sprint-07,area:frontend"
+create_issue "IG-724-3 — Manifest generator (BE)" $'AC:\n- Merkle over artifacts; verifier PASS' "sprint-07,area:backend"
+create_issue "IG-726-1 — OPA integration (BE)" $'AC:\n- Deny/allow with reason logged' "sprint-07,area:backend"
+
+
+printf "\nDone. Assign owners in the UI or extend script with --assignee flags.\n"

--- a/tests/e2e/runbook.spec.ts
+++ b/tests/e2e/runbook.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+
+test('Rapid Attribution flow', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await page.getByRole('button', { name: 'Import CSV' }).click();
+  await expect(page.getByText('Map columns')).toBeVisible();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByPlaceholder('Ask a question').fill('Show infrastructure pivot from malware X across last 90 days');
+  await page.getByRole('button', { name: 'Preview Cypher' }).click();
+  await expect(page.getByText('Estimated cost')).toBeVisible();
+  await page.getByRole('button', { name: 'Run in Sandbox' }).click();
+  await expect(page.getByTestId('tri-pane')).toBeVisible();
+  await page.getByTestId('graph').hover();
+  await expect(page.getByText('Provenance')).toBeVisible();
+});

--- a/tests/perf/nl2cypher_preview_test.js
+++ b/tests/perf/nl2cypher_preview_test.js
@@ -1,0 +1,24 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+
+export const options = {
+  vus: 25,
+  duration: '5m',
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<1500']
+  }
+};
+
+
+export default function () {
+  const payload = JSON.stringify({ prompt: 'Find co-mentions between entity A and B last 30 days' });
+  const res = http.post(`${__ENV.API_BASE}/copilot/preview`, payload, { headers: { 'Content-Type': 'application/json' } });
+  check(res, {
+    'status 200': (r) => r.status === 200,
+    'has cypher': (r) => (r.json('cypher') || '').length > 0,
+    'has estimate': (r) => r.json('estimate') !== undefined,
+  });
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
- add issue/PR templates, labels, and OpenAPI stub for Copilot
- seed Playwright and k6 tests with CI workflows and OPA policy stubs
- provide GitHub issue seeding script for Sprint 07

## Testing
- `npm test` *(fails: jest: not found)*
- `REPO=BrianCLong/intelgraph ./scripts/seed_issues.sh` *(fails: gh: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c67e803c83339bbe1c65830361c5