### PR TITLE
fix: correct GraphQL lint configuration

### DIFF
--- a/.graphql-schema-linterrc
+++ b/.graphql-schema-linterrc
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "fields-have-descriptions": "warn",
+    "types-have-descriptions": "warn",
+    "input-object-values-are-camel-cased": "error",
+    "enum-values-all-caps": "off"
+  }
+}

--- a/.graphqlrc.yml
+++ b/.graphqlrc.yml
@@ -1,3 +1,7 @@
-schema: 'packages/graphql/schema.graphql'
+schema:
+  - "server/src/graphql/schema/*.graphql"
+  - "server/src/graphql/schemas/*.graphql"
+  - "server/src/schema/*.graphql"
 documents:
-  - 'apps/frontend/src/**/*.graphql'
+  - "client/src/**/*.graphql"
+  - "server/src/**/*.graphql"

--- a/package.json
+++ b/package.json
@@ -103,6 +103,12 @@
     }
   },
   "lint-staged": {
+    "server/src/**/*.{graphql,gql}": [
+      "graphql-schema-linter"
+    ],
+    "client/src/**/*.graphql": [
+      "graphql-schema-linter"
+    ],
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "prettier -w"
@@ -110,9 +116,6 @@
     "*.py": [
       "ruff --fix",
       "black"
-    ],
-    "*.graphql": [
-      "graphql-schema-linter"
     ],
     "*.{md,css,scss,json,yml,yaml}": [
       "prettier -w"


### PR DESCRIPTION
## Summary
- align `.graphqlrc.yml` schema and document paths with actual server and client layout
- add `.graphql-schema-linterrc` with starter rules
- scope lint-staged to client and server GraphQL files

## Testing
- `npm install` *(fails: node-pre-gyp err for canvas)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npx graphql-schema-linter server/src/schema/ai.graphql` *(fails: TypeError string.split is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d4cb4d648333acea8d9decf965d7