### PR TITLE
feat: add API contracts and service skeletons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,3 +140,9 @@ USE_SPACY=false # Enable Spacy for NLP
 
 # Feature Flags
 DISABLE_SOCKET_AUTH=0 # Disable Socket.IO authentication (0 for enabled, 1 for disabled)
+# Prov-ledger and gateway services
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASS=pass
+OPA_URL=http://localhost:8181/v1/data/intelgraph/exports
+PORT=4001

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@intelgraph/gateway",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "@apollo/server": "^4.11.1",
+    "graphql": "^16.8.1",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import { ApolloServer } from '@apollo/server';
+import { expressMiddleware } from '@apollo/server/express4';
+import fs from 'fs';
+import path from 'path';
+import { resolvers } from './resolvers';
+import { logger } from './logger';
+
+const typeDefs = fs.readFileSync(path.join(__dirname, 'schema.graphql'), 'utf8');
+
+export async function createApp() {
+  const app = express();
+  const server = new ApolloServer({ typeDefs, resolvers });
+  await server.start();
+  app.use('/graphql', expressMiddleware(server));
+  return app;
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  createApp().then(app => {
+    const port = process.env.PORT || 4000;
+    app.listen(port, () => logger.info({ port }, 'gateway listening'));
+  });
+}

--- a/gateway/src/logger.ts
+++ b/gateway/src/logger.ts
@@ -1,0 +1,5 @@
+export const logger = {
+  info: (...args: any[]) => console.log(...args),
+  error: (...args: any[]) => console.error(...args),
+  warn: (...args: any[]) => console.warn(...args)
+};

--- a/gateway/src/opa.ts
+++ b/gateway/src/opa.ts
@@ -1,0 +1,12 @@
+import fetch from 'node-fetch';
+
+export async function evaluate(policy: string, input: any): Promise<{ allow: boolean; reason?: string[] }> {
+  const resp = await fetch((process.env.OPA_URL || 'http://localhost:8181/v1/data/') + policy, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input })
+  });
+  const json = await resp.json();
+  const deny = json.result?.deny || [];
+  return { allow: deny.length === 0, reason: deny };
+}

--- a/gateway/src/resolvers.ts
+++ b/gateway/src/resolvers.ts
@@ -1,0 +1,24 @@
+import { evaluate } from './opa';
+
+export const resolvers = {
+  Query: {
+    claim: () => null,
+    evidence: () => null,
+    searchNodes: () => [],
+  },
+  Mutation: {
+    createEvidence: () => {
+      throw new Error('not_implemented');
+    },
+    createClaim: () => {
+      throw new Error('not_implemented');
+    },
+    exportBundle: async (_: any, { id }: any, context: any) => {
+      const result = await evaluate('intelgraph/exports', { id, user: context?.user });
+      if (!result.allow) {
+        throw new Error('forbidden');
+      }
+      return 'todo';
+    },
+  },
+};

--- a/gateway/src/schema.graphql
+++ b/gateway/src/schema.graphql
@@ -1,0 +1,61 @@
+scalar JSON
+
+
+type Evidence {
+  id: ID!
+  source: String!
+  license: String!
+  confidence: Float
+  artifacts: [Artifact!]!
+  createdAt: String!
+}
+
+type Artifact {
+  id: ID!
+  sha256: String!
+  url: String
+}
+
+type Claim {
+  id: ID!
+  statement: String!
+  evidence: [Evidence!]!
+  attribution: String
+  confidence: Float
+  createdAt: String!
+}
+
+# Policy labels surfaced from graph nodes/edges
+interface PolicyLabeled {
+  policy: String
+}
+
+type Node implements PolicyLabeled {
+  id: ID!
+  labels: [String!]!
+  properties: JSON!
+  policy: String
+}
+
+type Edge implements PolicyLabeled {
+  id: ID!
+  type: String!
+  from: ID!
+  to: ID!
+  properties: JSON!
+  policy: String
+}
+
+type Query {
+  claim(id: ID!): Claim
+  evidence(id: ID!): Evidence
+  searchNodes(q: String!, limit: Int = 50): [Node!]!
+}
+
+type Mutation {
+  createEvidence(source: String!, license: String!, confidence: Float, artifacts: [ArtifactInput!]!): Evidence!
+  createClaim(statement: String!, evidenceIds: [ID!]!, attribution: String, confidence: Float): Claim!
+  exportBundle(id: ID!): String! # returns a presigned URL or download token
+}
+
+input ArtifactInput { id: ID!, sha256: String!, url: String }

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/tests/*.spec.ts'],
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+      tsconfig: {
+        esModuleInterop: true
+      }
+    }
+  }
+};
+
+export default config;

--- a/openapi/copilot.yml
+++ b/openapi/copilot.yml
@@ -1,0 +1,91 @@
+openapi: 3.0.3
+info:
+  title: IntelGraph Copilot
+  version: 0.1.0
+servers:
+  - url: https://api.example.com
+paths:
+  /copilot/preview:
+    post:
+      summary: Generate Cypher + cost/row estimate (no execute)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+              properties:
+                prompt:
+                  type: string
+                  minLength: 4
+                context:
+                  type: object
+                  additionalProperties: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - cypher
+                  - estimate
+                properties:
+                  cypher:
+                    type: string
+                  estimate:
+                    type: object
+                    properties:
+                      rows:
+                        type: integer
+                      cost:
+                        type: number
+                  warnings:
+                    type: array
+                    items:
+                      type: string
+        "400":
+          description: Invalid prompt
+  /copilot/execute:
+    post:
+      summary: Execute a **read-only** query in sandbox
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - cypher
+              properties:
+                cypher:
+                  type: string
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 100000
+                  default: 10000
+      responses:
+        "200":
+          description: Result set (nodes/edges rows)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  columns:
+                    type: array
+                    items:
+                      type: string
+                  rows:
+                    type: array
+                    items:
+                      type: array
+                      items: {}
+        "403":
+          description: Write operations are not permitted in sandbox
+        "422":
+          description: Unsafe Cypher detected

--- a/openapi/prov-ledger.yml
+++ b/openapi/prov-ledger.yml
@@ -1,0 +1,91 @@
+openapi: 3.0.3
+info:
+  title: Provenance & Claim Ledger
+  version: 0.1.0
+paths:
+  /evidence:
+    post:
+      summary: Create evidence record + optional file hashes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - source
+                - license
+                - artifacts
+              properties:
+                source:
+                  type: string
+                license:
+                  type: string
+                  enum:
+                    - CC-BY
+                    - ODC-BY
+                    - CUSTOM
+                confidence:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+                artifacts:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - id
+                      - sha256
+                    properties:
+                      id:
+                        type: string
+                      sha256:
+                        type: string
+                        pattern: '^[a-f0-9]{64}$'
+                      url:
+                        type: string
+      responses:
+        '201':
+          description: Created
+  /claims:
+    post:
+      summary: Create a claim linked to evidence
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - statement
+                - evidenceIds
+              properties:
+                statement:
+                  type: string
+                evidenceIds:
+                  type: array
+                  items:
+                    type: string
+                attribution:
+                  type: string
+                confidence:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+      responses:
+        '201':
+          description: Created
+  /bundles/{id}/export:
+    get:
+      summary: Download disclosure bundle manifest + files
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: Not found

--- a/openapi/sandbox.yml
+++ b/openapi/sandbox.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: Read-only Sandbox
+  version: 0.1.0
+paths:
+  /sandbox/run:
+    post:
+      summary: Run **read-only** Cypher with timeouts and budget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - cypher
+              properties:
+                cypher:
+                  type: string
+                timeoutMs:
+                  type: integer
+                  minimum: 100
+                  maximum: 10000
+                  default: 5000
+                budgetRU:
+                  type: integer
+                  minimum: 1
+                  maximum: 100000
+                  default: 10000
+      responses:
+        '200':
+          description: OK
+        '403':
+          description: Write op detected
+        '408':
+          description: Timeout

--- a/policies/exports.rego
+++ b/policies/exports.rego
@@ -1,0 +1,8 @@
+package intelgraph.exports
+
+default deny = []
+
+deny[msg] {
+  input.purpose != "research"
+  msg := "invalid_purpose"
+}

--- a/policies/tests/exports_test.rego
+++ b/policies/tests/exports_test.rego
@@ -1,0 +1,15 @@
+package intelgraph.exports
+
+import data.intelgraph.exports
+
+# Allow when purpose is research
+allow_when_purpose_research {
+  result := exports.deny with input as {"purpose": "research"}
+  count(result) == 0
+}
+
+# Deny when purpose not research
+block_invalid_purpose {
+  result := exports.deny with input as {"purpose": "other"}
+  count(result) == 1
+}

--- a/services/copilot/package.json
+++ b/services/copilot/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@intelgraph/copilot-service",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.2.0",
+    "express-rate-limit": "^6.11.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/services/copilot/src/index.ts
+++ b/services/copilot/src/index.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import previewRouter from './routes/preview';
+import executeRouter from './routes/execute';
+import { logger } from './lib/logger';
+
+const app = express();
+app.use(helmet());
+app.use(express.json({ limit: '1mb' }));
+app.use(rateLimit({ windowMs: 60_000, max: 600 }));
+
+app.use('/copilot/preview', previewRouter);
+app.use('/copilot/execute', executeRouter);
+
+app.use((err: any, _req: any, res: any, _next: any) => {
+  logger.error({ err }, 'Unhandled error');
+  res.status(500).json({ error: 'internal_error' });
+});
+
+const port = process.env.PORT || 4000;
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => logger.info({ port }, 'copilot listening'));
+}
+
+export default app;

--- a/services/copilot/src/lib/logger.ts
+++ b/services/copilot/src/lib/logger.ts
@@ -1,0 +1,5 @@
+export const logger = {
+  info: (...args: any[]) => console.log(...args),
+  error: (...args: any[]) => console.error(...args),
+  warn: (...args: any[]) => console.warn(...args)
+};

--- a/services/copilot/src/lib/prompt.ts
+++ b/services/copilot/src/lib/prompt.ts
@@ -1,0 +1,11 @@
+export function generateCypher(prompt: string, _context?: any): string {
+  return 'MATCH (n) RETURN n LIMIT 10';
+}
+
+export function estimateCost(_cypher: string): { rows: number; cost: number } {
+  return { rows: 10, cost: 1 };
+}
+
+export function guardrails(_cypher: string): string[] {
+  return [];
+}

--- a/services/copilot/src/lib/safety.ts
+++ b/services/copilot/src/lib/safety.ts
@@ -1,0 +1,10 @@
+const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+const PHONE = /\b\d{3}-\d{3}-\d{4}\b/g;
+const SSN = /\b\d{3}-\d{2}-\d{4}\b/g;
+
+export function scrub(input: string): string {
+  return input
+    .replace(EMAIL, '[redacted]')
+    .replace(PHONE, '[redacted]')
+    .replace(SSN, '[redacted]');
+}

--- a/services/copilot/src/routes/execute.ts
+++ b/services/copilot/src/routes/execute.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+
+const WRITE_BLACKLIST = [
+  /\bCREATE\b/i,
+  /\bMERGE\b/i,
+  /\bDELETE\b/i,
+  /\bSET\b/i,
+  /\bDROP\b/i
+];
+
+const r = Router();
+
+r.post('/', (req, res) => {
+  const { cypher, limit = 10000 } = req.body || {};
+  if (!cypher) {
+    return res.status(400).json({ error: 'invalid_payload' });
+  }
+  if (WRITE_BLACKLIST.some(rx => rx.test(cypher))) {
+    return res.status(403).json({ error: 'write_operations_forbidden' });
+  }
+  res.json({ columns: [], rows: [] });
+});
+
+export default r;

--- a/services/copilot/src/routes/preview.ts
+++ b/services/copilot/src/routes/preview.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { generateCypher, estimateCost, guardrails } from '../lib/prompt';
+
+const r = Router();
+
+r.post('/', (req, res) => {
+  const { prompt, context } = req.body || {};
+  if (!prompt || typeof prompt !== 'string' || prompt.length < 4) {
+    return res.status(400).json({ error: 'invalid_prompt' });
+  }
+  const cypher = generateCypher(prompt, context);
+  const warnings = guardrails(cypher);
+  const estimate = estimateCost(cypher);
+  res.json({ cypher, estimate, warnings });
+});
+
+export default r;

--- a/services/copilot/tsconfig.json
+++ b/services/copilot/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/prov-ledger/package.json
+++ b/services/prov-ledger/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@intelgraph/prov-ledger-service",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.2.0",
+    "express-rate-limit": "^6.11.2",
+    "neo4j-driver": "^5.28.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/services/prov-ledger/src/index.ts
+++ b/services/prov-ledger/src/index.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import evidenceRouter from './routes/evidence';
+import claimsRouter from './routes/claims';
+import exportRouter from './routes/export';
+import { logger } from './lib/logger';
+
+const app = express();
+app.use(helmet());
+app.use(express.json({ limit: '2mb' }));
+app.use(rateLimit({ windowMs: 60_000, max: 600 }));
+
+app.use('/evidence', evidenceRouter);
+app.use('/claims', claimsRouter);
+app.use('/bundles', exportRouter);
+
+app.use((err: any, _req: any, res: any, _next: any) => {
+  logger.error({ err }, 'Unhandled error');
+  res.status(500).json({ error: 'internal_error' });
+});
+
+const port = process.env.PORT || 4001;
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => logger.info({ port }, 'prov-ledger listening'));
+}
+
+export default app;

--- a/services/prov-ledger/src/lib/logger.ts
+++ b/services/prov-ledger/src/lib/logger.ts
@@ -1,0 +1,5 @@
+export const logger = {
+  info: (...args: any[]) => console.log(...args),
+  error: (...args: any[]) => console.error(...args),
+  warn: (...args: any[]) => console.warn(...args)
+};

--- a/services/prov-ledger/src/lib/manifest.ts
+++ b/services/prov-ledger/src/lib/manifest.ts
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+
+export interface Artifact {
+  id: string;
+  sha256: string;
+  url?: string;
+}
+export interface Manifest {
+  version: string;
+  createdAt: string;
+  artifacts: Artifact[];
+  merkleRoot: string;
+  nodes: string[];
+}
+
+export function buildManifest(artifacts: Artifact[]): Manifest {
+  if (!artifacts.length) throw new Error('no_artifacts');
+  const leaves = artifacts.map(a => Buffer.from(a.sha256, 'hex'));
+  const nodes: string[] = [];
+  let level = leaves;
+  while (level.length > 1) {
+    const next: Buffer[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      const left = level[i];
+      const right = i + 1 < level.length ? level[i + 1] : level[i];
+      const h = crypto
+        .createHash('sha256')
+        .update(Buffer.concat([left, right]))
+        .digest();
+      nodes.push(h.toString('hex'));
+      next.push(h);
+    }
+    level = next;
+  }
+  const merkleRoot = (level[0] || leaves[0]).toString('hex');
+  return {
+    version: '1.0',
+    createdAt: new Date().toISOString(),
+    artifacts,
+    merkleRoot,
+    nodes,
+  };
+}

--- a/services/prov-ledger/src/lib/neo.ts
+++ b/services/prov-ledger/src/lib/neo.ts
@@ -1,0 +1,22 @@
+import neo4j, { Driver } from 'neo4j-driver';
+
+let driver: Driver;
+export function getDriver(): Driver {
+  if (!driver) {
+    driver = neo4j.driver(
+      process.env.NEO4J_URI!,
+      neo4j.auth.basic(process.env.NEO4J_USER!, process.env.NEO4J_PASS!),
+      { disableLosslessIntegers: true }
+    );
+  }
+  return driver;
+}
+
+export async function withSession<T>(fn: (s: any) => Promise<T>): Promise<T> {
+  const session = getDriver().session({ defaultAccessMode: neo4j.session.WRITE });
+  try {
+    return await fn(session);
+  } finally {
+    await session.close();
+  }
+}

--- a/services/prov-ledger/src/routes/claims.ts
+++ b/services/prov-ledger/src/routes/claims.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { withSession } from '../lib/neo';
+
+const r = Router();
+
+r.post('/', async (req, res) => {
+  const { statement, evidenceIds, attribution, confidence } = req.body || {};
+  if (!statement || !Array.isArray(evidenceIds) || evidenceIds.length === 0) {
+    return res.status(400).json({ error: 'invalid_payload' });
+  }
+  const id = 'cl_' + Date.now().toString(36);
+  await withSession(async s => {
+    await s.run(
+      `CREATE (c:Claim {id: $id, statement: $statement, attribution: $attribution, confidence: $confidence, createdAt: datetime()})
+       WITH c
+       UNWIND $evidenceIds AS eid
+       MATCH (e:Evidence {id: eid})
+       CREATE (c)-[:SUPPORTED_BY]->(e)
+       RETURN c.id AS id`,
+      { id, statement, attribution: attribution ?? null, confidence: confidence ?? null, evidenceIds }
+    );
+  });
+  res.status(201).json({ id });
+});
+
+export default r;

--- a/services/prov-ledger/src/routes/evidence.ts
+++ b/services/prov-ledger/src/routes/evidence.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { withSession } from '../lib/neo';
+import { logger } from '../lib/logger';
+
+const r = Router();
+
+r.post('/', async (req, res) => {
+  const { source, license, confidence, artifacts } = req.body || {};
+  if (!source || !license || !Array.isArray(artifacts) || artifacts.length === 0) {
+    return res.status(400).json({ error: 'invalid_payload' });
+  }
+
+  try {
+    const id = 'ev_' + Date.now().toString(36);
+    await withSession(async s => {
+      await s.run(
+        `CREATE (e:Evidence {id: $id, source: $source, license: $license, confidence: $confidence, createdAt: datetime()})
+         WITH e
+         UNWIND $artifacts AS a
+         CREATE (ar:Artifact {id: a.id, sha256: a.sha256, url: a.url})-[:PART_OF]->(e)
+         RETURN e.id AS id`,
+        { id, source, license, confidence: confidence ?? null, artifacts }
+      );
+    });
+    res.status(201).json({ id });
+  } catch (e) {
+    logger.error({ e }, 'evidence_create_failed');
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+export default r;

--- a/services/prov-ledger/src/routes/export.ts
+++ b/services/prov-ledger/src/routes/export.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { withSession } from '../lib/neo';
+import { buildManifest } from '../lib/manifest';
+
+const r = Router();
+
+r.get('/:id/export', async (req, res) => {
+  const { id } = req.params;
+  const result = await withSession(async s =>
+    s.run(
+      `MATCH (c:Claim {id: $id})-[:SUPPORTED_BY]->(:Evidence)<-[:PART_OF]-(a:Artifact)
+       RETURN a.id AS id, a.sha256 AS sha256, a.url AS url`,
+      { id }
+    )
+  );
+  const artifacts = result.records.map((r: any) => ({
+    id: r.get('id'),
+    sha256: r.get('sha256'),
+    url: r.get('url'),
+  }));
+  if (!artifacts.length) return res.status(404).json({ error: 'bundle_not_found' });
+  const manifest = buildManifest(artifacts);
+  res.json({ manifest, artifacts });
+});
+
+export default r;

--- a/services/prov-ledger/tsconfig.json
+++ b/services/prov-ledger/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/services/sandbox/package.json
+++ b/services/sandbox/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@intelgraph/sandbox-service",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "helmet": "^7.2.0",
+    "express-rate-limit": "^6.11.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/services/sandbox/src/index.ts
+++ b/services/sandbox/src/index.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import runRouter from './routes/run';
+import { logger } from './lib/logger';
+
+const app = express();
+app.use(helmet());
+app.use(express.json({ limit: '1mb' }));
+app.use(rateLimit({ windowMs: 60_000, max: 600 }));
+
+app.use('/sandbox/run', runRouter);
+
+app.use((err: any, _req: any, res: any, _next: any) => {
+  logger.error({ err }, 'Unhandled error');
+  res.status(500).json({ error: 'internal_error' });
+});
+
+const port = process.env.PORT || 4002;
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => logger.info({ port }, 'sandbox listening'));
+}
+
+export default app;

--- a/services/sandbox/src/lib/logger.ts
+++ b/services/sandbox/src/lib/logger.ts
@@ -1,0 +1,5 @@
+export const logger = {
+  info: (...args: any[]) => console.log(...args),
+  error: (...args: any[]) => console.error(...args),
+  warn: (...args: any[]) => console.warn(...args)
+};

--- a/services/sandbox/src/lib/neo.ts
+++ b/services/sandbox/src/lib/neo.ts
@@ -1,0 +1,6 @@
+export async function withSession<T>(fn: (s: any) => Promise<T>): Promise<T> {
+  const session = {
+    run: async () => ({ keys: [], records: [] })
+  };
+  return await fn(session);
+}

--- a/services/sandbox/src/routes/run.ts
+++ b/services/sandbox/src/routes/run.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { withSession } from '../lib/neo';
+
+const WRITE_BLACKLIST = [
+  /\bCREATE\b/i,
+  /\bMERGE\b/i,
+  /\bDELETE\b/i,
+  /\bSET\b/i,
+  /\bDROP\b/i
+];
+
+const r = Router();
+
+r.post('/', async (req, res) => {
+  const { cypher, timeoutMs = 5000 } = req.body || {};
+  if (!cypher || WRITE_BLACKLIST.some(rx => rx.test(cypher))) {
+    return res.status(403).json({ error: 'write_operations_forbidden' });
+  }
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const data = await withSession(async s => s.run(cypher, {}, { timeout: timeoutMs }));
+    clearTimeout(t);
+    res.json({ columns: data.keys, rows: data.records.map((r: any) => r) });
+  } catch (e: any) {
+    if (controller.signal.aborted) {
+      return res.status(408).json({ error: 'timeout' });
+    }
+    res.status(422).json({ error: 'invalid_or_unsafe_cypher' });
+  }
+});
+
+export default r;

--- a/services/sandbox/tsconfig.json
+++ b/services/sandbox/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tests/copilot.preview.spec.ts
+++ b/tests/copilot.preview.spec.ts
@@ -1,0 +1,15 @@
+import request from 'supertest';
+import app from '../services/copilot/src/index';
+
+describe('copilot preview', () => {
+  it('rejects short prompt', async () => {
+    const res = await request(app).post('/copilot/preview').send({ prompt: 'hi' });
+    expect(res.status).toBe(400);
+  });
+  it('returns cypher + estimate', async () => {
+    const res = await request(app).post('/copilot/preview').send({ prompt: 'Find connections between A and B' });
+    expect(res.status).toBe(200);
+    expect(res.body.cypher).toContain('MATCH');
+    expect(res.body.estimate).toHaveProperty('rows');
+  });
+});

--- a/tests/manifest.golden.json
+++ b/tests/manifest.golden.json
@@ -1,0 +1,7 @@
+{
+  "artifacts": [
+    { "id": "a1", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+    { "id": "a2", "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }
+  ],
+  "merkleRoot": "<computed>"
+}

--- a/tests/manifest.spec.ts
+++ b/tests/manifest.spec.ts
@@ -1,0 +1,17 @@
+import { buildManifest } from '../services/prov-ledger/src/lib/manifest';
+
+describe('manifest', () => {
+  it('builds a merkle root deterministically', () => {
+    const artifacts = [
+      { id: 'a1', sha256: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+      { id: 'a2', sha256: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+    ];
+    const m = buildManifest(artifacts as any);
+    expect(m.merkleRoot).toMatch(/^[a-f0-9]{64}$/);
+    expect(m.artifacts.length).toBe(2);
+  });
+
+  it('throws on empty input', () => {
+    expect(() => buildManifest([] as any)).toThrow('no_artifacts');
+  });
+});

--- a/tests/sandbox.readonly.spec.ts
+++ b/tests/sandbox.readonly.spec.ts
@@ -1,0 +1,9 @@
+import request from 'supertest';
+import app from '../services/sandbox/src/index';
+
+describe('sandbox RO', () => {
+  it('blocks writes', async () => {
+    const res = await request(app).post('/sandbox/run').send({ cypher: 'CREATE (n)' });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenAPI specs for Copilot, provenance ledger, and sandbox services
- scaffold Node/Express services with logging, validation, and read-only enforcement
- introduce gateway GraphQL schema and OPA policy hooks

## Testing
- `npx jest -c jest.config.ts --runInBand`
- `npm test -- --config jest.config.cjs` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `opa test policies` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6de235bbc83339e4e49374b57d534