### PR TITLE
chore: improve graphql lint configuration

### DIFF
--- a/.graphql-schema-linterrc
+++ b/.graphql-schema-linterrc
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "fields-have-descriptions": "warn",
+    "types-have-descriptions": "warn",
+    "input-object-values-are-camel-cased": "error",
+    "enum-values-all-caps": "off"
+  }
+}

--- a/.graphqlrc.yml
+++ b/.graphqlrc.yml
@@ -1,3 +1,8 @@
-schema: 'packages/graphql/schema.graphql'
+schema:
+  - "server/src/graphql/schema/*.graphql"
+  - "server/src/graphql/schemas/*.graphql"
+  - "server/src/schema/*.graphql"
 documents:
-  - 'apps/frontend/src/**/*.graphql'
+  - "client/src/**/*.graphql"
+  - "server/src/**/*.graphql"
+

--- a/package.json
+++ b/package.json
@@ -103,6 +103,12 @@
     }
   },
   "lint-staged": {
+    "server/src/**/*.{graphql,gql}": [
+      "graphql-schema-linter"
+    ],
+    "client/src/**/*.graphql": [
+      "graphql-schema-linter"
+    ],
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",
       "prettier -w"
@@ -110,9 +116,6 @@
     "*.py": [
       "ruff --fix",
       "black"
-    ],
-    "*.graphql": [
-      "graphql-schema-linter"
     ],
     "*.{md,css,scss,json,yml,yaml}": [
       "prettier -w"


### PR DESCRIPTION
## Summary
- point GraphQL linter at actual schema and document locations
- relax schema linter rules for smoother adoption
- scope lint-staged GraphQL checks to server and client sources

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: sh: 1: eslint: not found)*
- `npm run format` *(fails: sh: 1: prettier: not found)*
- `npm install` *(fails: Package 'pixman-1' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6deb7ae5c8333a049c6b05ed5512f