### PR TITLE
feat: add verifiable disclosure bundles

### DIFF
--- a/prov-ledger/app/claims.py
+++ b/prov-ledger/app/claims.py
@@ -3,6 +3,7 @@ from typing import Dict
 import uuid
 
 from .nlp.embedder import embed
+from .events import emit
 
 STOPWORDS = {"the", "a", "an", "of", "and", "to"}
 
@@ -27,6 +28,7 @@ def create_claim(text: str) -> dict:
         "evidence": [],
     }
     _claims[cid] = claim
+    emit("prov.claim.registered", {"id": cid})
     return claim
 
 

--- a/prov-ledger/app/cli.py
+++ b/prov-ledger/app/cli.py
@@ -1,0 +1,51 @@
+import argparse
+import json
+import hashlib
+from typing import List
+
+from .disclosure import _merkle_root
+from .events import emit
+
+
+def _hash_claim(claim: dict) -> str:
+    return hashlib.sha256(claim["normalized"].encode()).hexdigest()
+
+
+def verify_bundle(path: str) -> tuple[bool, List[str]]:
+    with open(path) as f:
+        bundle = json.load(f)
+    manifest = bundle.get("manifest", {})
+    entries = manifest.get("entries", [])
+    id_to_hash = {e["id"]: e["hash"] for e in entries}
+    diffs: List[str] = []
+    for claim in bundle.get("claims", []):
+        h = _hash_claim(claim)
+        if id_to_hash.get(claim["id"]) != h:
+            diffs.append(claim["id"])
+    for ev in bundle.get("evidence", []):
+        if id_to_hash.get(ev["id"]) != ev.get("hash"):
+            diffs.append(ev["id"])
+    root = _merkle_root([e["hash"] for e in entries])
+    if root != manifest.get("root"):
+        diffs.append("root")
+    return len(diffs) == 0, diffs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify provenance bundle")
+    parser.add_argument("bundle", help="Path to bundle JSON")
+    args = parser.parse_args()
+    ok, diffs = verify_bundle(args.bundle)
+    emit("prov.verify.requested", {"bundle": args.bundle})
+    if ok:
+        print("PASS")
+        return 0
+    else:
+        print("FAIL")
+        if diffs:
+            print("diff:", ", ".join(diffs))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prov-ledger/app/disclosure.py
+++ b/prov-ledger/app/disclosure.py
@@ -1,0 +1,62 @@
+import hashlib
+import uuid
+from typing import Dict, List
+
+from . import claims, evidence, provenance
+from .events import emit
+
+_bundles: Dict[str, dict] = {}
+_manifests: Dict[str, dict] = {}
+
+
+def _merkle_root(hashes: List[str]) -> str:
+    if not hashes:
+        return ""
+    nodes = [bytes.fromhex(h) for h in hashes]
+    while len(nodes) > 1:
+        if len(nodes) % 2 == 1:
+            nodes.append(nodes[-1])
+        nodes = [hashlib.sha256(nodes[i] + nodes[i + 1]).digest() for i in range(0, len(nodes), 2)]
+    return nodes[0].hex()
+
+
+def build_bundle(claim_ids: List[str]) -> dict:
+    entries: List[dict] = []
+    bundle_claims: List[dict] = []
+    bundle_evidence: Dict[str, dict] = {}
+
+    for cid in claim_ids:
+        claim = claims.get_claim(cid)
+        if not claim:
+            continue
+        bundle_claims.append(claim)
+        chash = hashlib.sha256(claim["normalized"].encode()).hexdigest()
+        entries.append({"id": cid, "hash": chash})
+        for eid in claim["evidence"]:
+            ev = evidence.get_evidence(eid)
+            if not ev:
+                continue
+            terms = (ev.get("license_terms") or "").lower()
+            if "no-export" in terms:
+                owner = ev.get("license_owner") or "unknown"
+                raise ValueError(f"license restricts export by {owner}: {ev.get('license_terms')}")
+            bundle_evidence[eid] = ev
+            entries.append({"id": eid, "hash": ev["hash"]})
+
+    root = _merkle_root([e["hash"] for e in entries])
+    manifest = {"root": root, "entries": entries}
+    bundle_id = str(uuid.uuid4())
+    bundle = {
+        "bundle_id": bundle_id,
+        "manifest": manifest,
+        "claims": bundle_claims,
+        "evidence": list(bundle_evidence.values()),
+    }
+    _bundles[bundle_id] = bundle
+    _manifests[bundle_id] = manifest
+    emit("prov.bundle.built", {"bundle_id": bundle_id})
+    return bundle
+
+
+def get_manifest(bundle_id: str) -> dict | None:
+    return _manifests.get(bundle_id)

--- a/prov-ledger/app/events.py
+++ b/prov-ledger/app/events.py
@@ -1,0 +1,10 @@
+_events: list[dict] = []
+
+
+def emit(topic: str, payload: dict) -> None:
+    """Record an event in-memory.
+
+    Acts as a lightweight stand-in for Kafka emission so tests can
+    introspect generated events without external dependencies.
+    """
+    _events.append({"topic": topic, "payload": payload})

--- a/prov-ledger/app/evidence.py
+++ b/prov-ledger/app/evidence.py
@@ -9,7 +9,16 @@ from .signatures import verify_signature
 _evidence: Dict[str, dict] = {}
 
 
-def register_evidence(kind: str, url: str | None = None, content: bytes | None = None, title: str | None = None, signature: bytes | None = None, public_key: str | None = None) -> dict:
+def register_evidence(
+    kind: str,
+    url: str | None = None,
+    content: bytes | None = None,
+    title: str | None = None,
+    signature: bytes | None = None,
+    public_key: str | None = None,
+    license_terms: str | None = None,
+    license_owner: str | None = None,
+) -> dict:
     evid_id = str(uuid.uuid4())
     data = content or (url or "").encode()
     h, length = sha256_digest(BytesIO(data))
@@ -27,6 +36,8 @@ def register_evidence(kind: str, url: str | None = None, content: bytes | None =
         "created_at": datetime.utcnow().isoformat(),
         "signed": signed,
         "signer_fp": signer_fp,
+        "license_terms": license_terms,
+        "license_owner": license_owner,
     }
     _evidence[evid_id] = evid
     return evid

--- a/prov-ledger/app/schemas.py
+++ b/prov-ledger/app/schemas.py
@@ -26,6 +26,8 @@ class Evidence(BaseModel):
     created_at: Optional[str] = None
     signed: Optional[bool] = False
     signer_fp: Optional[str] = None
+    license_terms: Optional[str] = None
+    license_owner: Optional[str] = None
 
 
 class AttachEvidenceRequest(BaseModel):
@@ -44,3 +46,24 @@ class ProvExport(BaseModel):
     nodes: List[dict]
     edges: List[dict]
     metadata: Dict[str, str]
+
+
+class BundleRequest(BaseModel):
+    claim_ids: List[str] = Field(default_factory=list)
+
+
+class ManifestEntry(BaseModel):
+    id: str
+    hash: str
+
+
+class Manifest(BaseModel):
+    root: str
+    entries: List[ManifestEntry]
+
+
+class DisclosureBundle(BaseModel):
+    bundle_id: str
+    manifest: Manifest
+    claims: List[Claim]
+    evidence: List[Evidence]

--- a/prov-ledger/pyproject.toml
+++ b/prov-ledger/pyproject.toml
@@ -13,3 +13,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest", "httpx"]
+
+[project.scripts]
+ig-prov-verify = "app.cli:main"

--- a/prov-ledger/tests/test_disclosure_bundle.py
+++ b/prov-ledger/tests/test_disclosure_bundle.py
@@ -1,0 +1,53 @@
+import json
+import subprocess
+import tempfile
+
+from fixtures import client
+
+
+def create_claim_with_evidence(client, url, license_terms=None, license_owner=None):
+    claim = client.post(
+        "/claims/extract",
+        json={"text": "Jupiter is massive."},
+        headers={"X-API-Key": "testkey"},
+    ).json()[0]
+    evid = client.post(
+        "/evidence/register",
+        json={"kind": "url", "url": url, "license_terms": license_terms, "license_owner": license_owner},
+        headers={"X-API-Key": "testkey"},
+    ).json()
+    client.post(
+        f"/claims/{claim['id']}/attach",
+        json={"claim_id": claim["id"], "evidence_id": evid["id"]},
+        headers={"X-API-Key": "testkey"},
+    )
+    return claim, evid
+
+
+def test_bundle_build_and_verify(client):
+    claim, evid = create_claim_with_evidence(client, "http://example.com")
+    resp = client.post(
+        "/bundles/build",
+        json={"claim_ids": [claim["id"]]},
+        headers={"X-API-Key": "testkey"},
+    )
+    assert resp.status_code == 200
+    bundle = resp.json()
+    with tempfile.NamedTemporaryFile("w", delete=False) as f:
+        json.dump(bundle, f)
+        path = f.name
+    out = subprocess.run(["python", "-m", "app.cli", path], capture_output=True, text=True)
+    assert out.returncode == 0
+    assert "PASS" in out.stdout
+
+
+def test_bundle_blocked_by_license(client):
+    claim, evid = create_claim_with_evidence(client, "http://example.com/bad", "no-export", "alice")
+    resp = client.post(
+        "/bundles/build",
+        json={"claim_ids": [claim["id"]]},
+        headers={"X-API-Key": "testkey"},
+    )
+    assert resp.status_code == 403
+    detail = resp.json()["detail"]
+    assert "alice" in detail and "no-export" in detail


### PR DESCRIPTION
## Summary
- add in-memory events and license-aware evidence registration
- implement disclosure bundles with merkle manifest and CLI verifier
- expose bundle build and manifest endpoints

## Testing
- `pytest -q`
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: YAML syntax errors in workflows)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef858e208333827f389402e18e27