### PR TITLE
feat(connector): Elastic SIEM ingest & OPA tenant bundles

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+ENABLE_SPLUNK_HEC=false

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ jspm_packages/
 # Prevent secrets / env files
 .env.*
 !.env.example
+!.env.sample
 
 # dotenv environment variables file
 .env.test

--- a/client/src/components/connectors/EcsIngestPanel.tsx
+++ b/client/src/components/connectors/EcsIngestPanel.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import $ from 'jquery';
+import { useMutation, gql } from '@apollo/client';
+
+const MUT = gql`mutation($events: JSON!, $options: EcsIngestOptions!) {
+  ingestEcsEvents(events:$events, options:$options){ received accepted rejected batchId }
+}`;
+
+export default function EcsIngestPanel() {
+  const [mutate, { data, loading }] = useMutation(MUT);
+  const [json, setJson] = React.useState('[]');
+
+  React.useEffect(() => {
+    $('#ecsIngestBtn').off('click').on('click', async () => {
+      $('#ecsIngestBtn').prop('disabled', true);
+      try {
+        const events = JSON.parse(json);
+        const res = await mutate({ variables: { events, options: { source: 'elastic-ecs' } }});
+        const r = res.data.ingestEcsEvents;
+        $('#ecsIngestResult').text(`Received ${r.received}, accepted ${r.accepted}, rejected ${r.rejected} (batch ${r.batchId})`);
+      } catch (e) {
+        $('#ecsIngestResult').text('Invalid JSON or server error');
+      } finally {
+        $('#ecsIngestBtn').prop('disabled', false);
+      }
+    });
+  }, [json]);
+
+  return (
+    <div className="p-4 rounded-2xl shadow space-y-3">
+      <h3 className="text-lg font-semibold">Elastic SIEM (ECS) Ingest</h3>
+      <textarea value={json} onChange={e=>setJson(e.target.value)} className="w-full h-40 p-2 rounded border" />
+      <button id="ecsIngestBtn" className="px-4 py-2 rounded-2xl shadow">{loading ? 'Ingesting…' : 'Ingest JSON'}</button>
+      <div id="ecsIngestResult" className="text-sm opacity-80" />
+    </div>
+  );
+}

--- a/client/src/components/onboarding/GoldenPathWizard.jsx
+++ b/client/src/components/onboarding/GoldenPathWizard.jsx
@@ -69,6 +69,7 @@ import {
 } from '@mui/icons-material';
 import { useMutation, useQuery } from '@apollo/client';
 import { useNavigate } from 'react-router-dom';
+import EcsIngestPanel from '../connectors/EcsIngestPanel';
 
 // GraphQL operations (would be imported from actual files)
 const CREATE_INVESTIGATION = `
@@ -499,7 +500,7 @@ const GoldenPathWizard = ({ open, onClose, onComplete }) => {
               >
                 Simulate CSV Import
               </Button>
-              
+
               <Button
                 variant="outlined"
                 startIcon={<TimelineIcon />}
@@ -511,6 +512,9 @@ const GoldenPathWizard = ({ open, onClose, onComplete }) => {
               >
                 Simulate STIX Import
               </Button>
+            </Box>
+            <Box mt={3}>
+              <EcsIngestPanel />
             </Box>
           </Box>
         );

--- a/client/tests/ecs-ingest.spec.ts
+++ b/client/tests/ecs-ingest.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('ECS ingest panel works', async ({ page }) => {
+  await page.goto(process.env.APP_URL || 'http://localhost:5173');
+  await page.getByText('Elastic SIEM (ECS) Ingest').click();
+  await page.getByRole('textbox').fill('[{"@timestamp":"2025-08-22T00:00:00Z","event":{"id":"e2"},"source":{"ip":"3.3.3.3"},"destination":{"ip":"4.4.4.4"},"host":{"name":"h2"},"user":{"name":"u2"}}]');
+  await page.getByRole('button', { name: 'Ingest JSON' }).click();
+  await expect(page.locator('#ecsIngestResult')).toContainText('accepted 1');
+});

--- a/helm/intelgraph/templates/deployment-server.yaml
+++ b/helm/intelgraph/templates/deployment-server.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "intelgraph.fullname" . }}-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: opa
+          image: openpolicyagent/opa:0.67.0-rootless
+          args: ["run","--server","--addr=0.0.0.0:8181","--config-file=/config/config.yaml"]
+          ports:
+            - containerPort: 8181
+          volumeMounts:
+            - name: opa-config
+              mountPath: /config
+      volumes:
+        - name: opa-config
+          configMap:
+            name: opa-config

--- a/helm/intelgraph/templates/opa-configmap.yaml
+++ b/helm/intelgraph/templates/opa-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-config
+data:
+  config.yaml: |
+    services:
+      bundlesvc:
+        url: {{ .Values.opa.serviceUrl }}
+    bundles:
+      global:
+        service: bundlesvc
+        resource: bundles/global.tar.gz
+      {{- range .Values.opa.tenants }}
+      tenant-{{ .slug }}:
+        service: bundlesvc
+        resource: bundles/tenant/{{ .slug }}.tar.gz
+      {{- end }}
+    decision_logs:
+      console: true

--- a/helm/intelgraph/values/common-opa.yaml
+++ b/helm/intelgraph/values/common-opa.yaml
@@ -1,0 +1,7 @@
+opa:
+  enabled: true
+  serviceUrl: https://your-bundle-cdn.example.com
+  tenants:
+    - slug: acme
+    - slug: globex
+    - slug: initech

--- a/policies/combined.rego
+++ b/policies/combined.rego
@@ -1,0 +1,24 @@
+package intelgraph.combined
+
+default allow = false
+
+allow {
+  data.intelgraph.authz.allow
+}
+
+allow {
+  t := input.tenant
+  data.tenant[t].authz.allow_extra
+}
+
+deny_reason[msg] {
+  not allow
+  t := input.tenant
+  msg := coalesce([data.tenant[t].authz.deny_reasons[_], "policy_denied"])
+}
+
+coalesce(arr) = out {
+  count(arr) > 0
+  some x
+  out := arr[x]
+}

--- a/policies/combined_test.rego
+++ b/policies/combined_test.rego
@@ -1,0 +1,12 @@
+package intelgraph.combined
+
+import data.intelgraph.authz
+import data.tenant
+
+test_global_deny {
+  not allow with input as {"tenant":"default","user":{"role":"guest"},"field":"investigations"}
+}
+
+test_tenant_extra_allow {
+  allow with input as {"tenant":"acme","user":{"role":"viewer"},"field":"investigations"}
+}

--- a/policies/global/authz.rego
+++ b/policies/global/authz.rego
@@ -1,0 +1,15 @@
+package intelgraph.authz
+
+default allow = false
+
+# Example: allow read investigations if role permits
+allow {
+  input.user.role == "analyst"
+  input.operation == "Query"
+  input.field == "investigations"
+}
+
+deny_reason[msg] {
+  not allow
+  msg := sprintf("Denied by policy: role=%s op=%s field=%s", [input.user.role, input.operation, input.field])
+}

--- a/policies/tenant/acme/authz.rego
+++ b/policies/tenant/acme/authz.rego
@@ -1,0 +1,13 @@
+package tenant.acme.authz
+
+# Additional allowances or denials specific to acme
+allow_extra {
+  input.user.role == "viewer"
+  input.field == "investigations"
+}
+
+deny_reasons[msg] {
+  input.field == "exportInvestigationProvenance"
+  input.user.role != "analyst"
+  msg := "acme: export restricted to analysts"
+}

--- a/server/src/graphql/resolvers/connectors.ts
+++ b/server/src/graphql/resolvers/connectors.ts
@@ -1,0 +1,13 @@
+import { ingestEcsEvents } from '../../services/connectors/elasticEcs.js';
+
+export default {
+  Query: {
+    connectorStatus: () => ([
+      { name: 'elastic-ecs', enabled: true, version: '1.0.0' },
+      { name: 'splunk-hec', enabled: process.env.ENABLE_SPLUNK_HEC === 'true', version: '0.1.0' }
+    ])
+  },
+  Mutation: {
+    ingestEcsEvents: async (_: any, { events, options }: any) => ingestEcsEvents(events, options)
+  }
+};

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -7,6 +7,7 @@ import relationshipResolvers from './relationship';
 import userResolvers from './user';
 import investigationResolvers from './investigation';
 import { WargameResolver } from '../../resolvers/WargameResolver.js'; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
+import connectorResolvers from './connectors';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -24,6 +25,7 @@ const resolvers = {
     ...entityResolvers.Query,
     ...userResolvers.Query,
     ...investigationResolvers.Query,
+    ...connectorResolvers.Query,
     
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     getCrisisTelemetry: wargameResolver.getCrisisTelemetry.bind(wargameResolver),
@@ -43,6 +45,7 @@ const resolvers = {
     ...relationshipResolvers.Mutation,
     ...userResolvers.Mutation,
     ...investigationResolvers.Mutation,
+    ...connectorResolvers.Mutation,
     
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     runWarGameSimulation: wargameResolver.runWarGameSimulation.bind(wargameResolver),

--- a/server/src/graphql/schema.js
+++ b/server/src/graphql/schema.js
@@ -1,10 +1,17 @@
 import { gql } from 'graphql-tag';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 const { copilotTypeDefs } = require('./schema.copilot.js');
 const { graphTypeDefs } = require('./schema.graphops.js');
 const { aiTypeDefs } = require('./schema.ai.js');
 const { annotationsTypeDefs } = require('./schema.annotations.js');
 const graphragTypes = require('./types/graphragTypes.js');
 import { coreTypeDefs } from './schema.core.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const connectorsTypeDefs = gql(readFileSync(path.join(__dirname, 'schema/connectors.graphql'), 'utf8'));
 
 const base = gql`
   scalar JSON
@@ -15,4 +22,4 @@ const base = gql`
   type Subscription { _empty: String }
 `;
 
-export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs, annotationsTypeDefs];
+export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs, annotationsTypeDefs, connectorsTypeDefs];

--- a/server/src/graphql/schema/connectors.graphql
+++ b/server/src/graphql/schema/connectors.graphql
@@ -1,0 +1,17 @@
+type ConnectorStatus { name: String!, enabled: Boolean!, version: String! }
+
+input EcsIngestOptions {
+  source: String!
+  batchId: String
+  normalize: Boolean = true
+}
+
+type IngestResult { received: Int!, accepted: Int!, rejected: Int!, batchId: String }
+
+extend type Query {
+  connectorStatus: [ConnectorStatus!]!
+}
+
+extend type Mutation {
+  ingestEcsEvents(events: JSON!, options: EcsIngestOptions!): IngestResult!
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,7 @@ import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
 import { DataRetentionService } from './services/DataRetentionService.js';
 import { getNeo4jDriver } from './db/neo4j.js';
+import connectorRoutes from './routes/connectors.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const logger = logger.child({ name: 'index' });
@@ -30,6 +31,7 @@ const startServer = async () => {
     }
   }
   const app = await createApp();
+  app.use('/api', connectorRoutes);
   const schema = makeExecutableSchema({ typeDefs, resolvers });
   const httpServer = http.createServer(app);
 

--- a/server/src/routes/connectors.ts
+++ b/server/src/routes/connectors.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { ingestEcsEvents } from '../services/connectors/elasticEcs.js';
+
+const r = Router();
+
+r.post('/connectors/elastic-ecs', async (req, res, next) => {
+  try {
+    const out = await ingestEcsEvents(req.body?.events || [], { source: req.query.source as string || 'elastic-ecs' });
+    res.json(out);
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default r;

--- a/server/src/services/connectors/elasticEcs.ts
+++ b/server/src/services/connectors/elasticEcs.ts
@@ -1,0 +1,86 @@
+import neo4j from 'neo4j-driver';
+import { getNeo4jDriver } from '../../db/neo4j.js';
+import { v4 as uuid } from 'uuid';
+import baseLogger from '../../config/logger.js';
+
+const log = baseLogger.child({ name: 'elastic-ecs' });
+
+/**
+ * Minimal ECS -> Graph mapping
+ * Entities: Host, User, IP, Event
+ * Relationships: OBSERVED_ON (Event->Host), INVOLVES_USER (Event->User), COMMUNICATES_WITH (IP->IP)
+ */
+export async function ingestEcsEvents(events: any, opts: { source: string; batchId?: string; normalize?: boolean; }) {
+  const driver = getNeo4jDriver();
+  const session = driver.session({ defaultAccessMode: neo4j.session.WRITE });
+  const batchId = opts.batchId || uuid();
+  let received = 0, accepted = 0, rejected = 0;
+
+  try {
+    if (!Array.isArray(events)) throw new Error('events must be an array');
+    received = events.length;
+
+    await session.writeTransaction(async tx => {
+      for (const ev of events) {
+        try {
+          const e = sanitizeEcs(ev);
+          const params = {
+            id: e.event_id,
+            ts: e['@timestamp'],
+            category: e.category,
+            action: e.action,
+            outcome: e.outcome,
+            src_ip: e.src_ip,
+            dst_ip: e.dst_ip,
+            host: e.host_name,
+            user: e.user_name,
+            source: opts.source,
+            batchId
+          };
+
+          // Parameterized Cypher to prevent injection
+          await tx.run(
+            `
+            MERGE (h:Host {name:$host})
+            MERGE (u:User {name:$user})
+            MERGE (s:IP {address:$src_ip})
+            MERGE (d:IP {address:$dst_ip})
+            MERGE (e:Event {id:$id})
+              ON CREATE SET e.createdAt = datetime($ts)
+              ON MATCH  SET e.lastSeen  = datetime($ts)
+            SET e.category=$category, e.action=$action, e.outcome=$outcome, e.source=$source, e.batchId=$batchId
+            MERGE (e)-[:OBSERVED_ON]->(h)
+            MERGE (e)-[:INVOLVES_USER]->(u)
+            MERGE (s)-[:COMMUNICATES_WITH {batchId:$batchId}]->(d)
+            `,
+            params
+          );
+          accepted++;
+        } catch (err) {
+          rejected++;
+          log.warn({ err }, 'reject-ecs-event');
+        }
+      }
+    });
+
+    log.info({ batchId, accepted, rejected }, 'ecs-ingest-complete');
+    return { received, accepted, rejected, batchId };
+  } finally {
+    await session.close();
+  }
+}
+
+function sanitizeEcs(ev: any) {
+  const safe = (v: any) => (typeof v === 'string' ? v.slice(0, 512) : v);
+  return {
+    event_id: safe(ev?.event?.id || ev?.['event.id'] || uuid()),
+    '@timestamp': ev?.['@timestamp'] || new Date().toISOString(),
+    category: safe(ev?.event?.category || 'unknown'),
+    action: safe(ev?.event?.action || 'observe'),
+    outcome: safe(ev?.event?.outcome || 'unknown'),
+    src_ip: safe(ev?.source?.ip || ev?.['source.ip'] || '0.0.0.0'),
+    dst_ip: safe(ev?.destination?.ip || ev?.['destination.ip'] || '0.0.0.0'),
+    host_name: safe(ev?.host?.name || ev?.['host.name'] || 'unknown'),
+    user_name: safe(ev?.user?.name || ev?.['user.name'] || 'unknown'),
+  };
+}

--- a/server/src/services/connectors/splunkHec.ts
+++ b/server/src/services/connectors/splunkHec.ts
@@ -1,0 +1,3 @@
+const enabled = process.env.ENABLE_SPLUNK_HEC === 'true';
+export const isEnabled = () => enabled;
+// TODO: map HEC events -> ECS-like internal shape, reuse ingestEcsEvents

--- a/server/tests/connectors.elasticEcs.spec.ts
+++ b/server/tests/connectors.elasticEcs.spec.ts
@@ -1,0 +1,17 @@
+import { ingestEcsEvents } from '../src/services/connectors/elasticEcs';
+import * as neo from '../src/db/neo4j';
+
+jest.spyOn(neo, 'getNeo4jDriver').mockReturnValue({
+  session: () => ({
+    writeTransaction: async (fn: any) => fn({ run: async () => {} }),
+    close: async () => {}
+  })
+} as any);
+
+test('ingests minimal ECS array', async () => {
+  const events = [{ '@timestamp': '2025-08-22T00:00:00Z', event: { id: 'e1', category: 'network' }, source: { ip: '1.1.1.1' }, destination: { ip: '2.2.2.2' }, host: { name: 'h1' }, user: { name: 'u1' } }];
+  const res = await ingestEcsEvents(events, { source: 'test' });
+  expect(res.received).toBe(1);
+  expect(res.accepted).toBe(1);
+  expect(res.rejected).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add Elastic SIEM (ECS) ingest API and UI panel; stub Splunk HEC connector
- introduce tenant-scoped OPA bundles with Helm config and policy wiring

## Testing
- `npm test` *(fails: jest not found)*
- `opa test -v policies` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9ef1b56883339ea7232cf2828eff