### PR TITLE
feat: add policy audit sdk and sidecar

### DIFF
--- a/contracts/policy/abac.rego
+++ b/contracts/policy/abac.rego
@@ -1,0 +1,26 @@
+[
+  {
+    "subject": { "clearance": "top-secret" },
+    "action": "read",
+    "resource": { "classification": "secret" },
+    "context": { "purpose": "research" },
+    "decision": "allow",
+    "reason": "clearance matches classification"
+  },
+  {
+    "subject": { "license": "gold" },
+    "action": "use",
+    "resource": {},
+    "context": { "purpose": "licensed" },
+    "decision": "allow",
+    "reason": "license is valid"
+  },
+  {
+    "subject": { "purpose": "training" },
+    "action": "read",
+    "resource": {},
+    "context": {},
+    "decision": "allow",
+    "reason": "training materials accessible"
+  }
+]

--- a/packages/policy-audit/__tests__/audit.test.js
+++ b/packages/policy-audit/__tests__/audit.test.js
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { audit, verify } from '../src/audit.js';
+
+test('tampering breaks the chain', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-'));
+  audit({ decision: 'allow', reason: 'ok', subject: {}, resource: {} }, dir);
+  audit({ decision: 'deny', reason: 'no', subject: {}, resource: {} }, dir);
+  const file = path.join(dir, `audit-${new Date().toISOString().slice(0, 10)}.log`);
+  assert.strictEqual(verify(file), true);
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  const first = JSON.parse(lines[0]);
+  first.reason = 'tampered';
+  lines[0] = JSON.stringify(first);
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+  assert.strictEqual(verify(file), false);
+});

--- a/packages/policy-audit/__tests__/policy.test.js
+++ b/packages/policy-audit/__tests__/policy.test.js
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluate } from '../src/policy.js';
+
+function rand() {
+  return Math.random().toString(36).substring(2);
+}
+
+test('random inputs without policies are denied', () => {
+  for (let i = 0; i < 50; i++) {
+    const input = {
+      subject: { clearance: rand() },
+      action: rand(),
+      resource: { classification: rand() },
+      context: { purpose: rand() }
+    };
+    const res = evaluate(input, []);
+    assert.strictEqual(res.allow, false);
+  }
+});

--- a/packages/policy-audit/package.json
+++ b/packages/policy-audit/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@intelgraph/policy-audit",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.js"
+}

--- a/packages/policy-audit/src/audit.js
+++ b/packages/policy-audit/src/audit.js
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+
+export function audit(entry, logDir = '.') {
+  const date = new Date().toISOString().slice(0, 10);
+  const file = path.join(logDir, `audit-${date}.log`);
+  let prevHash = '';
+  if (fs.existsSync(file)) {
+    const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+    if (lines.length > 0) {
+      prevHash = JSON.parse(lines[lines.length - 1]).hash;
+    }
+  }
+  const data = {
+    ...entry,
+    timestamp: new Date().toISOString(),
+    prevHash
+  };
+  const hash = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(data))
+    .digest('hex');
+  const record = { ...data, hash };
+  fs.appendFileSync(file, JSON.stringify(record) + '\n');
+  return { auditId: hash };
+}
+
+export function verify(file) {
+  if (!fs.existsSync(file)) return false;
+  const lines = fs.readFileSync(file, 'utf8').trim().split('\n');
+  let prevHash = '';
+  for (const line of lines) {
+    const entry = JSON.parse(line);
+    const { hash, ...data } = entry;
+    const calc = crypto
+      .createHash('sha256')
+      .update(JSON.stringify(data))
+      .digest('hex');
+    if (entry.prevHash !== prevHash || calc !== hash) return false;
+    prevHash = hash;
+  }
+  return true;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const target = process.argv[2];
+  if (!target) {
+    console.error('usage: node audit.js <file>');
+    process.exit(1);
+  }
+  console.log(verify(target) ? 'chain valid' : 'chain invalid');
+}

--- a/packages/policy-audit/src/index.js
+++ b/packages/policy-audit/src/index.js
@@ -1,0 +1,2 @@
+export { evaluate } from './policy.js';
+export { audit, verify } from './audit.js';

--- a/packages/policy-audit/src/policy.js
+++ b/packages/policy-audit/src/policy.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+
+function loadPolicies() {
+  const file = path.resolve('contracts/policy/abac.rego');
+  const data = fs.readFileSync(file, 'utf8');
+  return JSON.parse(data);
+}
+
+function matches(rulePart, inputPart = {}) {
+  return Object.entries(rulePart || {}).every(([k, v]) => inputPart[k] === v);
+}
+
+export function evaluate(input, policies = loadPolicies()) {
+  for (const rule of policies) {
+    if (
+      matches(rule.subject, input.subject) &&
+      matches(rule.resource, input.resource) &&
+      (!rule.action || rule.action === input.action) &&
+      matches(rule.context, input.context)
+    ) {
+      return { allow: rule.decision === 'allow', reason: rule.reason };
+    }
+  }
+  return { allow: false, reason: 'no matching policy' };
+}

--- a/services/policy-audit/index.js
+++ b/services/policy-audit/index.js
@@ -1,0 +1,41 @@
+import http from 'http';
+import { evaluate, audit } from '../../packages/policy-audit/src/index.js';
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => {
+      try { resolve(JSON.parse(data || '{}')); } catch (e) { reject(e); }
+    });
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/v0/eval') {
+    try {
+      const body = await parseBody(req);
+      const result = evaluate(body);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+    } catch (e) {
+      res.writeHead(400); res.end();
+    }
+  } else if (req.method === 'POST' && req.url === '/v0/audit') {
+    try {
+      const body = await parseBody(req);
+      const result = audit(body);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+    } catch (e) {
+      res.writeHead(400); res.end();
+    }
+  } else {
+    res.writeHead(404); res.end();
+  }
+});
+
+const port = process.env.PORT || 8181;
+server.listen(port, () => {
+  console.log(`policy service listening on ${port}`);
+});

--- a/services/policy-audit/package.json
+++ b/services/policy-audit/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "policy-audit-service",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add basic ABAC policy examples
- implement policy evaluator and append-only audit log with SHA256 chain
- expose eval and audit HTTP endpoints via sidecar service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*
- `node --test packages/policy-audit/__tests__/policy.test.js packages/policy-audit/__tests__/audit.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68aa9f4b4d0c83339c853f34fc9f48e9