### PR TITLE
feat: add multi-domain correlation service

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,2 +1,3 @@
 export * from './graphql';
 export * from './realtime';
+export * from './integration';

--- a/packages/contracts/src/integration.ts
+++ b/packages/contracts/src/integration.ts
@@ -1,0 +1,23 @@
+export interface GeoInfo {
+  region?: string;
+  country?: string;
+}
+
+export interface FusionEntity {
+  id: string;
+  type: string;
+  domain: 'cybersecurity' | 'intelligence' | 'military' | 'nation-state';
+  phase: string;
+  description: string;
+  score?: number;
+  linked_to?: string[];
+  timestamp?: string;
+  geo?: GeoInfo;
+  tags?: string[];
+}
+
+export interface CorrelationAlert {
+  message: string;
+  source: string;
+  target: string;
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,6 +12,7 @@ import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
 import { register } from "./monitoring/metrics.js";
 import rbacRouter from "./routes/rbacRoutes.js";
+import integrationRouter from "./routes/integrationRoutes.js";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
 import { getContext } from "./lib/auth.js";
@@ -42,6 +43,7 @@ export const createApp = async () => {
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
   app.use("/rbac", rbacRouter);
+  app.use("/integration", integrationRouter);
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", register.contentType);
     res.end(await register.metrics());

--- a/server/src/routes/integrationRoutes.ts
+++ b/server/src/routes/integrationRoutes.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import { MultiDomainCorrelationService } from '../services/MultiDomainCorrelationService.js';
+
+const router = express.Router();
+const service = new MultiDomainCorrelationService();
+
+router.use(express.json());
+
+router.post('/correlate', (req, res) => {
+  const entities = req.body as any[];
+  const alerts = service.correlate(entities);
+  res.json({ alerts });
+});
+
+export default router;

--- a/server/src/services/MultiDomainCorrelationService.test.ts
+++ b/server/src/services/MultiDomainCorrelationService.test.ts
@@ -1,0 +1,32 @@
+import { MultiDomainCorrelationService } from './MultiDomainCorrelationService';
+import { FusionEntity } from '../../../packages/contracts/src/integration';
+
+describe('MultiDomainCorrelationService', () => {
+  it('triggers alert for credential access during low maturity phase', () => {
+    const service = new MultiDomainCorrelationService();
+    const entities: FusionEntity[] = [
+      {
+        id: 'actor1',
+        type: 'threat_actor',
+        domain: 'intelligence',
+        phase: 'Phase 3',
+        description: 'APT actor',
+        tags: ['credential_access'],
+        linked_to: ['org1'],
+      },
+      {
+        id: 'org1',
+        type: 'maturity_score',
+        domain: 'cybersecurity',
+        phase: 'Phase 2',
+        description: 'Mid-level org',
+        score: 40,
+      },
+    ];
+
+    const alerts = service.correlate(entities);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].source).toBe('actor1');
+    expect(alerts[0].target).toBe('org1');
+  });
+});

--- a/server/src/services/MultiDomainCorrelationService.ts
+++ b/server/src/services/MultiDomainCorrelationService.ts
@@ -1,0 +1,29 @@
+import { FusionEntity, CorrelationAlert } from '../../../packages/contracts/src/integration';
+
+export class MultiDomainCorrelationService {
+  correlate(entities: FusionEntity[]): CorrelationAlert[] {
+    const alerts: CorrelationAlert[] = [];
+
+    for (const entity of entities) {
+      if (!entity.linked_to) continue;
+      for (const linkId of entity.linked_to) {
+        const target = entities.find((e) => e.id === linkId);
+        if (!target) continue;
+
+        if (
+          entity.tags?.includes('credential_access') &&
+          target.domain === 'cybersecurity' &&
+          target.phase === 'Phase 2'
+        ) {
+          alerts.push({
+            message: 'Vulnerability in identity protection detected during low maturity phase',
+            source: entity.id,
+            target: target.id,
+          });
+        }
+      }
+    }
+
+    return alerts;
+  }
+}


### PR DESCRIPTION
## Summary
- define FusionEntity schema for cross-domain intelligence
- add rule-based MultiDomainCorrelationService and `/integration/correlate` route
- export schema through contracts package

## Testing
- `npm install` *(fails: canvas missing pixman-1 library)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npm run format` *(fails: SyntaxError in workflow YAML)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa12d6b7c83339f4ee40e00e6eaf3