### PR TITLE
feat: add immutable audit log skeleton

### DIFF
--- a/ops/audit-log/README.md
+++ b/ops/audit-log/README.md
@@ -1,0 +1,5 @@
+# Audit Log Operations
+
+- Append-only storage with periodic Merkle roots.
+- Roots should be anchored externally for tamper evidence.
+- Storage should emulate WORM; retention controlled via `AUDIT_RETENTION_DAYS`.

--- a/packages/sdk/audit-js/__tests__/verify.test.js
+++ b/packages/sdk/audit-js/__tests__/verify.test.js
@@ -1,0 +1,16 @@
+import crypto from 'node:crypto';
+import { merkleRoot, verifyBundle } from '../src/index.js';
+
+describe('audit sdk', () => {
+  test('verifyBundle detects tampering', () => {
+    const hashes = [
+      crypto.createHash('sha256').update('a').digest('hex'),
+      crypto.createHash('sha256').update('b').digest('hex'),
+    ];
+    const root = merkleRoot(hashes);
+    const bundle = { hashes: [...hashes], merkleRoot: root };
+    expect(verifyBundle(bundle)).toBe(true);
+    bundle.hashes[1] = crypto.createHash('sha256').update('c').digest('hex');
+    expect(verifyBundle(bundle)).toBe(false);
+  });
+});

--- a/packages/sdk/audit-js/package.json
+++ b/packages/sdk/audit-js/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@intelgraph/audit-js",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.js"
+}

--- a/packages/sdk/audit-js/src/index.js
+++ b/packages/sdk/audit-js/src/index.js
@@ -1,0 +1,26 @@
+import crypto from 'node:crypto';
+
+export function merkleRoot(hashes) {
+  if (!hashes.length) return '';
+  let nodes = hashes.map((h) => Buffer.from(h, 'hex'));
+  while (nodes.length > 1) {
+    const next = [];
+    for (let i = 0; i < nodes.length; i += 2) {
+      const left = nodes[i];
+      const right = i + 1 < nodes.length ? nodes[i + 1] : nodes[i];
+      next.push(
+        crypto
+          .createHash('sha256')
+          .update(Buffer.concat([left, right]))
+          .digest(),
+      );
+    }
+    nodes = next;
+  }
+  return nodes[0].toString('hex');
+}
+
+export function verifyBundle(bundle) {
+  const root = merkleRoot(bundle.hashes || []);
+  return root === bundle.merkleRoot;
+}

--- a/services/audit-log/src/__tests__/integrity.test.ts
+++ b/services/audit-log/src/__tests__/integrity.test.ts
@@ -1,0 +1,28 @@
+import { computeHash, merkleRoot } from '../index.js';
+
+describe('audit log integrity', () => {
+  test('tampering changes merkle root', () => {
+    const rec1 = {
+      user: 'u',
+      action: 'a',
+      resource: 'r',
+      authorityId: 'id',
+      reason: 'ok',
+      timestamp: '1',
+    };
+    const hash1 = computeHash(rec1, '');
+    const rec2 = {
+      user: 'u2',
+      action: 'a2',
+      resource: 'r2',
+      authorityId: 'id2',
+      reason: 'ok2',
+      timestamp: '2',
+    };
+    const hash2 = computeHash(rec2, hash1);
+    const root = merkleRoot([hash1, hash2]);
+    const tamperedHash2 = computeHash({ ...rec2, reason: 'bad' }, hash1);
+    const tamperedRoot = merkleRoot([hash1, tamperedHash2]);
+    expect(tamperedRoot).not.toBe(root);
+  });
+});

--- a/services/audit-log/src/index.ts
+++ b/services/audit-log/src/index.ts
@@ -1,0 +1,79 @@
+import express from 'express';
+import crypto from 'node:crypto';
+
+interface AuditRecord {
+  user: string;
+  action: string;
+  resource: string;
+  authorityId: string;
+  reason: string;
+  timestamp: string;
+  hash: string;
+}
+
+export const app = express();
+app.use(express.json());
+
+export const log: AuditRecord[] = [];
+
+export function computeHash(record: Omit<AuditRecord, 'hash'>, prevHash: string): string {
+  const data = JSON.stringify(record) + prevHash;
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+export function merkleRoot(hashes: string[]): string {
+  if (hashes.length === 0) return '';
+  let nodes = hashes.map((h) => Buffer.from(h, 'hex'));
+  while (nodes.length > 1) {
+    const next: Buffer[] = [];
+    for (let i = 0; i < nodes.length; i += 2) {
+      const left = nodes[i];
+      const right = i + 1 < nodes.length ? nodes[i + 1] : nodes[i];
+      next.push(
+        crypto
+          .createHash('sha256')
+          .update(Buffer.concat([left, right]))
+          .digest(),
+      );
+    }
+    nodes = next;
+  }
+  return nodes[0].toString('hex');
+}
+
+app.post('/audit/append', (req, res) => {
+  const records = Array.isArray(req.body.records) ? req.body.records : [];
+  const offsets: number[] = [];
+  const hashes: string[] = [];
+
+  for (const r of records) {
+    const base = {
+      user: r.user,
+      action: r.action,
+      resource: r.resource,
+      authorityId: r.authorityId,
+      reason: r.reason,
+      timestamp: new Date().toISOString(),
+    };
+    const prevHash = log.length ? log[log.length - 1].hash : '';
+    const hash = computeHash(base, prevHash);
+    log.push({ ...base, hash });
+    offsets.push(log.length - 1);
+    hashes.push(hash);
+  }
+
+  res.json({ offsets, merkleRoot: merkleRoot(hashes) });
+});
+
+app.get('/audit/query', (req, res) => {
+  const { user, action, resource, start, end } = req.query;
+  let results = log.slice();
+  if (user) results = results.filter((r) => r.user === user);
+  if (action) results = results.filter((r) => r.action === action);
+  if (resource) results = results.filter((r) => r.resource === resource);
+  if (start) results = results.filter((r) => r.timestamp >= start);
+  if (end) results = results.filter((r) => r.timestamp <= end);
+  res.json({ records: results });
+});
+
+export default app;

--- a/tools/audit-proof-cli/index.js
+++ b/tools/audit-proof-cli/index.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { verifyBundle } from '../../packages/sdk/audit-js/src/index.js';
+
+const args = process.argv.slice(2);
+const fileIdx = args.indexOf('--file');
+if (fileIdx === -1 || !args[fileIdx + 1]) {
+  console.error('usage: audit verify --file <bundle>');
+  process.exit(1);
+}
+
+const bundlePath = args[fileIdx + 1];
+const bundle = JSON.parse(readFileSync(bundlePath, 'utf8'));
+const ok = verifyBundle(bundle);
+if (ok) {
+  console.log('green');
+  process.exit(0);
+}
+console.log('red');
+process.exit(1);


### PR DESCRIPTION
## Summary
- add audit-log service with append and query APIs using hash chains and Merkle roots
- provide JS SDK to verify audit bundles
- add audit-proof CLI and ops notes

## Testing
- `npm run format` (fails: Map keys must be unique in .github/workflows/cd-deploy.yml)
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: node-pre-gyp build error for canvas: Package 'pixman-1' not found)
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aaa73a6f3c8333bc130016c13d5b5e