### PR TITLE
feat: add wizard-of-oz stub API

### DIFF
--- a/server/src/admin/wizard.html
+++ b/server/src/admin/wizard.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Wizard Fixture Admin</title>
+  </head>
+  <body>
+    <h1>Simulated Fixture Editor</h1>
+    <textarea id="fixtures" style="width:100%;height:300px;"></textarea>
+    <br />
+    <button onclick="save()">Save</button>
+    <script>
+      async function load() {
+        const res = await fetch('/api/wizard/fixtures');
+        document.getElementById('fixtures').value = JSON.stringify(await res.json(), null, 2);
+      }
+      async function save() {
+        try {
+          const data = JSON.parse(document.getElementById('fixtures').value);
+          await fetch('/api/wizard/fixtures', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+          });
+          alert('Saved');
+        } catch (e) {
+          alert('Invalid JSON');
+        }
+      }
+      load();
+    </script>
+  </body>
+</html>

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { pinoHttp } from "pino-http";
 import { auditLogger } from "./middleware/audit-logger.js";
 import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
+import wizardRouter from "./routes/wizard.js";
 import { register } from "./monitoring/metrics.js";
 import rbacRouter from "./routes/rbacRoutes.js";
 import { typeDefs } from "./graphql/schema.js";
@@ -41,6 +42,7 @@ export const createApp = async () => {
   // Rate limiting (exempt monitoring endpoints)
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
+  app.use("/api/wizard", wizardRouter);
   app.use("/rbac", rbacRouter);
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", register.contentType);

--- a/server/src/fixtures/hard-capability.json
+++ b/server/src/fixtures/hard-capability.json
@@ -1,0 +1,4 @@
+{
+  "default": "This is a simulated default response.",
+  "hello": "Hi there! Simulated greeting received."
+}

--- a/server/src/routes/wizard.ts
+++ b/server/src/routes/wizard.ts
@@ -1,0 +1,41 @@
+import express, { Request, Response } from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import WizardStubService from '../services/WizardStubService.js';
+
+const router = express.Router();
+router.use(express.json());
+
+const service = new WizardStubService();
+
+router.post('/perform', async (req: Request, res: Response) => {
+  const input: string = req.body?.input || '';
+
+  if (process.env.USE_REAL_HARD_CAPABILITY === 'true') {
+    const real = { banner: '*** REAL MODE ENABLED ***', simulated: false };
+    service.logInteraction(req.body, real);
+    return res.json(real);
+  }
+
+  const response = await service.handleRequest(input);
+  service.logInteraction(req.body, response);
+  res.json(response);
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+router.get('/admin', (_req: Request, res: Response) => {
+  res.sendFile(path.join(__dirname, '..', 'admin', 'wizard.html'));
+});
+
+router.get('/fixtures', (_req: Request, res: Response) => {
+  res.json(service.getFixtures());
+});
+
+router.post('/fixtures', (req: Request, res: Response) => {
+  service.setFixtures(req.body as any);
+  res.json({ success: true });
+});
+
+export default router;

--- a/server/src/services/WizardStubService.ts
+++ b/server/src/services/WizardStubService.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface Fixtures {
+  [key: string]: string;
+}
+
+export default class WizardStubService {
+  private fixturesPath: string;
+  private fixtures: Fixtures;
+  private logPath: string;
+
+  constructor() {
+    this.fixturesPath = path.join(__dirname, '..', 'fixtures', 'hard-capability.json');
+    this.logPath = path.join(__dirname, '..', '..', 'wizard-audit.log');
+    this.fixtures = this.loadFixtures();
+  }
+
+  private loadFixtures(): Fixtures {
+    try {
+      const data = fs.readFileSync(this.fixturesPath, 'utf-8');
+      return JSON.parse(data);
+    } catch (e) {
+      return { default: 'No fixtures loaded.' };
+    }
+  }
+
+  getFixtures(): Fixtures {
+    return this.fixtures;
+  }
+
+  setFixtures(newFixtures: Fixtures): void {
+    this.fixtures = newFixtures;
+    fs.writeFileSync(this.fixturesPath, JSON.stringify(this.fixtures, null, 2));
+  }
+
+  private redactPII(str: string): string {
+    return str
+      .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[REDACTED_EMAIL]')
+      .replace(/\b\d{3}[-.]?\d{3}[-.]?\d{4}\b/g, '[REDACTED_PHONE]');
+  }
+
+  logInteraction(request: unknown, response: unknown): void {
+    const entry = {
+      timestamp: new Date().toISOString(),
+      request: this.redactPII(JSON.stringify(request)),
+      response: this.redactPII(JSON.stringify(response)),
+    };
+    fs.appendFileSync(this.logPath, JSON.stringify(entry) + '\n');
+  }
+
+  private getFixtureResponse(input: string): string {
+    for (const [pattern, response] of Object.entries(this.fixtures)) {
+      if (pattern !== 'default' && input.includes(pattern)) {
+        return response;
+      }
+    }
+    return this.fixtures.default || 'No simulated response available.';
+  }
+
+  private async jitterDelay(): Promise<void> {
+    const delay = 50 + Math.random() * 250;
+    return new Promise(resolve => setTimeout(resolve, delay));
+  }
+
+  async handleRequest(input: string): Promise<Record<string, unknown>> {
+    await this.jitterDelay();
+    const result = this.getFixtureResponse(input);
+    return {
+      banner: '*** SIMULATED RESPONSE ***',
+      simulated: true,
+      result,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add WizardStubService with fixtures, audit logging, PII redaction and latency jitter
- expose `/api/wizard` routes with feature flag and simple admin fixture editor
- wire stub API into server app

## Testing
- `npm install`
- `cd server && npm install`
- `cd client && npm install`
- `npm run lint` (fails: Unexpected console statement, parsing errors)
- `npm run format` (fails: SyntaxError: Map keys must be unique; "script" is repeated)
- `npm test` (fails: YAML parse errors in workflows)


------
https://chatgpt.com/codex/tasks/task_e_68aaa6df2bfc8333852b8a0c27d268e7