### PR TITLE
feat: add server performance benchmarks and budget

### DIFF
--- a/docs/PERFORMANCE_BUDGET.md
+++ b/docs/PERFORMANCE_BUDGET.md
@@ -1,0 +1,59 @@
+# Performance Budget
+
+This repository enforces a baseline performance budget for the **server** application:
+
+| Metric       | Budget    |
+| ------------ | --------- |
+| p95 latency  | <= 200 ms |
+| Peak RPS     | >= 100    |
+| Memory usage | <= 512 MB |
+
+## Microbenchmarks
+
+Run hot-path microbenchmarks for utility functions:
+
+```bash
+npm run perf:micro
+```
+
+Results are written to `server/perf/microbench-results.json`.
+
+## Load Testing
+
+Execute a lightweight load test against the `/health` endpoint using [k6](https://k6.io/):
+
+```bash
+# In one terminal start the server
+npm run server:dev
+# In another terminal run the load generator
+npm run perf:load
+```
+
+This produces `server/perf/load-results.json` for analysis.
+
+## Budget Check
+
+Combine benchmark results and verify they meet the budget:
+
+```bash
+npm run perf:check
+```
+
+The script exits with non-zero status if any budget is exceeded and is suitable for CI.
+
+## Profiling
+
+1. Run the server with profiling enabled:
+   ```bash
+   node --inspect server/dist/index.js
+   ```
+2. Capture CPU/heap profiles via Chrome DevTools or `clinic flame`.
+3. Focus on slow GraphQL resolvers, data redaction, and database calls.
+
+## Tuning Checklist
+
+- [ ] Record baseline: `npm run perf:micro` and `npm run perf:load`.
+- [ ] Profile hot paths and identify bottlenecks.
+- [ ] Apply optimizations (e.g., caching, query tuning).
+- [ ] Re-run benchmarks and document before/after numbers.
+- [ ] Commit updated results and profiling notes.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "release": "changeset version && changeset publish",
     "precommit": "lint-staged",
     "db:prisma:diff": "prisma migrate diff --from-url $DATABASE_URL --to-schema-datamodel prisma/schema.prisma",
-    "db:knex:smoke": "knex migrate:down && knex migrate:up"
+    "db:knex:smoke": "knex migrate:down && knex migrate:up",
+    "perf:micro": "node --loader ts-node/esm server/perf/microbench.ts",
+    "perf:load": "k6 run server/perf/k6-load-test.js --out json=server/perf/load-results.json",
+    "perf:check": "node server/perf/check-budgets.js"
   },
   "keywords": [
     "intelligence-analysis",

--- a/server/perf/budget.json
+++ b/server/perf/budget.json
@@ -1,0 +1,5 @@
+{
+  "p95LatencyMs": 200,
+  "peakRps": 100,
+  "memoryMb": 512
+}

--- a/server/perf/check-budgets.js
+++ b/server/perf/check-budgets.js
@@ -1,0 +1,31 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function readJson(name) {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, name), 'utf8'));
+}
+
+const budget = readJson('budget.json');
+const micro = readJson('microbench-results.json');
+const load = readJson('load-results.json');
+
+const latencyP95 = load.metrics.http_req_duration.values['p(95)'];
+const rps = load.metrics.http_reqs.values.rate;
+const memory = micro.memoryMb;
+
+let ok = true;
+if (latencyP95 > budget.p95LatencyMs) {
+  console.error(`p95 latency ${latencyP95}ms exceeds budget ${budget.p95LatencyMs}ms`);
+  ok = false;
+}
+if (rps < budget.peakRps) {
+  console.error(`RPS ${rps} below budget ${budget.peakRps}`);
+  ok = false;
+}
+if (memory > budget.memoryMb) {
+  console.error(`Memory ${memory}MB exceeds budget ${budget.memoryMb}MB`);
+  ok = false;
+}
+
+if (!ok) process.exit(1);
+else console.log('Performance budgets met');

--- a/server/perf/k6-load-test.js
+++ b/server/perf/k6-load-test.js
@@ -1,0 +1,14 @@
+import http from 'k6/http';
+import { Trend } from 'k6/metrics';
+
+export const latency = new Trend('latency');
+
+export const options = {
+  vus: 10,
+  duration: '30s',
+};
+
+export default function () {
+  const res = http.get('http://localhost:4000/health');
+  latency.add(res.timings.duration);
+}

--- a/server/perf/microbench.ts
+++ b/server/perf/microbench.ts
@@ -1,0 +1,44 @@
+import { performance } from 'node:perf_hooks';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { redactData } from '../src/utils/dataRedaction.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const ITERATIONS = 1000;
+const samples: number[] = [];
+
+const sampleData = {
+  email: 'user@example.com',
+  phone: '555-1234',
+  name: 'Alice Agent',
+  address: '123 Main St',
+};
+
+const user = { id: 'u1', role: 'ANALYST' } as any;
+
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = performance.now();
+  redactData(sampleData, user);
+  const duration = performance.now() - start;
+  samples.push(duration);
+}
+
+samples.sort((a, b) => a - b);
+const p95 = samples[Math.floor(ITERATIONS * 0.95)];
+const avg = samples.reduce((a, b) => a + b, 0) / ITERATIONS;
+
+const memoryMb = process.memoryUsage().rss / 1024 / 1024;
+
+const results = {
+  function: 'redactData',
+  iterations: ITERATIONS,
+  avgMs: Number(avg.toFixed(3)),
+  p95Ms: Number(p95.toFixed(3)),
+  memoryMb: Number(memoryMb.toFixed(1)),
+};
+
+const outFile = path.join(__dirname, 'microbench-results.json');
+fs.writeFileSync(outFile, JSON.stringify(results, null, 2));
+console.log(JSON.stringify(results, null, 2));


### PR DESCRIPTION
## Summary
- document server perf budget with latency, RPS, and memory targets
- add microbenchmark, k6 load test, and CI budget checker scripts
- wire perf scripts into package.json

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Map keys must be unique in cd-deploy.yml)*
- `npm test` *(fails: YAML syntax errors in workflows)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa6bebce88333b684aa8c127c7aa2