### PR TITLE
feat: add accessible ui prototype example

### DIFF
--- a/client/examples/accessible-ui-prototype.html
+++ b/client/examples/accessible-ui-prototype.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accessible Prototype</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+        padding: 1rem;
+      }
+      header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .mode-toggle button {
+        margin-right: 0.5rem;
+      }
+      button:focus,
+      input:focus {
+        outline: 2px solid #005fcc;
+        outline-offset: 2px;
+      }
+      main {
+        margin-top: 1rem;
+        max-width: 600px;
+      }
+      ul {
+        padding: 0;
+      }
+      li {
+        list-style: none;
+        margin: 0.5rem 0;
+      }
+      @media (max-width: 600px) {
+        header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>IntelGraph Mock Search</h1>
+      <div class="mode-toggle" role="group" aria-label="Interaction mode">
+        <button id="minimalBtn" aria-pressed="true">Minimal Path</button>
+        <button id="copilotBtn" aria-pressed="false">Assistive Copilot</button>
+        <button id="powerBtn" aria-pressed="false">Power User</button>
+      </div>
+    </header>
+
+    <main>
+      <form id="searchForm">
+        <label for="searchInput">Search reports</label>
+        <input id="searchInput" type="text" />
+        <button type="submit">Search</button>
+      </form>
+      <p id="assistiveHint" role="status" aria-live="polite" hidden>Hint: try "cyber threat"</p>
+      <ul id="results" role="list"></ul>
+    </main>
+
+    <script>
+      const data = [
+        { id: 1, title: 'Supply chain risk' },
+        { id: 2, title: 'GeoInt imagery update' },
+        { id: 3, title: 'Cyber threat bulletin' },
+      ];
+      let mode = 'minimal';
+      const resultsEl = document.getElementById('results');
+      const hint = document.getElementById('assistiveHint');
+      const searchInput = document.getElementById('searchInput');
+      const logEvent = (name, detail) => {
+        console.log('event', name, detail);
+      };
+
+      function renderResults(items) {
+        resultsEl.innerHTML = '';
+        items.forEach((item) => {
+          const li = document.createElement('li');
+          const btn = document.createElement('button');
+          btn.textContent = item.title;
+          btn.addEventListener('click', () => logEvent('select_item', { id: item.id }));
+          li.appendChild(btn);
+          resultsEl.appendChild(li);
+        });
+      }
+
+      renderResults(data);
+
+      document.getElementById('searchForm').addEventListener('submit', (e) => {
+        e.preventDefault();
+        const q = searchInput.value.toLowerCase();
+        const filtered = data.filter((d) => d.title.toLowerCase().includes(q));
+        renderResults(filtered);
+        logEvent('search', { query: q });
+      });
+
+      function setMode(newMode) {
+        mode = newMode;
+        document.querySelectorAll('.mode-toggle button').forEach((btn) => {
+          btn.setAttribute('aria-pressed', btn.id.startsWith(mode));
+        });
+        hint.hidden = mode !== 'copilot';
+        logEvent('variant_change', { variant: mode });
+      }
+
+      document.getElementById('minimalBtn').addEventListener('click', () => setMode('minimal'));
+      document.getElementById('copilotBtn').addEventListener('click', () => setMode('copilot'));
+      document.getElementById('powerBtn').addEventListener('click', () => setMode('power'));
+
+      window.addEventListener('keydown', (e) => {
+        if (mode === 'power' && e.key === '/') {
+          e.preventDefault();
+          searchInput.focus();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/docs/accessible-ui-prototype-testing.md
+++ b/docs/accessible-ui-prototype-testing.md
@@ -1,0 +1,12 @@
+# Accessible UI Prototype: User Testing Plan
+
+1. **Recruit participants** representing a mix of assistive technology users, keyboard-only users, and power users.
+2. **Scenario walkthroughs**
+   - Minimal Path: complete a search with no hints.
+   - Assistive Copilot: follow the hint and complete the task.
+   - Power User: use the `/` shortcut and keyboard navigation.
+3. **Observation & logging**
+   - Screen recording and event logs (`variant_change`, `search`, `select_item`).
+   - Note where participants struggle or use assistive features.
+4. **Post-task interviews** to gather qualitative feedback on clarity, efficiency, and accessibility.
+5. **Iterate** on the interface based on findings, prioritizing WCAG 2.2 AA compliance and user preferences.


### PR DESCRIPTION
## Summary
- add standalone accessible UI prototype with minimal, copilot, and power user modes
- document plan for user testing the prototype

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in workflow YAML)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa697b6a08333b45ce1d85db1cd3b