### PR TITLE
feat: add privacy labeler service and SDK

### DIFF
--- a/apps/web/src/features/redaction/index.html
+++ b/apps/web/src/features/redaction/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Redaction Demo</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script type="module" src="./redaction.js"></script>
+  </head>
+  <body>
+    <textarea id="input"></textarea>
+    <button id="scan">Scan</button>
+    <button id="apply">Apply</button>
+    <pre id="results"></pre>
+  </body>
+</html>

--- a/apps/web/src/features/redaction/redaction.js
+++ b/apps/web/src/features/redaction/redaction.js
@@ -1,0 +1,21 @@
+import $ from 'jquery';
+import {
+  scan,
+  redactProposals,
+  applyRedactions,
+} from '../../../../packages/sdk/privacy-js/index.js';
+
+$(function () {
+  $('#scan').on('click', async () => {
+    const text = $('#input').val();
+    const result = await scan(text);
+    $('#results').text(JSON.stringify(result, null, 2));
+  });
+
+  $('#apply').on('click', async () => {
+    const text = $('#input').val();
+    const proposals = (await redactProposals(text)).proposals;
+    const applied = await applyRedactions(text, proposals, 'admin', 'ui');
+    $('#results').text(applied.redacted);
+  });
+});

--- a/packages/sdk/privacy-js/README.md
+++ b/packages/sdk/privacy-js/README.md
@@ -1,0 +1,3 @@
+# Privacy JS SDK
+
+Lightweight client for the privacy labeler service.

--- a/packages/sdk/privacy-js/index.js
+++ b/packages/sdk/privacy-js/index.js
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+export async function scan(text) {
+  const res = await axios.post('/privacy/scan', { text });
+  return res.data;
+}
+
+export async function redactProposals(text) {
+  const res = await axios.post('/privacy/redact-proposals', { text });
+  return res.data;
+}
+
+export async function applyRedactions(text, proposals, authority, reason) {
+  const res = await axios.post('/privacy/apply', {
+    text,
+    proposals,
+    authority,
+    reason,
+  });
+  return res.data;
+}

--- a/packages/sdk/privacy-js/package.json
+++ b/packages/sdk/privacy-js/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@intelgraph/privacy-js",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "dependencies": {
+    "axios": "^1.11.0"
+  }
+}

--- a/services/privacy-labeler/main.py
+++ b/services/privacy-labeler/main.py
@@ -1,0 +1,78 @@
+import random
+import re
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+try:
+    import torch
+
+    torch.manual_seed(42)
+except Exception:  # pragma: no cover - torch optional
+    torch = None
+
+app = FastAPI(title="Privacy Labeler", version="0.1.0")
+
+random.seed(42)
+MODEL_VERSION = "0.1.0"
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_RE = re.compile(r"\b\d{3}-\d{3}-\d{4}\b")
+
+
+class ScanRequest(BaseModel):
+    text: str
+
+
+class ApplyRequest(BaseModel):
+    text: str
+    proposals: list
+    authority: str | None = None
+    reason: str | None = None
+
+
+@app.post("/privacy/scan")
+def scan(req: ScanRequest):
+    matches = []
+    text = req.text
+    for m in EMAIL_RE.finditer(text):
+        matches.append(
+            {
+                "label": "EMAIL",
+                "confidence": 1.0,
+                "span": [m.start(), m.end()],
+                "explainability": {"pattern": "EMAIL_RE"},
+            }
+        )
+    for m in PHONE_RE.finditer(text):
+        matches.append(
+            {
+                "label": "PHONE",
+                "confidence": 1.0,
+                "span": [m.start(), m.end()],
+                "explainability": {"pattern": "PHONE_RE"},
+            }
+        )
+    return {"labels": matches, "model_version": MODEL_VERSION}
+
+
+@app.post("/privacy/redact-proposals")
+def redact_proposals(req: ScanRequest):
+    scan_result = scan(req)
+    suggestions = []
+    for lbl in scan_result["labels"]:
+        start, end = lbl["span"]
+        suggestions.append({"span": [start, end], "replacement": "[REDACTED]"})
+    return {"proposals": suggestions}
+
+
+@app.post("/privacy/apply")
+def apply(req: ApplyRequest):
+    if not req.authority or not req.reason:
+        raise HTTPException(status_code=400, detail="authority and reason required")
+    text = list(req.text)
+    for prop in req.proposals:
+        start, end = prop["span"]
+        repl = prop.get("replacement", "[REDACTED]")
+        text[start:end] = list(repl)
+    return {"redacted": "".join(text)}

--- a/services/privacy-labeler/tests/test_privacy.py
+++ b/services/privacy-labeler/tests/test_privacy.py
@@ -1,0 +1,44 @@
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+main = SourceFileLoader(
+    "privacy_labeler.main", str(Path(__file__).resolve().parents[1] / "main.py")
+).load_module()
+app = main.app
+client = TestClient(app)
+
+
+def test_scan_detects_email():
+    res = client.post("/privacy/scan", json={"text": "email me at foo@example.com"})
+    assert res.status_code == 200
+    data = res.json()
+    labels = [item["label"] for item in data["labels"]]
+    assert "EMAIL" in labels
+
+
+def test_redact_proposals_and_apply():
+    text = "call 123-456-7890"
+    res = client.post("/privacy/redact-proposals", json={"text": text})
+    proposals = res.json()["proposals"]
+    apply_res = client.post(
+        "/privacy/apply",
+        json={
+            "text": text,
+            "proposals": proposals,
+            "authority": "admin",
+            "reason": "policy",
+        },
+    )
+    assert apply_res.status_code == 200
+    redacted = apply_res.json()["redacted"]
+    assert "[REDACTED]" in redacted
+
+
+def test_apply_requires_authority():
+    res = client.post(
+        "/privacy/apply",
+        json={"text": "foo", "proposals": [], "authority": None, "reason": None},
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- add FastAPI privacy labeler service with regex PII detection and redaction endpoints
- introduce privacy-js SDK for client interactions
- provide web redaction UI stub with jQuery hooks

## Testing
- `python -m pytest services/privacy-labeler/tests/test_privacy.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Prettier syntax errors in existing files)*
- `npm test` *(fails: jest not found)*
- `npm run modelcard` *(fails: Missing script 'modelcard')*
- `npm run sec:zap` *(fails: Missing script 'sec:zap')*

------
https://chatgpt.com/codex/tasks/task_e_68aaa609a010833395cc179f47f66ac2