### PR TITLE
feat: add workflow engine skeleton

### DIFF
--- a/apps/web/src/features/workflow/WorkflowPanel.tsx
+++ b/apps/web/src/features/workflow/WorkflowPanel.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import $ from 'jquery';
+
+interface ChecklistItem {
+  text: string;
+  done: boolean;
+}
+
+interface CaseInfo {
+  state: string;
+  assignees: string[];
+  checklist: ChecklistItem[];
+  slaRemaining: number | null;
+}
+
+export default function WorkflowPanel() {
+  const [caseId, setCaseId] = useState<string | null>(null);
+  const [info, setInfo] = useState<CaseInfo | null>(null);
+
+  useEffect(() => {
+    const handler = (_e: any, node: any) => setCaseId(node.id());
+    $(document).on('cy:selected', handler);
+    return () => $(document).off('cy:selected', handler);
+  }, []);
+
+  useEffect(() => {
+    let timer: any;
+    if (caseId) {
+      const fetchInfo = async () => {
+        const res = await fetch(`/wf/cases/${caseId}`);
+        const data = await res.json();
+        setInfo(data);
+      };
+      fetchInfo();
+      timer = setInterval(fetchInfo, 1000);
+    }
+    return () => clearInterval(timer);
+  }, [caseId]);
+
+  if (!info) return <Typography tabIndex={0}>Select a case</Typography>;
+
+  return (
+    <div aria-label="workflow panel">
+      <Typography tabIndex={0}>State: {info.state}</Typography>
+      <Typography tabIndex={0}>SLA remaining: {info.slaRemaining}</Typography>
+      <List aria-label="checklist">
+        {info.checklist.map((item, idx) => (
+          <ListItem key={idx} disablePadding>
+            <Checkbox tabIndex={0} inputProps={{ 'aria-label': item.text }} />
+            <ListItemText primary={item.text} />
+          </ListItem>
+        ))}
+      </List>
+      <Button variant="contained" tabIndex={0} aria-label="refresh" onClick={() => caseId && fetch(`/wf/cases/${caseId}`).then(r => r.json()).then(setInfo)}>
+        Refresh
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/workflow/workflow.spec.ts
+++ b/apps/web/src/features/workflow/workflow.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import http from 'http';
+import app from '../../../../../services/workflow/src/index.js';
+
+let server: http.Server;
+let base: string;
+
+test.beforeAll(async () => {
+  server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as any;
+  base = `http://localhost:${port}`;
+  await fetch(`${base}/wf/definition`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: 'p',
+      definition: {
+        initial: 'open',
+        states: {
+          open: { on: { close: 'closed' }, sla: 1 },
+          closed: { on: {} }
+        },
+        guards: { close: () => true }
+      }
+    })
+  });
+  await fetch(`${base}/wf/start`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: '1', definition: 'p' })
+  });
+});
+
+test.afterAll(async () => {
+  server.close();
+});
+
+test('start→transition→complete with SLA countdown UI', async ({ page }) => {
+  await page.setContent(`<div id="sla"></div><script>
+    async function refresh(){
+      const res=await fetch('${base}/wf/cases/1');
+      const data=await res.json();
+      document.getElementById('sla').textContent=data.slaRemaining;
+    }
+    refresh();
+    setInterval(refresh,500);
+  </script>`);
+  const first = Number(await page.textContent('#sla'));
+  await page.waitForTimeout(600);
+  const second = Number(await page.textContent('#sla'));
+  expect(second).toBeLessThan(first);
+  await page.evaluate(async (base) => {
+    await fetch(`${base}/wf/transition`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: '1', transition: 'close', reason: 'ok' })
+    });
+  }, base);
+  const state = await page.evaluate(async (base) => {
+    const res = await fetch(`${base}/wf/cases/1`);
+    return (await res.json()).state;
+  }, base);
+  expect(state).toBe('closed');
+});

--- a/packages/sdk/workflow-js/index.js
+++ b/packages/sdk/workflow-js/index.js
@@ -1,0 +1,31 @@
+export async function createDefinition(baseUrl, name, definition) {
+  const res = await fetch(`${baseUrl}/wf/definition`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, definition })
+  });
+  return res.json();
+}
+
+export async function startCase(baseUrl, id, definition) {
+  const res = await fetch(`${baseUrl}/wf/start`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, definition })
+  });
+  return res.json();
+}
+
+export async function transitionCase(baseUrl, id, transition, reason) {
+  const res = await fetch(`${baseUrl}/wf/transition`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, transition, reason })
+  });
+  return res.json();
+}
+
+export async function getCase(baseUrl, id) {
+  const res = await fetch(`${baseUrl}/wf/cases/${id}`);
+  return res.json();
+}

--- a/packages/sdk/workflow-js/package.json
+++ b/packages/sdk/workflow-js/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@intelgraph/workflow-js",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/services/workflow/package.json
+++ b/services/workflow/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@intelgraph/workflow-service",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "eventemitter3": "^5.0.1"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.4",
+    "jest": "^29.7.0"
+  }
+}

--- a/services/workflow/src/index.js
+++ b/services/workflow/src/index.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { workflowRouter } from './routes.js';
+
+export function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(workflowRouter);
+  return app;
+}
+
+export default createApp();

--- a/services/workflow/src/routes.js
+++ b/services/workflow/src/routes.js
@@ -1,0 +1,41 @@
+import express from 'express';
+import WorkflowEngine from './workflow.js';
+
+const router = express.Router();
+const engine = new WorkflowEngine();
+
+router.post('/wf/definition', (req, res) => {
+  engine.define(req.body.name, req.body.definition);
+  res.json({ status: 'ok' });
+});
+
+router.post('/wf/start', (req, res) => {
+  const { id, definition } = req.body;
+  const data = engine.start(id, definition);
+  res.json(data);
+});
+
+router.post('/wf/transition', (req, res) => {
+  const { id, transition, reason } = req.body;
+  try {
+    const data = engine.transition(id, transition, reason);
+    res.json(data);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.get('/wf/cases/:id', (req, res) => {
+  try {
+    const data = engine.getCase(req.params.id);
+    res.json(data);
+  } catch (err) {
+    res.status(404).json({ error: err.message });
+  }
+});
+
+router.get('/metrics', (req, res) => {
+  res.json(engine.metrics);
+});
+
+export { router as workflowRouter, engine as workflowEngine };

--- a/services/workflow/src/server.js
+++ b/services/workflow/src/server.js
@@ -1,0 +1,5 @@
+import { createApp } from './index.js';
+
+const app = createApp();
+const port = process.env.PORT || 4000;
+app.listen(port, () => console.log(`workflow service on ${port}`));

--- a/services/workflow/src/workflow.js
+++ b/services/workflow/src/workflow.js
@@ -1,0 +1,79 @@
+import EventEmitter from 'eventemitter3';
+
+class WorkflowEngine extends EventEmitter {
+  constructor() {
+    super();
+    this.definitions = new Map();
+    this.cases = new Map();
+    this.metrics = { slaBreaches: 0 };
+  }
+
+  define(name, definition) {
+    this.definitions.set(name, definition);
+  }
+
+  start(id, definitionName) {
+    const def = this.definitions.get(definitionName);
+    if (!def) throw new Error('definition not found');
+    const initial = def.initial;
+    const caseData = {
+      id,
+      definition: definitionName,
+      state: initial,
+      assignees: def.states[initial].assignees || [],
+      checklist: this._sanitizeChecklist(def.states[initial].checklist || []),
+      deadline: this._calcDeadline(def.states[initial].sla)
+    };
+    this.cases.set(id, caseData);
+    this.emit('started', { id, state: initial });
+    return caseData;
+  }
+
+  transition(id, transition, reason) {
+    if (!reason) throw new Error('reason required');
+    const caseData = this.cases.get(id);
+    if (!caseData) throw new Error('case not found');
+    const def = this.definitions.get(caseData.definition);
+    const stateConfig = def.states[caseData.state];
+    const target = stateConfig.on?.[transition];
+    if (!target) throw new Error('invalid transition');
+    const guard = def.guards?.[transition];
+    if (guard && !guard(caseData, reason)) {
+      throw new Error('guard rejected');
+    }
+    caseData.state = target;
+    const targetConfig = def.states[target];
+    caseData.assignees = targetConfig.assignees || [];
+    caseData.checklist = this._sanitizeChecklist(targetConfig.checklist || []);
+    caseData.deadline = this._calcDeadline(targetConfig.sla);
+    this.emit('transitioned', { id, transition, state: target, reason });
+    return caseData;
+  }
+
+  getCase(id) {
+    const caseData = this.cases.get(id);
+    if (!caseData) throw new Error('case not found');
+    const now = Date.now();
+    const remaining = caseData.deadline ? caseData.deadline - now : null;
+    if (remaining !== null && remaining < 0) {
+      this.metrics.slaBreaches += 1;
+      this.emit('sla_breached', { id });
+    }
+    return {
+      state: caseData.state,
+      assignees: caseData.assignees,
+      checklist: caseData.checklist,
+      slaRemaining: remaining !== null ? Math.max(0, remaining) : null
+    };
+  }
+
+  _calcDeadline(slaSeconds) {
+    return typeof slaSeconds === 'number' ? Date.now() + slaSeconds * 1000 : null;
+  }
+
+  _sanitizeChecklist(items) {
+    return items.map((text) => ({ text: String(text).replace(/[<>]/g, ''), done: false }));
+  }
+}
+
+export default WorkflowEngine;

--- a/services/workflow/tests/workflow.test.js
+++ b/services/workflow/tests/workflow.test.js
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import app from '../src/index.js';
+import { workflowEngine } from '../src/routes.js';
+
+describe('workflow engine', () => {
+  beforeAll(() => {
+    const def = {
+      initial: 'open',
+      states: {
+        open: {
+          on: { review: 'review' },
+          sla: 1,
+          assignees: ['a'],
+          checklist: ['<script>xss</script>']
+        },
+        review: { on: { close: 'closed' }, sla: 1 },
+        closed: { on: {} }
+      },
+      guards: {
+        close: (_case, reason) => reason === 'ok'
+      }
+    };
+    workflowEngine.define('test', def);
+  });
+
+  test('start to transition to review', async () => {
+    await request(app).post('/wf/start').send({ id: '1', definition: 'test' }).expect(200);
+    const res = await request(app)
+      .post('/wf/transition')
+      .send({ id: '1', transition: 'review', reason: 'need review' })
+      .expect(200);
+    expect(res.body.state).toBe('review');
+  });
+
+  test('guard prevents invalid close', async () => {
+    await request(app)
+      .post('/wf/transition')
+      .send({ id: '1', transition: 'close', reason: 'bad' })
+      .expect(400);
+  });
+
+  test('sanitizes checklist to avoid xss', async () => {
+    await request(app).post('/wf/start').send({ id: '2', definition: 'test' }).expect(200);
+    const res = await request(app).get('/wf/cases/2').expect(200);
+    expect(res.body.checklist[0].text).toBe('scriptxss/script');
+  });
+});


### PR DESCRIPTION
## Summary
- add Express-based workflow service with state machine, SLA tracking, and metrics
- expose workflow JS SDK for creating definitions and transitioning cases
- provide accessible WorkflowPanel component with checklist and SLA countdown

## Testing
- `npm --prefix services/workflow test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npx -y playwright test apps/web/src/features/workflow/workflow.spec.ts` *(fails: Cannot find module '@playwright/test')*
- `npm run docker:build` *(fails: Missing script 'docker:build')*

------
https://chatgpt.com/codex/tasks/task_e_68aaa5efed7883338ae712825f3dd51a