### PR TITLE
feat(graphrag): expose popular subgraph metrics

### DIFF
--- a/server/src/routes/graphragRoutes.js
+++ b/server/src/routes/graphragRoutes.js
@@ -260,6 +260,38 @@ router.post('/embeddings/generate', validateRequest(embeddingSchema), async (req
 
 /**
  * @swagger
+ * /api/graphrag/popular:
+ *   get:
+ *     summary: List popular subgraph cache keys
+ *     tags: [GraphRAG]
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *           minimum: 1
+ *           maximum: 100
+ *     responses:
+ *       200:
+ *         description: Popular subgraphs
+ */
+router.get('/popular', async (req, res) => {
+  initializeServices();
+  const limit = Math.min(parseInt(req.query.limit, 10) || 10, 100);
+  try {
+    const popular = await graphRAGService.getPopularSubgraphs(limit);
+    res.json({ popular });
+  } catch (error) {
+    logger.error('Failed to get popular subgraphs', { error: error.message });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+/**
+ * @swagger
  * /api/graphrag/health:
  *   get:
  *     summary: Get GraphRAG service health

--- a/server/src/services/GraphRAGService.d.ts
+++ b/server/src/services/GraphRAGService.d.ts
@@ -40,6 +40,9 @@ export class GraphRAGService {
     maxHops?: number;
     rankingStrategy?: string;
   }): Promise<RAG>;
+  getPopularSubgraphs(
+    limit?: number,
+  ): Promise<{ key: string; count: number }[]>;
   // Add other public methods if needed
 }
 


### PR DESCRIPTION
## Summary
- expose popular subgraph cache metrics via GraphRAG service
- add REST endpoint for popular subgraphs
- cover popular subgraph retrieval in unit tests

## Testing
- `npm install` (fails: node-canvas build, requires dependencies)
- `npm run lint` (fails: Cannot find module '../package.json')
- `npm run format` (fails: Prettier syntax errors in CI YAML)
- `npm test` (fails: Cannot find module 'chalk')

------
https://chatgpt.com/codex/tasks/task_e_68aaa3d95230833398d8a5c6dd815cc0