### PR TITLE
feat: scaffold ingest sandbox and connector sdk

### DIFF
--- a/connectors/examples/csv/index.ts
+++ b/connectors/examples/csv/index.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import { BaseConnector, createEmitter, ConnectorContext } from '@intelgraph/connector-js';
+
+class CsvConnector extends BaseConnector {
+  constructor(private file: string) {
+    super();
+  }
+
+  async run(ctx: ConnectorContext): Promise<void> {
+    const lines = fs.readFileSync(this.file, 'utf-8').trim().split('\n');
+    const headers = lines[0].split(',');
+    for (const line of lines.slice(1)) {
+      const cols = line.split(',');
+      const record: Record<string, string> = {};
+      headers.forEach((h, i) => (record[h] = cols[i]));
+      ctx.emit({ type: 'Record', ...record });
+    }
+  }
+}
+
+const connector = new CsvConnector(process.argv[2]);
+const emit = createEmitter(process.stdout);
+connector.run({ emit });

--- a/connectors/examples/rest/index.ts
+++ b/connectors/examples/rest/index.ts
@@ -1,0 +1,17 @@
+import { BaseConnector, createEmitter, ConnectorContext } from '@intelgraph/connector-js';
+
+class RestConnector extends BaseConnector {
+  constructor(private url: string) { super(); }
+
+  async run(ctx: ConnectorContext): Promise<void> {
+    const res = await fetch(this.url);
+    const data = await res.json();
+    for (const item of data) {
+      ctx.emit(item);
+    }
+  }
+}
+
+const connector = new RestConnector(process.argv[2]);
+const emit = createEmitter(process.stdout);
+connector.run({ emit });

--- a/connectors/examples/s3/index.ts
+++ b/connectors/examples/s3/index.ts
@@ -1,0 +1,13 @@
+import { BaseConnector, createEmitter, ConnectorContext } from '@intelgraph/connector-js';
+
+// Placeholder connector illustrating how an S3 source could be implemented.
+class S3Connector extends BaseConnector {
+  async run(ctx: ConnectorContext): Promise<void> {
+    // In a real connector, list objects from S3 and emit their contents.
+    ctx.emit({ type: 'Placeholder', message: 'S3 connector not implemented' });
+  }
+}
+
+const connector = new S3Connector();
+const emit = createEmitter(process.stdout);
+connector.run({ emit });

--- a/packages/mapping-dsl/__tests__/index.test.ts
+++ b/packages/mapping-dsl/__tests__/index.test.ts
@@ -1,0 +1,19 @@
+import { validateMapping } from '../src/index';
+
+describe('validateMapping', () => {
+  it('validates a correct mapping', () => {
+    const result = validateMapping({
+      version: '1.0.0',
+      entities: [{ type: 'Person', fields: { id: 'id' } }],
+      relationships: [{ type: 'KNOWS', from: 'Person', to: 'Person' }]
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('returns errors for invalid mapping', () => {
+    const result = validateMapping({});
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/mapping-dsl/package.json
+++ b/packages/mapping-dsl/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@intelgraph/mapping-dsl",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.6",
+    "@types/jest": "^29.5.14"
+  }
+}

--- a/packages/mapping-dsl/src/index.ts
+++ b/packages/mapping-dsl/src/index.ts
@@ -1,0 +1,16 @@
+import Ajv, { ErrorObject } from 'ajv';
+import schema from './schema.json';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ErrorObject[];
+}
+
+export function validateMapping(mapping: unknown): ValidationResult {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+  const valid = validate(mapping) as boolean;
+  return { valid, errors: validate.errors || [] };
+}
+
+export { schema };

--- a/packages/mapping-dsl/src/schema.json
+++ b/packages/mapping-dsl/src/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "version": { "type": "string" },
+    "entities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string" },
+          "fields": { "type": "object" }
+        },
+        "required": ["type", "fields"]
+      }
+    },
+    "relationships": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string" },
+          "from": { "type": "string" },
+          "to": { "type": "string" }
+        },
+        "required": ["type", "from", "to"]
+      }
+    }
+  },
+  "required": ["version", "entities", "relationships"]
+}

--- a/packages/mapping-dsl/tsconfig.json
+++ b/packages/mapping-dsl/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sdk/connector-js/__tests__/index.test.ts
+++ b/packages/sdk/connector-js/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+import { createEmitter } from '../src/index';
+import { Writable } from 'stream';
+
+describe('createEmitter', () => {
+  it('writes newline delimited JSON', () => {
+    let data = '';
+    const stream = new Writable({
+      write(chunk, _enc, cb) {
+        data += chunk.toString();
+        cb();
+      }
+    });
+    const emit = createEmitter(stream);
+    emit({ foo: 'bar' });
+    expect(data).toBe('{"foo":"bar"}\n');
+  });
+});

--- a/packages/sdk/connector-js/package.json
+++ b/packages/sdk/connector-js/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@intelgraph/connector-js",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.6",
+    "@types/jest": "^29.5.14"
+  }
+}

--- a/packages/sdk/connector-js/src/index.ts
+++ b/packages/sdk/connector-js/src/index.ts
@@ -1,0 +1,19 @@
+export interface ConnectorContext {
+  emit: (record: unknown) => void;
+}
+
+export interface Connector {
+  run(ctx: ConnectorContext): Promise<void>;
+}
+
+export class BaseConnector implements Connector {
+  async run(_ctx: ConnectorContext): Promise<void> {
+    /* override in subclass */
+  }
+}
+
+export function createEmitter(stream: NodeJS.WritableStream) {
+  return (record: unknown) => {
+    stream.write(JSON.stringify(record) + '\n');
+  };
+}

--- a/packages/sdk/connector-js/tsconfig.json
+++ b/packages/sdk/connector-js/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/services/ingest-sandbox/main.py
+++ b/services/ingest-sandbox/main.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+import json
+from pathlib import Path
+from jsonschema import Draft7Validator
+
+app = FastAPI(title="Ingest Sandbox")
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / 'packages' / 'mapping-dsl' / 'src' / 'schema.json'
+with open(SCHEMA_PATH) as f:
+    MAPPING_SCHEMA = json.load(f)
+
+validator = Draft7Validator(MAPPING_SCHEMA)
+
+class MappingRequest(BaseModel):
+    mapping: dict
+
+@app.post('/ingest-sandbox/validate-mapping')
+def validate_mapping(req: MappingRequest):
+    errors = [
+        {
+            'message': e.message,
+            'path': list(e.path)
+        }
+        for e in validator.iter_errors(req.mapping)
+    ]
+    return { 'valid': len(errors) == 0, 'errors': errors }
+
+@app.get('/ingest-sandbox/schemas')
+def get_schemas():
+    return {
+        'entities': MAPPING_SCHEMA.get('entities', []),
+        'relationships': MAPPING_SCHEMA.get('relationships', [])
+    }
+
+@app.post('/ingest-sandbox/run')
+async def run():
+    async def iterator():
+        sample = { 'type': 'Person', 'id': '1', 'name': 'Alice' }
+        yield json.dumps(sample) + '\n'
+    return StreamingResponse(iterator(), media_type='application/jsonl')

--- a/services/ingest-sandbox/requirements.txt
+++ b/services/ingest-sandbox/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+jsonschema

--- a/services/ingest-sandbox/tests/test_main.py
+++ b/services/ingest-sandbox/tests/test_main.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+spec = importlib.util.spec_from_file_location(
+    'main', Path(__file__).resolve().parent.parent / 'main.py'
+)
+main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(main)  # type: ignore
+
+client = TestClient(main.app)
+
+def test_validate_mapping():
+    resp = client.post('/ingest-sandbox/validate-mapping', json={
+        'mapping': {
+            'version': '1.0.0',
+            'entities': [{ 'type': 'Person', 'fields': { 'id': 'id' } }],
+            'relationships': [{ 'type': 'KNOWS', 'from': 'Person', 'to': 'Person' }]
+        }
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['valid'] is True
+
+def test_validate_mapping_errors():
+    resp = client.post('/ingest-sandbox/validate-mapping', json={'mapping': {}})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['valid'] is False
+    assert len(data['errors']) > 0


### PR DESCRIPTION
## Summary
- add FastAPI ingest sandbox with mapping validation and schema listing
- introduce mapping DSL package with JSON Schema and validator
- add connector JS SDK and example connectors for csv/rest/s3

## Testing
- `pytest services/ingest-sandbox/tests/test_main.py`
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: missing @eslint/js)*
- `npm run typecheck` *(fails: cannot read tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa44394a08333ad600211a1faec00