### PR TITLE
feat: add realtime collaboration scaffold

### DIFF
--- a/apps/web/src/features/collab-widget/CollabWidget.tsx
+++ b/apps/web/src/features/collab-widget/CollabWidget.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, List, ListItem, TextField, Button, Typography } from '@mui/material';
+import DOMPurify from 'dompurify';
+import $ from 'jquery';
+import { CollabClient } from '../../../../packages/sdk/collab-js/src/collabClient';
+
+interface Comment {
+  commentId: string;
+  text: string;
+  userId: string;
+}
+
+interface Props {
+  entityId: string;
+  client: CollabClient;
+}
+
+export const CollabWidget: React.FC<Props> = ({ entityId, client }) => {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [text, setText] = useState('');
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    const cy = (window as { cy?: unknown }).cy;
+    if (cy) {
+      (
+        $ as unknown as (el: unknown) => {
+          on: (
+            event: string,
+            selector: string,
+            cb: (e: { target: { id: () => string } }) => void,
+          ) => void;
+        }
+      )(cy).on('select', 'node', (e: { target: { id: () => string } }) => {
+        client.updateSelection(e.target.id(), true);
+      });
+    }
+    const handleAdd = (msg: { commentId: string; text: string; userId: string }) => {
+      setComments((prev) => [
+        ...prev,
+        { commentId: msg.commentId, text: msg.text, userId: msg.userId },
+      ]);
+    };
+    client.on('comment.add', handleAdd);
+    return () => {
+      client.off('comment.add', handleAdd);
+    };
+  }, [client]);
+
+  const add = () => {
+    if (text.trim()) {
+      client.addComment(entityId, text);
+      setText('');
+    }
+  };
+
+  const onKey = (e: React.KeyboardEvent<HTMLLIElement>) => {
+    if (e.key === 'ArrowDown') (e.currentTarget.nextElementSibling as HTMLElement)?.focus();
+    if (e.key === 'ArrowUp') (e.currentTarget.previousElementSibling as HTMLElement)?.focus();
+  };
+
+  return (
+    <Box sx={{ width: 300 }}>
+      <Typography variant="h6">Comments</Typography>
+      <List ref={listRef}>
+        {comments.map((c) => (
+          <ListItem key={c.commentId} tabIndex={0} onKeyDown={onKey}>
+            <span dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(c.text) }} />
+          </ListItem>
+        ))}
+      </List>
+      <TextField
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={() => client.typing(entityId)}
+      />
+      <Button onClick={add}>Add</Button>
+    </Box>
+  );
+};
+
+export default CollabWidget;

--- a/packages/sdk/collab-js/__tests__/crdt.test.ts
+++ b/packages/sdk/collab-js/__tests__/crdt.test.ts
@@ -1,0 +1,9 @@
+import { TextCRDT } from '../src/crdt';
+
+test('CRDT insert and delete', () => {
+  const doc = new TextCRDT('hi');
+  doc.apply({ insert: { pos: 2, value: '!' } });
+  expect(doc.value()).toBe('hi!');
+  doc.apply({ delete: { pos: 1, count: 1 } });
+  expect(doc.value()).toBe('h!');
+});

--- a/packages/sdk/collab-js/__tests__/reducers.test.ts
+++ b/packages/sdk/collab-js/__tests__/reducers.test.ts
@@ -1,0 +1,13 @@
+import { presenceReducer } from '../src/reducers';
+
+test('presence reducer handles join and leave', () => {
+  let state = presenceReducer(undefined, {
+    type: 'presence.join',
+    sessionId: '1',
+    userId: 'u',
+    tenantId: 't',
+  });
+  expect(state['1']).toEqual({ userId: 'u', tenantId: 't' });
+  state = presenceReducer(state, { type: 'presence.leave', sessionId: '1' });
+  expect(state['1']).toBeUndefined();
+});

--- a/packages/sdk/collab-js/jest.config.cjs
+++ b/packages/sdk/collab-js/jest.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: { 'ts-jest': { useESM: true } },
+};

--- a/packages/sdk/collab-js/package.json
+++ b/packages/sdk/collab-js/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@intelgraph/collab-js",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/packages/sdk/collab-js/src/collabClient.ts
+++ b/packages/sdk/collab-js/src/collabClient.ts
@@ -1,0 +1,52 @@
+import { EventEmitter } from 'events';
+import type { Operation } from './crdt';
+
+export interface Identity {
+  userId: string;
+  tenantId: string;
+  sessionId: string;
+}
+
+export class CollabClient extends EventEmitter {
+  private ws?: WebSocket;
+  private id?: Identity;
+  private hb?: ReturnType<typeof setInterval>;
+
+  connect(url: string, identity: Identity): void {
+    this.id = identity;
+    this.ws = new WebSocket(url);
+    this.ws.onopen = () => {
+      this.send({ type: 'presence.join' });
+      this.hb = setInterval(() => this.send({ type: 'heartbeat' }), 30000);
+    };
+    this.ws.onmessage = (ev) => {
+      const msg = JSON.parse(ev.data.toString());
+      this.emit(msg.type, msg);
+    };
+  }
+
+  private send(msg: Record<string, unknown>): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    const eventId = msg.eventId || crypto.randomUUID();
+    this.ws.send(JSON.stringify({ ...msg, ...this.id, eventId }));
+  }
+
+  updateSelection(entityId: string, selection: unknown): void {
+    this.send({ type: 'selection.update', entityId, selection });
+  }
+
+  addComment(entityId: string, text: string, commentId = crypto.randomUUID()): void {
+    this.send({ type: 'comment.add', entityId, commentId, text });
+  }
+
+  editComment(entityId: string, commentId: string, op: Operation): void {
+    this.send({ type: 'comment.edit', entityId, commentId, op });
+  }
+
+  typing(entityId: string): void {
+    this.send({ type: 'typing', entityId });
+  }
+}
+
+export { TextCRDT } from './crdt';
+export { presenceReducer } from './reducers';

--- a/packages/sdk/collab-js/src/crdt.ts
+++ b/packages/sdk/collab-js/src/crdt.ts
@@ -1,0 +1,30 @@
+export type Operation = {
+  insert?: { pos: number; value: string };
+  delete?: { pos: number; count: number };
+};
+
+export class TextCRDT {
+  private text: string;
+
+  constructor(initial = '') {
+    this.text = initial;
+  }
+
+  apply(op: Operation): void {
+    if (op.insert) {
+      const { pos, value } = op.insert;
+      this.text = this.text.slice(0, pos) + value + this.text.slice(pos);
+    } else if (op.delete) {
+      const { pos, count } = op.delete;
+      this.text = this.text.slice(0, pos) + this.text.slice(pos + count);
+    }
+  }
+
+  value(): string {
+    return this.text;
+  }
+
+  merge(other: TextCRDT): TextCRDT {
+    return new TextCRDT(other.value());
+  }
+}

--- a/packages/sdk/collab-js/src/index.ts
+++ b/packages/sdk/collab-js/src/index.ts
@@ -1,0 +1,3 @@
+export * from './collabClient';
+export * from './crdt';
+export * from './reducers';

--- a/packages/sdk/collab-js/src/reducers.ts
+++ b/packages/sdk/collab-js/src/reducers.ts
@@ -1,0 +1,26 @@
+export interface PresenceRecord {
+  userId: string;
+  tenantId: string;
+}
+
+export type PresenceState = Record<string, PresenceRecord>;
+
+export function presenceReducer(
+  state: PresenceState = {},
+  action: { type: string; sessionId?: string; userId?: string; tenantId?: string },
+): PresenceState {
+  switch (action.type) {
+    case 'presence.join':
+      return {
+        ...state,
+        [action.sessionId]: { userId: action.userId, tenantId: action.tenantId },
+      };
+    case 'presence.leave': {
+      const next = { ...state };
+      delete next[action.sessionId];
+      return next;
+    }
+    default:
+      return state;
+  }
+}

--- a/services/collab/server.js
+++ b/services/collab/server.js
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const http = require('http');
+const url = require('url');
+const { WebSocketServer } = require('ws');
+
+const HEARTBEAT_INTERVAL = 30000;
+const IDLE_TIMEOUT = 60000;
+
+const comments = new Map();
+const sessions = new Map();
+const processed = new Set();
+
+function sanitize(str = '') {
+  return str.replace(/[<>]/g, '');
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  if (req.method === 'GET' && parsed.pathname && parsed.pathname.startsWith('/collab/history/')) {
+    const entityId = parsed.pathname.split('/').pop();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(comments.get(entityId) || []));
+    return;
+  }
+  res.writeHead(404);
+  res.end();
+});
+
+const wss = new WebSocketServer({ server });
+
+wss.on('connection', (ws) => {
+  ws.on('message', (data) => {
+    try {
+      const msg = JSON.parse(data);
+      if (!msg.eventId || processed.has(msg.eventId)) return;
+      processed.add(msg.eventId);
+      switch (msg.type) {
+        case 'presence.join': {
+          sessions.set(msg.sessionId, { ...msg, ws, last: Date.now() });
+          broadcast({
+            type: 'presence.join',
+            userId: msg.userId,
+            tenantId: msg.tenantId,
+            sessionId: msg.sessionId,
+          });
+          break;
+        }
+        case 'presence.leave': {
+          sessions.delete(msg.sessionId);
+          broadcast(msg);
+          break;
+        }
+        case 'selection.update':
+        case 'comment.add':
+        case 'comment.edit':
+        case 'typing': {
+          if (msg.type === 'comment.add') {
+            const list = comments.get(msg.entityId) || [];
+            list.push({ commentId: msg.commentId, userId: msg.userId, text: sanitize(msg.text) });
+            comments.set(msg.entityId, list);
+          }
+          broadcast(msg);
+          break;
+        }
+        case 'heartbeat': {
+          const session = sessions.get(msg.sessionId);
+          if (session) session.last = Date.now();
+          break;
+        }
+        default:
+          break;
+      }
+    } catch {
+      // ignore invalid messages
+    }
+  });
+
+  ws.on('close', () => {
+    for (const [id, sess] of sessions.entries()) {
+      if (sess.ws === ws) {
+        sessions.delete(id);
+        broadcast({
+          type: 'presence.leave',
+          sessionId: id,
+          userId: sess.userId,
+          tenantId: sess.tenantId,
+        });
+      }
+    }
+  });
+});
+
+function broadcast(msg) {
+  const data = JSON.stringify(msg);
+  for (const sess of sessions.values()) {
+    try {
+      sess.ws.send(data);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, sess] of sessions.entries()) {
+    if (now - sess.last > IDLE_TIMEOUT) {
+      sessions.delete(id);
+      try {
+        sess.ws.close();
+      } catch {
+        // ignore
+      }
+    }
+  }
+}, HEARTBEAT_INTERVAL);
+
+server.listen(4000);


### PR DESCRIPTION
## Summary
- scaffold WebSocket collab service with presence, selections, comments and heartbeat cleanup
- add JS SDK with CRDT text helper and reducers
- prototype web collab widget with keyboard-accessible comments and cytoscape selection broadcast

## Testing
- `npm run format` *(fails: Map keys must be unique; "script" is repeated)*
- `npx eslint services/collab/server.js packages/sdk/collab-js/src packages/sdk/collab-js/__tests__ apps/web/src/features/collab-widget/CollabWidget.tsx`
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npx jest --config packages/sdk/collab-js/jest.config.cjs packages/sdk/collab-js/__tests__/crdt.test.ts packages/sdk/collab-js/__tests__/reducers.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68aaa48c02a0833382711b94ca65b6fa