### PR TITLE
feat: add synthetic data privacy endpoints

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,6 +12,8 @@ import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
 import { register } from "./monitoring/metrics.js";
 import rbacRouter from "./routes/rbacRoutes.js";
+import synthRouter from "./routes/synthRoutes.js";
+import privacyRouter from "./routes/privacyRoutes.js";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
 import { getContext } from "./lib/auth.js";
@@ -42,6 +44,8 @@ export const createApp = async () => {
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
   app.use("/rbac", rbacRouter);
+  app.use("/synth", synthRouter);
+  app.use("/privacy", privacyRouter);
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", register.contentType);
     res.end(await register.metrics());

--- a/server/src/controllers/PrivacyReportController.js
+++ b/server/src/controllers/PrivacyReportController.js
@@ -1,0 +1,19 @@
+const PrivacyReportService = require('../services/PrivacyReportService');
+
+class PrivacyReportController {
+  constructor() {
+    this.svc = PrivacyReportService;
+  }
+
+  async get(req, res) {
+    try {
+      const { dataset } = req.params;
+      const report = await this.svc.getReport(dataset);
+      res.status(200).json({ success: true, report });
+    } catch (e) {
+      res.status(400).json({ success: false, error: e.message });
+    }
+  }
+}
+
+module.exports = PrivacyReportController;

--- a/server/src/controllers/SyntheticDataController.js
+++ b/server/src/controllers/SyntheticDataController.js
@@ -1,0 +1,25 @@
+const SyntheticDataService = require('../services/SyntheticDataService');
+
+class SyntheticDataController {
+  async train(req, res) {
+    try {
+      const { dataset, epsilon } = req.body || {};
+      const result = await SyntheticDataService.train({ dataset, epsilon });
+      res.status(201).json({ success: true, ...result });
+    } catch (e) {
+      res.status(400).json({ success: false, error: e.message });
+    }
+  }
+
+  async sample(req, res) {
+    try {
+      const { modelId, count } = req.body || {};
+      const result = await SyntheticDataService.sample({ modelId, count });
+      res.status(200).json({ success: true, ...result });
+    } catch (e) {
+      res.status(400).json({ success: false, error: e.message });
+    }
+  }
+}
+
+module.exports = SyntheticDataController;

--- a/server/src/routes/__tests__/synth.test.ts
+++ b/server/src/routes/__tests__/synth.test.ts
@@ -1,0 +1,41 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../middleware/auth', () => ({
+  ensureAuthenticated: (_req: any, _res: any, next: any) => next(),
+}));
+
+const synthRouter = require('../synthRoutes');
+const privacyRouter = require('../privacyRoutes');
+
+describe('synthetic data routes', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/synth', synthRouter);
+  app.use('/privacy', privacyRouter);
+
+  it('trains model', async () => {
+    const res = await request(app)
+      .post('/synth/train')
+      .send({ dataset: [], epsilon: 1 });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('modelId');
+    expect(res.body.epsilon).toBe(1);
+  });
+
+  it('samples data', async () => {
+    const res = await request(app)
+      .post('/synth/sample')
+      .send({ modelId: 'm1', count: 2 });
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body).toHaveProperty('riskReport');
+  });
+
+  it('gets privacy report', async () => {
+    const res = await request(app).get('/privacy/report/demo');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('report');
+    expect(res.body.report.dataset).toBe('demo');
+  });
+});

--- a/server/src/routes/privacyRoutes.js
+++ b/server/src/routes/privacyRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const PrivacyReportController = require('../controllers/PrivacyReportController');
+const { ensureAuthenticated } = require('../middleware/auth');
+
+const router = express.Router();
+const controller = new PrivacyReportController();
+
+router.use(ensureAuthenticated);
+
+router.get('/report/:dataset', (req, res) => controller.get(req, res));
+
+module.exports = router;

--- a/server/src/routes/synthRoutes.js
+++ b/server/src/routes/synthRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const SyntheticDataController = require('../controllers/SyntheticDataController');
+const { ensureAuthenticated } = require('../middleware/auth');
+
+const router = express.Router();
+const controller = new SyntheticDataController();
+
+router.use(ensureAuthenticated);
+
+router.post('/train', (req, res) => controller.train(req, res));
+router.post('/sample', (req, res) => controller.sample(req, res));
+
+module.exports = router;

--- a/server/src/services/PrivacyReportService.js
+++ b/server/src/services/PrivacyReportService.js
@@ -1,0 +1,13 @@
+class PrivacyReportService {
+  async getReport(dataset) {
+    // TODO: compute actual k-anonymity and DP metrics
+    return {
+      dataset,
+      epsilon: 0,
+      delta: 0,
+      kAnonymity: null,
+    };
+  }
+}
+
+module.exports = new PrivacyReportService();

--- a/server/src/services/SyntheticDataService.js
+++ b/server/src/services/SyntheticDataService.js
@@ -1,0 +1,16 @@
+class SyntheticDataService {
+  async train({ dataset, epsilon }) {
+    // TODO: implement actual DP training with CTGAN or DDPM
+    const modelId = `model_${Date.now()}`;
+    return { modelId, epsilon };
+  }
+
+  async sample({ modelId, count = 1 }) {
+    // TODO: integrate PII masking, k-anonymity checks and linkage risk scoring
+    const data = Array.from({ length: count }, (_, i) => ({ id: i + 1 }));
+    const riskReport = { reidentificationRisk: 0 };
+    return { data, riskReport };
+  }
+}
+
+module.exports = new SyntheticDataService();


### PR DESCRIPTION
## Summary
- add placeholder synthetic data service with DP-aware train/sample stubs
- expose `/synth/*` and `/privacy/report` routes
- add basic tests covering training, sampling, and report retrieval

## Testing
- `npm test` *(fails: jest: not found - missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa526659c833384d11d89ad407342