### PR TITLE
feat: add refinery endpoints for materialized views

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,6 +12,7 @@ import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
 import { register } from "./monitoring/metrics.js";
 import rbacRouter from "./routes/rbacRoutes.js";
+import refineryRouter from "./routes/refinery.js";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
 import { getContext } from "./lib/auth.js";
@@ -42,6 +43,7 @@ export const createApp = async () => {
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
   app.use("/rbac", rbacRouter);
+  app.use(refineryRouter);
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", register.contentType);
     res.end(await register.metrics());

--- a/server/src/routes/__tests__/refinery.test.ts
+++ b/server/src/routes/__tests__/refinery.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../../featureFlags/flagsmith', () => ({
+  isEnabled: jest.fn(),
+}));
+
+import refineryRouter from '../refinery';
+import { isEnabled } from '../../featureFlags/flagsmith';
+
+const app = express();
+app.use(express.json());
+app.use(refineryRouter);
+
+describe('Refinery routes', () => {
+  beforeEach(() => {
+    (isEnabled as jest.Mock).mockResolvedValue(false);
+  });
+
+  it('returns advisory plan', async () => {
+    const res = await request(app).post('/advisor/plan').send({ query: 'SELECT 1' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('viewSpec');
+    expect(res.body).toHaveProperty('costDelta');
+    expect(res.body).toHaveProperty('ROI');
+  });
+
+  it('honors feature flag for create', async () => {
+    const res = await request(app).post('/views/demo/create');
+    expect(isEnabled).toHaveBeenCalledWith('refinery.auto');
+    expect(res.status).toBe(202);
+    expect(res.body.status).toBe('advisory-only');
+  });
+
+  it('creates view when flag enabled', async () => {
+    (isEnabled as jest.Mock).mockResolvedValueOnce(true);
+    const res = await request(app).post('/views/demo/create');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('created');
+  });
+
+  it('returns health metrics', async () => {
+    const res = await request(app).get('/views/demo/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('lag');
+    expect(res.body).toHaveProperty('hitRate');
+  });
+});

--- a/server/src/routes/refinery.ts
+++ b/server/src/routes/refinery.ts
@@ -1,0 +1,51 @@
+import express, { Request, Response } from 'express';
+import { isEnabled } from '../featureFlags/flagsmith.js';
+
+const router = express.Router();
+router.use(express.json());
+
+/**
+ * Cost-based advisor for materialized views
+ * POST /advisor/plan -> {viewSpec, costDelta, ROI}
+ */
+router.post('/advisor/plan', async (_req: Request, res: Response) => {
+  res.json({ viewSpec: {}, costDelta: 0, ROI: 0 });
+});
+
+/**
+ * View management endpoints guarded by refinery.auto flag
+ */
+async function ensureFlag(): Promise<boolean> {
+  return isEnabled('refinery.auto');
+}
+
+router.post('/views/:id/create', async (_req: Request, res: Response) => {
+  if (!(await ensureFlag())) {
+    return res.status(202).json({ status: 'advisory-only' });
+  }
+  res.json({ status: 'created' });
+});
+
+router.post('/views/:id/refresh', async (_req: Request, res: Response) => {
+  if (!(await ensureFlag())) {
+    return res.status(202).json({ status: 'advisory-only' });
+  }
+  res.json({ status: 'refreshed' });
+});
+
+router.post('/views/:id/drop', async (_req: Request, res: Response) => {
+  if (!(await ensureFlag())) {
+    return res.status(202).json({ status: 'advisory-only' });
+  }
+  res.json({ status: 'dropped' });
+});
+
+/**
+ * Metrics endpoint for view health
+ * GET /views/:id/health -> {lag, hitRate}
+ */
+router.get('/views/:id/health', (_req: Request, res: Response) => {
+  res.json({ lag: 0, hitRate: 0 });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add stub refinery router for advisor and view lifecycle endpoints
- wire refinery router into express app
- add tests covering advisory mode and view metrics

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Prettier SyntaxError in workflows)*
- `cd server && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa5297b788333850e68e7d2c949b0