### PR TITLE
feat: scaffold rapid service

### DIFF
--- a/.github/workflows/rapid-service.yml
+++ b/.github/workflows/rapid-service.yml
@@ -1,0 +1,27 @@
+name: rapid-service
+
+on:
+  push:
+    paths:
+      - 'services/rapid-service/**'
+      - '.github/workflows/rapid-service.yml'
+  pull_request:
+    paths:
+      - 'services/rapid-service/**'
+      - '.github/workflows/rapid-service.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/rapid-service
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test
+      - run: docker build -t rapid-service .
+      - run: docker run -d -p 3000:3000 --name rapid-service rapid-service && sleep 3 && curl -f http://localhost:3000/health && docker stop rapid-service

--- a/services/rapid-service/.gitignore
+++ b/services/rapid-service/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+package-lock.json

--- a/services/rapid-service/Dockerfile
+++ b/services/rapid-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY src ./src
+COPY openapi.yaml ./
+EXPOSE 3000
+CMD ["node", "src/index.js"]

--- a/services/rapid-service/Makefile
+++ b/services/rapid-service/Makefile
@@ -1,0 +1,15 @@
+.PHONY: install test start docker-build docker-run
+install:
+	npm install
+
+test:
+	npm test
+
+start:
+	npm start
+
+docker-build:
+	docker build -t rapid-service .
+
+docker-run:
+	docker run --rm -p 3000:3000 rapid-service

--- a/services/rapid-service/jest.config.js
+++ b/services/rapid-service/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/services/rapid-service/openapi.yaml
+++ b/services/rapid-service/openapi.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.1
+info:
+  title: Rapid Service
+  version: '1.0.0'
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok

--- a/services/rapid-service/package.json
+++ b/services/rapid-service/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rapid-service",
+  "version": "0.1.0",
+  "description": "Sample microservice with health endpoint",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "pino": "^8.17.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/services/rapid-service/seed.js
+++ b/services/rapid-service/seed.js
@@ -1,0 +1,9 @@
+const logger = require('./src/logger');
+
+async function seed() {
+  logger.info('seeding started');
+  // Add seed logic here
+  logger.info('seeding complete');
+}
+
+seed();

--- a/services/rapid-service/src/config.js
+++ b/services/rapid-service/src/config.js
@@ -1,0 +1,6 @@
+require('dotenv').config();
+
+module.exports = {
+  port: process.env.PORT || 3000,
+  logLevel: process.env.LOG_LEVEL || 'info'
+};

--- a/services/rapid-service/src/index.js
+++ b/services/rapid-service/src/index.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const config = require('./config');
+const logger = require('./logger');
+
+const app = express();
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+let server;
+if (require.main === module) {
+  server = app.listen(config.port, () => {
+    logger.info({ event: 'server_start', port: config.port }, 'server started');
+  });
+
+  const shutdown = () => {
+    logger.info('shutting down');
+    server.close(() => {
+      logger.info('shutdown complete');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+module.exports = app;

--- a/services/rapid-service/src/logger.js
+++ b/services/rapid-service/src/logger.js
@@ -1,0 +1,6 @@
+const pino = require('pino');
+const config = require('./config');
+
+const logger = pino({ level: config.logLevel });
+
+module.exports = logger;

--- a/services/rapid-service/test/health.test.js
+++ b/services/rapid-service/test/health.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../src/index');
+
+describe('GET /health', () => {
+  it('returns ok', async () => {
+    const res = await request(app).get('/health');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold minimal Express microservice with health endpoint
- add structured logging, env config, OpenAPI spec, Makefile, Dockerfile, and seed script
- add GitHub Actions CI and unit tests
- ignore service package-lock to avoid binary diff

## Testing
- `npm test` *(fails: jest not found)*
- `cd services/rapid-service && npm test`
- `cd services/rapid-service && make test`
- `cd services/rapid-service && docker build -t rapid-service .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa67994908333861ebae67d2b1424