### PR TITLE
feat: add sdk service endpoints

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,25 +1,26 @@
-import "dotenv/config";
-import express from "express";
-import { ApolloServer } from "@apollo/server";
-import { expressMiddleware } from "@as-integrations/express4";
-import { makeExecutableSchema } from "@graphql-tools/schema";
-import cors from "cors";
-import helmet from "helmet";
-import rateLimit from "express-rate-limit";
-import { pinoHttp } from "pino-http";
-import { auditLogger } from "./middleware/audit-logger.js";
-import monitoringRouter from "./routes/monitoring.js";
-import aiRouter from "./routes/ai.js";
-import { register } from "./monitoring/metrics.js";
-import rbacRouter from "./routes/rbacRoutes.js";
-import { typeDefs } from "./graphql/schema.js";
-import resolvers from "./graphql/resolvers/index.js";
-import { getContext } from "./lib/auth.js";
-import { getNeo4jDriver } from "./db/neo4j.js";
-import path from "path";
-import { fileURLToPath } from "url";
-import jwt from "jsonwebtoken"; // Assuming jsonwebtoken is available or will be installed
-import { Request, Response, NextFunction } from "express"; // Import types for middleware
+import 'dotenv/config';
+import express from 'express';
+import { ApolloServer } from '@apollo/server';
+import { expressMiddleware } from '@as-integrations/express4';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import { pinoHttp } from 'pino-http';
+import { auditLogger } from './middleware/audit-logger.js';
+import monitoringRouter from './routes/monitoring.js';
+import aiRouter from './routes/ai.js';
+import { register } from './monitoring/metrics.js';
+import rbacRouter from './routes/rbacRoutes.js';
+import sdkRouter from './routes/sdk.js';
+import { typeDefs } from './graphql/schema.js';
+import resolvers from './graphql/resolvers/index.js';
+import { getContext } from './lib/auth.js';
+import { getNeo4jDriver } from './db/neo4j.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import jwt from 'jsonwebtoken'; // Assuming jsonwebtoken is available or will be installed
+import { Request, Response, NextFunction } from 'express'; // Import types for middleware
 import logger from './config/logger';
 
 export const createApp = async () => {
@@ -31,30 +32,31 @@ export const createApp = async () => {
   app.use(helmet());
   app.use(
     cors({
-      origin: process.env.CORS_ORIGIN?.split(",") ?? ["http://localhost:3000"],
+      origin: process.env.CORS_ORIGIN?.split(',') ?? ['http://localhost:3000'],
       credentials: true,
     }),
   );
-  app.use(pinoHttp({ logger: appLogger, redact: ["req.headers.authorization"] }));
+  app.use(pinoHttp({ logger: appLogger, redact: ['req.headers.authorization'] }));
   app.use(auditLogger);
 
   // Rate limiting (exempt monitoring endpoints)
-  app.use("/monitoring", monitoringRouter);
-  app.use("/api/ai", aiRouter);
-  app.use("/rbac", rbacRouter);
-  app.get("/metrics", async (_req, res) => {
-    res.set("Content-Type", register.contentType);
+  app.use('/monitoring', monitoringRouter);
+  app.use('/api/ai', aiRouter);
+  app.use('/rbac', rbacRouter);
+  app.use('/sdk', sdkRouter);
+  app.get('/metrics', async (_req, res) => {
+    res.set('Content-Type', register.contentType);
     res.end(await register.metrics());
   });
   app.use(
     rateLimit({
       windowMs: Number(process.env.RATE_LIMIT_WINDOW_MS || 60_000),
       max: Number(process.env.RATE_LIMIT_MAX || 600),
-      message: { error: "Too many requests, please try again later" },
+      message: { error: 'Too many requests, please try again later' },
     }),
   );
 
-  app.get("/search/evidence", async (req, res) => {
+  app.get('/search/evidence', async (req, res) => {
     const { q, skip = 0, limit = 10 } = req.query;
 
     if (!q) {
@@ -87,11 +89,11 @@ export const createApp = async () => {
       ]);
 
       const evidence = searchResult.records.map((record) => ({
-        node: record.get("node").properties,
-        score: record.get("score"),
+        node: record.get('node').properties,
+        score: record.get('score'),
       }));
 
-      const total = countResult.records[0].get("total").toNumber();
+      const total = countResult.records[0].get('total').toNumber();
 
       res.send({
         data: evidence,
@@ -105,9 +107,9 @@ export const createApp = async () => {
       });
     } catch (error) {
       logger.error(
-        `Error in search/evidence: ${error instanceof Error ? error.message : "Unknown error"}`,
+        `Error in search/evidence: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
-      res.status(500).send({ error: "Internal server error" });
+      res.status(500).send({ error: 'Internal server error' });
     } finally {
       await session.close();
     }
@@ -116,17 +118,11 @@ export const createApp = async () => {
   const schema = makeExecutableSchema({ typeDefs, resolvers });
 
   // GraphQL over HTTP
-  const { persistedQueriesPlugin } = await import(
-    "./graphql/plugins/persistedQueries.js"
-  );
-  const { default: pbacPlugin } = await import("./graphql/plugins/pbac.js");
-  const { default: resolverMetricsPlugin } = await import(
-    "./graphql/plugins/resolverMetrics.js"
-  );
-  const { default: auditLoggerPlugin } = await import(
-    "./graphql/plugins/auditLogger.js"
-  );
-  const { depthLimit } = await import("./graphql/validation/depthLimit.js");
+  const { persistedQueriesPlugin } = await import('./graphql/plugins/persistedQueries.js');
+  const { default: pbacPlugin } = await import('./graphql/plugins/pbac.js');
+  const { default: resolverMetricsPlugin } = await import('./graphql/plugins/resolverMetrics.js');
+  const { default: auditLoggerPlugin } = await import('./graphql/plugins/auditLogger.js');
+  const { depthLimit } = await import('./graphql/validation/depthLimit.js');
 
   import { otelApolloPlugin } from './graphql/middleware/otelPlugin';
 
@@ -139,10 +135,10 @@ export const createApp = async () => {
       resolverMetricsPlugin as any,
       auditLoggerPlugin as any,
       // Enable PBAC in production
-      ...(process.env.NODE_ENV === 'production' ? [pbacPlugin() as any] : [])
+      ...(process.env.NODE_ENV === 'production' ? [pbacPlugin() as any] : []),
     ],
     // Security configuration based on environment
-    introspection: process.env.NODE_ENV !== "production",
+    introspection: process.env.NODE_ENV !== 'production',
     // Enhanced query validation rules
     validationRules: [
       depthLimit(process.env.NODE_ENV === 'production' ? 6 : 8), // Stricter in prod
@@ -160,29 +156,32 @@ export const createApp = async () => {
   await apollo.start();
 
   // Production Authentication - Use proper JWT validation
-  const { productionAuthMiddleware, applyProductionSecurity, graphqlSecurityConfig } = await import('./config/production-security.js');
-  
+  const { productionAuthMiddleware, applyProductionSecurity, graphqlSecurityConfig } = await import(
+    './config/production-security.js'
+  );
+
   // Apply security middleware based on environment
   if (process.env.NODE_ENV === 'production') {
     applyProductionSecurity(app);
   }
-  
-  const authenticateToken = process.env.NODE_ENV === 'production' 
-    ? productionAuthMiddleware 
-    : (req: Request, res: Response, next: NextFunction) => {
-        // Development mode - relaxed auth for easier testing
-        const authHeader = req.headers["authorization"];
-        const token = authHeader && authHeader.split(" ")[1];
-        
-        if (!token) {
-          console.warn("Development: No token provided, allowing request");
-          (req as any).user = { sub: 'dev-user', email: 'dev@intelgraph.local', role: 'admin' };
-        }
-        next();
-      };
+
+  const authenticateToken =
+    process.env.NODE_ENV === 'production'
+      ? productionAuthMiddleware
+      : (req: Request, res: Response, next: NextFunction) => {
+          // Development mode - relaxed auth for easier testing
+          const authHeader = req.headers['authorization'];
+          const token = authHeader && authHeader.split(' ')[1];
+
+          if (!token) {
+            console.warn('Development: No token provided, allowing request');
+            (req as any).user = { sub: 'dev-user', email: 'dev@intelgraph.local', role: 'admin' };
+          }
+          next();
+        };
 
   app.use(
-    "/graphql",
+    '/graphql',
     express.json(),
     authenticateToken, // WAR-GAMED SIMULATION - Add authentication middleware here
     expressMiddleware(apollo, { context: getContext }),

--- a/server/src/appFactory.ts
+++ b/server/src/appFactory.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import config from './config/index.js';
 import logger from './utils/logger.js';
+import sdkRouter from './routes/sdk.js';
 
 interface AppOptions {
   lightweight?: boolean;
@@ -13,29 +14,33 @@ function createApp({ lightweight = false }: AppOptions = {}) {
   const app = express();
   app.disable('x-powered-by');
 
-  app.use(helmet({
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
-        scriptSrc: ["'self'"],
-        imgSrc: ["'self'", "data:", "https:"]
-      }
-    },
-    referrerPolicy: { policy: 'no-referrer' }
-  }));
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          scriptSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:', 'https:'],
+        },
+      },
+      referrerPolicy: { policy: 'no-referrer' },
+    }),
+  );
 
   app.use(cors({ origin: config.cors.origin, credentials: true }));
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true, limit: '10mb' }));
   app.use(morgan('combined', { stream: { write: (msg) => logger.info(msg.trim()) } }));
 
+  app.use('/sdk', sdkRouter);
+
   app.get('/health', (req, res) => {
     res.status(200).json({
       status: 'OK',
       timestamp: new Date().toISOString(),
       environment: config.env,
-      version: '1.0.0'
+      version: '1.0.0',
     });
   });
 

--- a/server/src/routes/sdk.ts
+++ b/server/src/routes/sdk.ts
@@ -1,0 +1,35 @@
+import express, { Request, Response } from 'express';
+
+const router = express.Router();
+
+/**
+ * Health check for SDK service
+ */
+router.get('/health', (_req: Request, res: Response) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+/**
+ * Publish a new SDK version. Currently a stub that validates input and
+ * acknowledges the request. Integration with the actual SDK generator will
+ * be added later.
+ */
+router.post('/publish', (req: Request, res: Response) => {
+  const { language, version } = req.body as {
+    language?: string;
+    version?: string;
+  };
+
+  if (!language || !version) {
+    return res.status(400).json({ error: 'language and version are required' });
+  }
+
+  // TODO: integrate with SDK generation pipeline
+  res.status(202).json({
+    message: 'SDK publish request accepted',
+    language,
+    version,
+  });
+});
+
+export default router;

--- a/server/tests/sdkRoutes.test.ts
+++ b/server/tests/sdkRoutes.test.ts
@@ -1,0 +1,29 @@
+import request from 'supertest';
+import { createApp } from '../src/appFactory';
+
+describe('SDK Routes', () => {
+  it('GET /sdk/health returns ok', async () => {
+    const app = createApp({ lightweight: true });
+    const res = await request(app).get('/sdk/health').expect(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+
+  it('POST /sdk/publish accepts valid payload', async () => {
+    const app = createApp({ lightweight: true });
+    const res = await request(app)
+      .post('/sdk/publish')
+      .send({ language: 'ts', version: '1.0.0' })
+      .expect(202);
+    expect(res.body).toMatchObject({
+      message: 'SDK publish request accepted',
+      language: 'ts',
+      version: '1.0.0',
+    });
+  });
+
+  it('POST /sdk/publish requires language and version', async () => {
+    const app = createApp({ lightweight: true });
+    const res = await request(app).post('/sdk/publish').send({}).expect(400);
+    expect(res.body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## Summary
- add basic /sdk routes with health check and publish stub
- mount sdk routes in app and appFactory
- test sdk endpoints

## Testing
- `npm run format` *(fails: SyntaxError in .github/workflows)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `cd server && npm install` *(fails: canvas build missing pixman-1)*
- `cd server && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa65510c88333ba0191ad9190b0ef