### PR TITLE
feat: scaffold tenant admin service and sdk

### DIFF
--- a/apps/web/src/features/org-admin/OrgAdminSettings.jsx
+++ b/apps/web/src/features/org-admin/OrgAdminSettings.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function OrgAdminSettings() {
+  return (
+    <div>
+      <h2>Org Administration</h2>
+      <p>SSO, SCIM, and quota management coming soon.</p>
+    </div>
+  );
+}

--- a/apps/web/src/features/org-admin/OrgAdminSettings.test.jsx
+++ b/apps/web/src/features/org-admin/OrgAdminSettings.test.jsx
@@ -1,0 +1,7 @@
+import OrgAdminSettings from './OrgAdminSettings.jsx';
+
+describe('OrgAdminSettings', () => {
+  it('is a function', () => {
+    expect(typeof OrgAdminSettings).toBe('function');
+  });
+});

--- a/ops/tenant/README.md
+++ b/ops/tenant/README.md
@@ -1,0 +1,5 @@
+# Tenant Operations
+
+Sample IdP metadata and SCIM attribute mappings for the tenant administration service.
+
+Billing events can be forwarded to a pluggable adapter such as Stripe.

--- a/ops/tenant/idp-metadata.xml
+++ b/ops/tenant/idp-metadata.xml
@@ -1,0 +1,3 @@
+<xml>
+  <EntityDescriptor entityID="https://idp.example.com" />
+</xml>

--- a/ops/tenant/scim-mapping.json
+++ b/ops/tenant/scim-mapping.json
@@ -1,0 +1,4 @@
+{
+  "userName": "userName",
+  "externalId": "id"
+}

--- a/packages/sdk/tenant-js/index.js
+++ b/packages/sdk/tenant-js/index.js
@@ -1,0 +1,20 @@
+const BASE = process.env.TENANT_ADMIN_URL || 'http://localhost:3000';
+
+async function post(path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body || {}),
+  });
+  if (!res.ok) throw new Error(`request failed: ${res.status}`);
+  return res.json();
+}
+
+export const createOrg = (data) => post('/orgs', data);
+export const createProject = (data) => post('/projects', data);
+export const createQuota = (data) => post('/quotas', data);
+export const initiateSaml = (data) => post('/sso/saml/initiate', data);
+export const initiateOidc = (data) => post('/sso/oidc/initiate', data);
+export const scimUser = (data) => post('/scim/v2/Users', data);
+export const scimGroup = (data) => post('/scim/v2/Groups', data);
+export const billingEvent = (data) => post('/billing/events', data);

--- a/packages/sdk/tenant-js/index.test.js
+++ b/packages/sdk/tenant-js/index.test.js
@@ -1,0 +1,8 @@
+import * as sdk from './index.js';
+
+describe('tenant-js sdk', () => {
+  it('exports helpers', () => {
+    expect(typeof sdk.createOrg).toBe('function');
+    expect(typeof sdk.billingEvent).toBe('function');
+  });
+});

--- a/packages/sdk/tenant-js/package.json
+++ b/packages/sdk/tenant-js/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@intelgraph/tenant-js",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "type": "module"
+}

--- a/services/tenant-admin/index.js
+++ b/services/tenant-admin/index.js
@@ -1,0 +1,69 @@
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+// Audit logging middleware
+app.use((req, res, next) => {
+  console.log(`audit: ${req.method} ${req.path}`);
+  next();
+});
+
+// Quota enforcement stub
+app.use((req, res, next) => {
+  next();
+});
+
+// Tenant management endpoints
+app.post('/orgs', (req, res) => {
+  res.status(201).json({ id: 'org-placeholder' });
+});
+
+app.post('/projects', (req, res) => {
+  res.status(201).json({ id: 'project-placeholder' });
+});
+
+app.post('/quotas', (req, res) => {
+  res.status(201).json({ id: 'quota-placeholder' });
+});
+
+// Billing events
+app.post('/billing/events', (req, res) => {
+  res.status(202).json({ status: 'accepted' });
+});
+
+// SSO initiation stubs
+app.post('/sso/saml/initiate', (req, res) => {
+  res.status(200).json({ redirect: '/saml/acs' });
+});
+
+app.post('/sso/oidc/initiate', (req, res) => {
+  res.status(200).json({ redirect: '/oidc/callback' });
+});
+
+// SSO callbacks
+app.post('/sso/saml/acs', (req, res) => {
+  res.status(200).json({ status: 'saml-acs' });
+});
+
+app.post('/sso/oidc/callback', (req, res) => {
+  res.status(200).json({ status: 'oidc-callback' });
+});
+
+// SCIM subset
+app.post('/scim/v2/Users', (req, res) => {
+  res.status(201).json({ id: 'user-placeholder' });
+});
+
+app.post('/scim/v2/Groups', (req, res) => {
+  res.status(201).json({ id: 'group-placeholder' });
+});
+
+export default app;
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`tenant-admin listening on ${port}`);
+  });
+}

--- a/services/tenant-admin/index.test.js
+++ b/services/tenant-admin/index.test.js
@@ -1,0 +1,5 @@
+describe('tenant-admin service', () => {
+  it('placeholder test', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/services/tenant-admin/package.json
+++ b/services/tenant-admin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tenant-admin-service",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold tenant-admin service with SSO, SCIM, billing and quota stubs
- add tenant-js SDK for tenant administration API
- add org admin settings component and tenant ops templates

## Testing
- `npm run lint` *(fails: Parsing error in repository)*
- `npm test` *(fails: multiple unit tests and configuration errors)*
- `npm run test:e2e` *(fails: Playwright and import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa61dde0c83339d4d6dfe4863d1d6