### PR TITLE
feat: scaffold entity resolution service

### DIFF
--- a/client/src/features/er-console/index.tsx
+++ b/client/src/features/er-console/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/**
+ * Minimal placeholder for the ER Console feature.
+ */
+export const ERConsole: React.FC = () => {
+  return (
+    <div>
+      <h2>Entity Resolution Console</h2>
+      <p>Pending implementation.</p>
+    </div>
+  );
+};
+
+export default ERConsole;
+

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,0 +1,7 @@
+# Connectors
+
+This directory will host source connectors that emit provenance and canonicalization hints
+for the Entity Resolution subsystem.
+
+*This is a placeholder.*
+

--- a/server/src/graphql/resolvers/erResolvers.ts
+++ b/server/src/graphql/resolvers/erResolvers.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolver stubs for Entity Resolution GraphQL operations
+ */
+export const erResolvers = {
+  Query: {
+    erPair: async (_parent: unknown, args: { id: string }) => {
+      return {
+        id: args.id,
+        leftId: '',
+        rightId: '',
+        score: 0,
+        decision: null
+      };
+    }
+  },
+  Mutation: {
+    labelPair: async (
+      _parent: unknown,
+      args: { id: string; decision: string }
+    ) => {
+      return { id: args.id, leftId: '', rightId: '', score: 0, decision: args.decision };
+    }
+  }
+};
+
+export default erResolvers;
+

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -6,6 +6,7 @@ import entityResolvers from './entity';
 import relationshipResolvers from './relationship';
 import userResolvers from './user';
 import investigationResolvers from './investigation';
+import erResolvers from './erResolvers';
 import { WargameResolver } from '../../resolvers/WargameResolver.js'; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
 
 // Instantiate the WargameResolver
@@ -24,6 +25,7 @@ const resolvers = {
     ...entityResolvers.Query,
     ...userResolvers.Query,
     ...investigationResolvers.Query,
+    ...erResolvers.Query,
     
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     getCrisisTelemetry: wargameResolver.getCrisisTelemetry.bind(wargameResolver),
@@ -43,6 +45,7 @@ const resolvers = {
     ...relationshipResolvers.Mutation,
     ...userResolvers.Mutation,
     ...investigationResolvers.Mutation,
+    ...erResolvers.Mutation,
     
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     runWarGameSimulation: wargameResolver.runWarGameSimulation.bind(wargameResolver),

--- a/server/src/graphql/schema-combined.ts
+++ b/server/src/graphql/schema-combined.ts
@@ -3,6 +3,7 @@ const { copilotTypeDefs } = require('./schema.copilot.js');
 const { graphTypeDefs } = require('./schema.graphops.js');
 const { aiTypeDefs } = require('./schema.ai.js');
 const graphragTypes = require('./types/graphragTypes.js');
+const erTypes = require('./types/erTypes.ts');
 const coreTypeDefs = require('./schema/core.js');
 
 const base = gql`
@@ -13,5 +14,5 @@ const base = gql`
   type Subscription { _empty: String }
 `;
 
-export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs];
+export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, erTypes, aiTypeDefs];
 

--- a/server/src/graphql/schema.js
+++ b/server/src/graphql/schema.js
@@ -4,6 +4,7 @@ const { graphTypeDefs } = require('./schema.graphops.js');
 const { aiTypeDefs } = require('./schema.ai.js');
 const { annotationsTypeDefs } = require('./schema.annotations.js');
 const graphragTypes = require('./types/graphragTypes.js');
+const erTypes = require('./types/erTypes.ts');
 import { coreTypeDefs } from './schema.core.js';
 
 const base = gql`
@@ -15,4 +16,4 @@ const base = gql`
   type Subscription { _empty: String }
 `;
 
-export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs, annotationsTypeDefs];
+export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, erTypes, aiTypeDefs, annotationsTypeDefs];

--- a/server/src/graphql/types/erTypes.ts
+++ b/server/src/graphql/types/erTypes.ts
@@ -1,0 +1,25 @@
+/**
+ * GraphQL type definitions for Entity Resolution operations
+ */
+const gql = require('graphql-tag');
+
+const erTypes = gql`
+  type ERPair {
+    id: ID!
+    leftId: ID!
+    rightId: ID!
+    score: Float
+    decision: String
+  }
+
+  extend type Query {
+    erPair(id: ID!): ERPair
+  }
+
+  extend type Mutation {
+    labelPair(id: ID!, decision: String!): ERPair
+  }
+`;
+
+module.exports = erTypes;
+

--- a/services/er/__init__.py
+++ b/services/er/__init__.py
@@ -1,0 +1,2 @@
+"""Entity Resolution service package."""
+

--- a/services/er/blocking.py
+++ b/services/er/blocking.py
@@ -1,0 +1,40 @@
+"""Blocking strategies for entity resolution.
+
+This module defines placeholder classes for different blocking techniques
+such as MinHash for textual fields and geohash for locations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+
+@dataclass
+class CandidatePair:
+    """Represents a pair of entity IDs considered for matching."""
+
+    left_id: str
+    right_id: str
+
+
+class MinHashBlocker:
+    """Simple placeholder MinHash blocker."""
+
+    def block(self, records: Iterable[dict]) -> List[CandidatePair]:
+        """Generate candidate pairs from an iterable of records.
+
+        The current implementation is a stub that returns an empty list.
+        """
+        return []
+
+
+class GeohashBlocker:
+    """Placeholder geohash blocker for geospatial data."""
+
+    def block(self, records: Iterable[dict]) -> List[CandidatePair]:
+        """Generate candidate pairs based on geospatial proximity."""
+        return []
+
+
+__all__ = ["CandidatePair", "MinHashBlocker", "GeohashBlocker"]
+

--- a/services/er/cli.py
+++ b/services/er/cli.py
@@ -1,0 +1,45 @@
+"""Command line interface for the entity resolution service.
+
+The CLI exposes minimal subcommands that mirror the intended production
+interface. Commands are placeholders and only log the requested action.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+
+def _print_action(name: str, **kwargs: Any) -> None:
+    print(json.dumps({"action": name, **kwargs}))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="IntelGraph ER tooling")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    block = sub.add_parser("block", help="Generate candidate pairs")
+    block.add_argument("--entity-type", required=True)
+    block.add_argument("--since")
+
+    score = sub.add_parser("score", help="Score candidate pairs")
+    score.add_argument("--run", required=True)
+
+    train = sub.add_parser("train", help="Train an ER model")
+    train.add_argument("--dataset", required=True)
+    train.add_argument("--algo", default="graphsage+xgb")
+
+    eval_cmd = sub.add_parser("eval", help="Evaluate an ER dataset")
+    eval_cmd.add_argument("--dataset", required=True)
+    eval_cmd.add_argument("--report", default="pr")
+
+    export = sub.add_parser("export-bundle", help="Export models and metrics")
+    export.add_argument("--run", required=True)
+
+    args = parser.parse_args()
+    _print_action(args.command, **{k: v for k, v in vars(args).items() if k != "command"})
+
+
+if __name__ == "__main__":
+    main()
+

--- a/services/er/scoring.py
+++ b/services/er/scoring.py
@@ -1,0 +1,31 @@
+"""Scoring utilities for entity resolution.
+
+This module contains a placeholder scorer that would normally combine
+feature vectors and produce match probabilities.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .blocking import CandidatePair
+
+
+@dataclass
+class ScoredPair:
+    """Candidate pair annotated with a score."""
+
+    pair: CandidatePair
+    score: float
+
+
+class SimpleScorer:
+    """Stub probability scorer."""
+
+    def score(self, pairs: Iterable[CandidatePair]) -> List[ScoredPair]:
+        """Assign a default score to each candidate pair."""
+        return [ScoredPair(pair=p, score=0.0) for p in pairs]
+
+
+__all__ = ["ScoredPair", "SimpleScorer"]
+


### PR DESCRIPTION
## Summary
- add Python stubs for ER blocking, scoring, and CLI
- scaffold ER GraphQL types and resolvers
- add placeholder React console and connectors docs

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68aac55051dc83339ce216f95847b43a