### PR TITLE
feat: add collaboration stubs

### DIFF
--- a/client/src/features/collab/PresenceAvatars.test.tsx
+++ b/client/src/features/collab/PresenceAvatars.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import PresenceAvatars from './PresenceAvatars';
+
+describe('PresenceAvatars', () => {
+  it('renders user initials', () => {
+    render(<PresenceAvatars users={[{ id: '1', name: 'Alice' }]} />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+});

--- a/client/src/features/collab/PresenceAvatars.tsx
+++ b/client/src/features/collab/PresenceAvatars.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Avatar from '@mui/material/Avatar';
+import Stack from '@mui/material/Stack';
+
+export interface PresenceUser {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+interface Props {
+  users: PresenceUser[];
+}
+
+/**
+ * PresenceAvatars renders collaborator avatars for the current session.
+ */
+const PresenceAvatars: React.FC<Props> = ({ users }) => (
+  <Stack direction="row" spacing={1} data-testid="presence-avatars">
+    {users.map(u => (
+      <Avatar
+        key={u.id}
+        sx={{ bgcolor: u.color || 'primary.main', width: 24, height: 24 }}
+        title={u.name}
+      >
+        {u.name.charAt(0).toUpperCase()}
+      </Avatar>
+    ))}
+  </Stack>
+);
+
+export default PresenceAvatars;

--- a/client/src/features/collab/index.ts
+++ b/client/src/features/collab/index.ts
@@ -1,0 +1,1 @@
+export { default as PresenceAvatars } from './PresenceAvatars';

--- a/server/src/graphql/resolvers-combined.ts
+++ b/server/src/graphql/resolvers-combined.ts
@@ -4,6 +4,7 @@ const copilotResolvers = require('./resolvers.copilot.js');
 const graphResolvers = require('./resolvers.graphops.js');
 const aiResolvers = require('./resolvers.ai.js');
 const annotationsResolvers = require('./resolvers.annotations.js');
+const collabResolvers = require('./resolvers.collab.js');
 import { v4 as uuidv4 } from 'uuid';
 
 interface User {
@@ -58,6 +59,7 @@ export const resolvers = {
     ...(copilotResolvers.Query || {}),
     ...(aiResolvers.Query || {}),
     ...(annotationsResolvers.Query || {}),
+    ...(collabResolvers.Query || {}),
     me: async (_: any, __: any, { user }: Context): Promise<User> => {
       if (!user) throw new Error('Not authenticated');
       return user;
@@ -74,6 +76,7 @@ export const resolvers = {
     ...(graphResolvers.Mutation || {}),
     ...(aiResolvers.Mutation || {}),
     ...(annotationsResolvers.Mutation || {}),
+    ...(collabResolvers.Mutation || {}),
     login: async (_: any, { input }: { input: LoginInput }, { req }: Context) => {
       const { email, password } = input;
       const ipAddress = req?.ip;
@@ -109,6 +112,7 @@ export const resolvers = {
     ...(copilotResolvers.Subscription || {}),
     ...(aiResolvers.Subscription || {}),
     ...(annotationsResolvers.Subscription || {}),
+    ...(collabResolvers.Subscription || {}),
     investigationUpdated: {
       subscribe: () => pubsub.asyncIterator(['INVESTIGATION_UPDATED'])
     },

--- a/server/src/graphql/resolvers.collab.js
+++ b/server/src/graphql/resolvers.collab.js
@@ -1,0 +1,19 @@
+const branches = [];
+
+module.exports = {
+  Query: {
+    branches: () => branches,
+  },
+  Mutation: {
+    createBranch: (_, { name }) => {
+      const branch = { id: String(branches.length + 1), name };
+      branches.push(branch);
+      return branch;
+    },
+  },
+  Subscription: {
+    presenceUpdated: {
+      subscribe: (_, __, { pubsub }) => pubsub.asyncIterator('PRESENCE_UPDATED'),
+    },
+  },
+};

--- a/server/src/graphql/schema-combined.ts
+++ b/server/src/graphql/schema-combined.ts
@@ -4,6 +4,7 @@ const { graphTypeDefs } = require('./schema.graphops.js');
 const { aiTypeDefs } = require('./schema.ai.js');
 const graphragTypes = require('./types/graphragTypes.js');
 const coreTypeDefs = require('./schema/core.js');
+const { collabTypeDefs } = require('./schema.collab.js');
 
 const base = gql`
   scalar JSON
@@ -13,5 +14,5 @@ const base = gql`
   type Subscription { _empty: String }
 `;
 
-export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs];
+export const typeDefs = [base, coreTypeDefs, copilotTypeDefs, graphTypeDefs, graphragTypes, aiTypeDefs, collabTypeDefs];
 

--- a/server/src/graphql/schema.collab.js
+++ b/server/src/graphql/schema.collab.js
@@ -1,0 +1,54 @@
+import { gql } from 'graphql-tag';
+
+export const collabTypeDefs = gql`
+  scalar DateTime
+  scalar JSON
+
+  type Branch {
+    id: ID!
+    name: String!
+    head: Commit
+  }
+
+  type Commit {
+    id: ID!
+    message: String
+    createdAt: DateTime!
+  }
+
+  type ChangeSet {
+    id: ID!
+    branchId: ID!
+    changes: JSON
+  }
+
+  type Review {
+    id: ID!
+    branch: Branch!
+    status: String!
+  }
+
+  type Annotation {
+    id: ID!
+    content: String!
+    authorId: ID!
+    createdAt: DateTime!
+  }
+
+  type Presence {
+    userId: ID!
+    status: String!
+  }
+
+  extend type Query {
+    branches: [Branch!]!
+  }
+
+  extend type Mutation {
+    createBranch(name: String!): Branch!
+  }
+
+  extend type Subscription {
+    presenceUpdated: Presence!
+  }
+`;

--- a/server/tests/collab.resolvers.test.ts
+++ b/server/tests/collab.resolvers.test.ts
@@ -1,0 +1,14 @@
+import { graphql } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { collabTypeDefs } from '../src/graphql/schema.collab.js';
+import collabResolvers from '../src/graphql/resolvers.collab.js';
+
+describe('collab resolvers', () => {
+  it('creates a branch', async () => {
+    const schema = makeExecutableSchema({ typeDefs: collabTypeDefs, resolvers: collabResolvers });
+    const mutation = `mutation { createBranch(name: \"test\"){ id name } }`;
+    const result = await graphql({ schema, source: mutation });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.createBranch.name).toBe('test');
+  });
+});

--- a/services/collab/README.md
+++ b/services/collab/README.md
@@ -1,0 +1,7 @@
+# Collaboration Service
+
+Real-time collaboration gateway using Socket.IO. Handles operational transform
+sync and presence broadcast for IntelGraph.
+
+This is a minimal placeholder implementation. A server is exposed via
+`createCollabServer` for integration tests and future expansion.

--- a/services/collab/src/index.ts
+++ b/services/collab/src/index.ts
@@ -1,0 +1,29 @@
+import http from 'http';
+import { Server } from 'socket.io';
+
+export interface CollabServer {
+  io: Server;
+  httpServer: http.Server;
+}
+
+/**
+ * createCollabServer sets up a minimal Socket.IO server that relays
+ * operational events between connected clients. Clients join a room for a
+ * specific branch and broadcast changes to peers.
+ */
+export function createCollabServer(): CollabServer {
+  const httpServer = http.createServer();
+  const io = new Server(httpServer, { path: '/collab' });
+
+  io.on('connection', socket => {
+    socket.on('branch:join', branchId => {
+      socket.join(`branch:${branchId}`);
+    });
+
+    socket.on('op', (branchId, op) => {
+      socket.to(`branch:${branchId}`).emit('op', op);
+    });
+  });
+
+  return { io, httpServer };
+}


### PR DESCRIPTION
## Summary
- stub collaboration service with Socket.IO relay
- add GraphQL types/resolvers for branches and commits
- add presence avatar component and tests

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm run format` *(fails: prettier not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac4dee0208333826506e9a037fa99