### PR TITLE
feat: add governance middleware and route stubs

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,6 +12,7 @@ import monitoringRouter from "./routes/monitoring.js";
 import aiRouter from "./routes/ai.js";
 import { register } from "./monitoring/metrics.js";
 import rbacRouter from "./routes/rbacRoutes.js";
+import governanceRouter from "./routes/governance.ts";
 import { typeDefs } from "./graphql/schema.js";
 import resolvers from "./graphql/resolvers/index.js";
 import { getContext } from "./lib/auth.js";
@@ -42,6 +43,7 @@ export const createApp = async () => {
   app.use("/monitoring", monitoringRouter);
   app.use("/api/ai", aiRouter);
   app.use("/rbac", rbacRouter);
+  app.use("/", governanceRouter);
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", register.contentType);
     res.end(await register.metrics());

--- a/server/src/middleware/governance.ts
+++ b/server/src/middleware/governance.ts
@@ -1,0 +1,45 @@
+import { Request, Response, NextFunction } from "express";
+
+// Extend Express Request to include tenantId
+declare global {
+  namespace Express {
+    interface Request {
+      tenantId?: string;
+    }
+  }
+}
+
+/**
+ * Ensures the tenant context from headers matches any tenant parameter on the request.
+ * This very small example is used only for tests and does not perform JWT validation.
+ */
+export function tenantEnforcer(req: Request, res: Response, next: NextFunction) {
+  const headerTenant = req.headers["x-tenant-id"] as string | undefined;
+  const resourceTenant =
+    (req.query.tenant as string | undefined) ||
+    (req.body && (req.body.tenant as string | undefined));
+
+  if (!headerTenant) {
+    return res.status(401).json({ error: "tenant header required" });
+  }
+  if (resourceTenant && resourceTenant !== headerTenant) {
+    return res.status(403).json({ error: "tenant forbidden" });
+  }
+
+  req.tenantId = headerTenant;
+  next();
+}
+
+/**
+ * Simple middleware that requires a reason for access. In a real system the reason
+ * would be stored with the audit record.
+ */
+export function reasonRequired(req: Request, res: Response, next: NextFunction) {
+  const reason = (req.headers["x-reason"] as string | undefined) ||
+    (req.body && (req.body.reason as string | undefined));
+  if (!reason) {
+    return res.status(400).json({ error: "reason required" });
+  }
+  next();
+}
+

--- a/server/src/routes/governance.ts
+++ b/server/src/routes/governance.ts
@@ -1,0 +1,48 @@
+import { Router } from "express";
+import { tenantEnforcer, reasonRequired } from "../middleware/governance";
+
+export interface AuditEvent {
+  id: number;
+  tenant: string;
+  action: string;
+}
+
+export const auditEvents: AuditEvent[] = [];
+export const logAudit = (event: AuditEvent) => auditEvents.push(event);
+
+const router = Router();
+
+// Auth placeholder
+router.post("/auth/login", (req, res) => {
+  const tenant = req.headers["x-tenant-id"] as string | undefined;
+  if (!tenant) {
+    return res.status(400).json({ error: "tenant header required" });
+  }
+  res.json({ token: "stub-token", tenant });
+});
+
+// Retrieve audit events for the tenant
+router.get("/audit/events", reasonRequired, tenantEnforcer, (req, res) => {
+  const events = auditEvents.filter((e) => e.tenant === req.tenantId);
+  res.json(events);
+});
+
+// Policy simulation: return events that would be blocked
+router.post("/policy/simulate", reasonRequired, (req, res) => {
+  const { blockedTenants = [] } = req.body as { blockedTenants?: string[] };
+  const blocked = auditEvents.filter((e) => blockedTenants.includes(e.tenant));
+  res.json({ blocked });
+});
+
+// K-anonymity/redaction helper
+router.post("/export/redact", reasonRequired, tenantEnforcer, (req, res) => {
+  const { data = [], k = 2 } = req.body as { data?: Array<{ value: string }>; k?: number };
+  const counts: Record<string, number> = {};
+  data.forEach((d) => {
+    counts[d.value] = (counts[d.value] || 0) + 1;
+  });
+  const redacted = data.map((d) => (counts[d.value] >= k ? d.value : "REDACTED"));
+  res.json({ data: redacted });
+});
+
+export default router;

--- a/server/tests/governance.test.ts
+++ b/server/tests/governance.test.ts
@@ -1,0 +1,47 @@
+import express from "express";
+import request from "supertest";
+import governanceRouter, { logAudit, auditEvents } from "../src/routes/governance.ts";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(governanceRouter);
+  return app;
+};
+
+describe("governance routes", () => {
+  beforeEach(() => {
+    auditEvents.length = 0;
+  });
+
+  it("forbids cross-tenant reads", async () => {
+    logAudit({ id: 1, tenant: "t1", action: "view" });
+    const app = buildApp();
+    const res = await request(app)
+      .get("/audit/events?tenant=t2")
+      .set("x-tenant-id", "t1")
+      .set("x-reason", "test");
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects access without reason", async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .get("/audit/events")
+      .set("x-tenant-id", "t1");
+    expect(res.status).toBe(400);
+  });
+
+  it("policy simulation returns blocked calls", async () => {
+    logAudit({ id: 1, tenant: "t1", action: "view" });
+    logAudit({ id: 2, tenant: "t2", action: "view" });
+    const app = buildApp();
+    const res = await request(app)
+      .post("/policy/simulate")
+      .set("x-reason", "sim")
+      .send({ blockedTenants: ["t1"] });
+    expect(res.status).toBe(200);
+    expect(res.body.blocked).toHaveLength(1);
+    expect(res.body.blocked[0].tenant).toBe("t1");
+  });
+});


### PR DESCRIPTION
## Summary
- add tenant and reason enforcement middleware
- stub governance router with auth, audit, policy simulation, and redaction endpoints
- register governance routes and add basic tests

## Testing
- `npm run lint server/src/middleware/governance.ts server/src/routes/governance.ts server/tests/governance.test.ts` *(fails: eslint not found)*
- `npm install` *(fails: canvas build error: missing pixman-1)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac3de27bc833396e6f2e9db58bebd