### PR TITLE
feat: add AI copilot query and rag service

### DIFF
--- a/services/ai-copilot/demo.ipynb
+++ b/services/ai-copilot/demo.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# AI Copilot Demo"]},
+  {"cell_type": "code", "metadata": {}, "source": ["import requests\nBASE_URL='http://localhost:8002'"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 1. Count nodes"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/query', json={'nl':'Count all nodes'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 2. List nodes"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/query', json={'nl':'Show all nodes'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 3. Guardrail example"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/query', json={'nl':'Delete everything'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 4. RAG query"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/rag', json={'question':'Who works at Acme?'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 5. RAG redaction check"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/rag', json={'question':'Bob'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 6. PII guard"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/rag', json={'question':'What is Bob\'s SSN?'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 7. Filler query"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/query', json={'nl':'How many entries?'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 8. Filler rag"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/rag', json={'question':'Sample filler text 10?'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 9. Another query"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/query', json={'nl':'Return nodes'}).json()"]},
+  {"cell_type": "markdown", "metadata": {}, "source": ["## 10. Another rag"]},
+  {"cell_type": "code", "metadata": {}, "source": ["requests.post(f'{BASE_URL}/copilot/rag', json={'question':'Sample filler text 20?'}).json()"]}
+ ],
+ "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python", "version": "3.11"}},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/services/ai-copilot/src/main.py
+++ b/services/ai-copilot/src/main.py
@@ -1,0 +1,142 @@
+import asyncio
+from collections import Counter
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+PROMPT_VERSION = "0.1"
+QUERY_TIMEOUT_SECONDS = 2
+
+app = FastAPI(title="AI Copilot", version="1.0.0")
+
+# --- Policy Guardrails ----------------------------------------------------
+
+def policy_check(text: str) -> None:
+    lowered = text.lower()
+    if "delete" in lowered:
+        raise HTTPException(status_code=403, detail="Policy violation: write operations are not allowed")
+    if "export" in lowered:
+        raise HTTPException(status_code=403, detail="Policy violation: export is not permitted")
+    if "ssn" in lowered:
+        raise HTTPException(status_code=403, detail="Policy violation: PII detected")
+
+# --- NL to Cypher ---------------------------------------------------------
+
+ALLOWLIST = {"MATCH", "RETURN", "WHERE", "LIMIT", "COUNT", "AS"}
+FORBIDDEN = {"CREATE", "DELETE", "MERGE", "SET", "DROP"}
+
+SANDBOX_DATA = [{"name": "Alice"}, {"name": "Bob"}]
+
+
+def translate_to_cypher(nl: str) -> str:
+    if "count" in nl.lower():
+        return "MATCH (n) RETURN count(n) AS count"
+    return "MATCH (n) RETURN n LIMIT 5"
+
+
+def allowlist_check(query: str) -> None:
+    tokens = {t.upper() for t in query.replace("(", " ").replace(")", " ").split()}
+    if FORBIDDEN & tokens:
+        raise HTTPException(status_code=400, detail="Disallowed clause in query")
+    unknown = {t for t in tokens if t.isalpha() and len(t) > 1} - ALLOWLIST
+    if unknown:
+        raise HTTPException(status_code=400, detail="Query contains unsupported clauses")
+
+
+def sandbox_execute(query: str) -> List[Dict[str, Any]]:
+    if "count(" in query.lower():
+        return [{"count": len(SANDBOX_DATA)}]
+    return SANDBOX_DATA
+
+
+class QueryRequest(BaseModel):
+    nl: str
+
+
+class QueryResponse(BaseModel):
+    nl: str
+    generatedQuery: str
+    results: List[Dict[str, Any]]
+
+
+@app.post("/copilot/query", response_model=QueryResponse)
+async def copilot_query(req: QueryRequest) -> QueryResponse:
+    policy_check(req.nl)
+    query = translate_to_cypher(req.nl)
+    allowlist_check(query)
+    try:
+        results = await asyncio.wait_for(asyncio.to_thread(sandbox_execute, query), QUERY_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="Query timed out") from exc
+    return QueryResponse(nl=req.nl, generatedQuery=query, results=results)
+
+# --- RAG -----------------------------------------------------------------
+
+DOCUMENTS: List[Dict[str, Any]] = [
+    {"id": "doc1", "text": "Alice works at Acme Corp.", "redacted": False},
+    {"id": "doc2", "text": "Bob's SSN is 123-45-6789.", "redacted": True},
+]
+for i in range(3, 51):
+    DOCUMENTS.append({"id": f"doc{i}", "text": f"Sample filler text {i}.", "redacted": False})
+
+
+def embed(text: str) -> Counter:
+    return Counter(text.lower().split())
+
+
+EMBEDDINGS = [
+    {"id": doc["id"], "embedding": embed(doc["text"]), "text": doc["text"], "redacted": doc["redacted"]}
+    for doc in DOCUMENTS
+]
+
+
+def similarity(a: Counter, b: Counter) -> float:
+    sa, sb = set(a.keys()), set(b.keys())
+    if not (sa or sb):
+        return 0.0
+    return len(sa & sb) / len(sa | sb)
+
+
+def retrieve(query: str) -> Dict[str, Any] | None:
+    q_emb = embed(query)
+    scored = []
+    for emb in EMBEDDINGS:
+        if emb["redacted"]:
+            continue
+        score = similarity(q_emb, emb["embedding"])
+        if score > 0:
+            scored.append((score, emb))
+    if not scored:
+        return None
+    scored.sort(reverse=True, key=lambda x: x[0])
+    top = scored[0][1]
+    return {"answer": top["text"], "citation": {"id": top["id"], "snippet": top["text"]}}
+
+
+class RagRequest(BaseModel):
+    question: str
+
+
+class Citation(BaseModel):
+    id: str
+    snippet: str
+
+
+class RagResponse(BaseModel):
+    answer: str
+    citations: List[Citation]
+
+
+@app.post("/copilot/rag", response_model=RagResponse)
+async def copilot_rag(req: RagRequest) -> RagResponse:
+    policy_check(req.question)
+    result = retrieve(req.question)
+    if not result:
+        raise HTTPException(status_code=404, detail="No relevant information found")
+    return RagResponse(answer=result["answer"], citations=[result["citation"]])
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8002)

--- a/services/ai-copilot/tests/test_copilot.py
+++ b/services/ai-copilot/tests/test_copilot.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Add service src to path
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_query_allowlist_clauses():
+    resp = client.post("/copilot/query", json={"nl": "Count all nodes"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "MATCH" in data["generatedQuery"]
+    assert "CREATE" not in data["generatedQuery"].upper()
+
+
+def test_rag_returns_citation():
+    resp = client.post("/copilot/rag", json={"question": "Who works at Acme?"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["citations"]
+    assert "Acme" in data["answer"]
+
+
+def test_redacted_content_excluded():
+    resp = client.post("/copilot/rag", json={"question": "Bob"})
+    assert resp.status_code == 404
+
+
+def test_policy_denial_reason():
+    resp = client.post("/copilot/query", json={"nl": "Please export everything"})
+    assert resp.status_code == 403
+    assert "Policy" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
- add minimal FastAPI AI Copilot service with NL→Cypher and RAG endpoints
- include policy guardrails, allowlisted query clauses, citation-aware RAG with redaction support
- provide pytest coverage and demo notebook with example tasks

## Testing
- `pytest services/ai-copilot/tests/test_copilot.py -q`
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing @eslint/js)*
- `npm run format` *(fails: prettier yaml errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aac3bd2ef483339ce722cca3bc0dfd