### PR TITLE
feat: add manifest verification CLI

### DIFF
--- a/prov-ledger/app/manifest.py
+++ b/prov-ledger/app/manifest.py
@@ -1,0 +1,65 @@
+import json
+import pathlib
+from typing import Iterable, Dict, Any
+
+from .hashing import sha256_digest
+
+
+def generate_manifest(paths: Iterable[pathlib.Path]) -> Dict[str, Any]:
+    files = []
+    for path in paths:
+        with path.open('rb') as fh:
+            digest, size = sha256_digest(fh)
+        files.append({"path": str(path), "sha256": digest, "size": size})
+    return {"files": files}
+
+
+def save_manifest(manifest: Dict[str, Any], dest: pathlib.Path) -> None:
+    dest.write_text(json.dumps(manifest, indent=2))
+
+
+def load_manifest(src: pathlib.Path) -> Dict[str, Any]:
+    return json.loads(src.read_text())
+
+
+def verify_manifest(root: pathlib.Path, manifest: Dict[str, Any]) -> bool:
+    for info in manifest.get("files", []):
+        path = root / info["path"]
+        if not path.exists():
+            return False
+        with path.open('rb') as fh:
+            digest, _ = sha256_digest(fh)
+        if digest != info["sha256"]:
+            return False
+    return True
+
+
+def _cli() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Manifest utilities")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    gen = sub.add_parser("generate")
+    gen.add_argument("manifest")
+    gen.add_argument("files", nargs="+")
+
+    ver = sub.add_parser("verify")
+    ver.add_argument("manifest")
+    ver.add_argument("root", nargs="?", default=".")
+
+    args = parser.parse_args()
+    if args.cmd == "generate":
+        paths = [pathlib.Path(p) for p in args.files]
+        manifest = generate_manifest(paths)
+        save_manifest(manifest, pathlib.Path(args.manifest))
+        return 0
+    if args.cmd == "verify":
+        manifest = load_manifest(pathlib.Path(args.manifest))
+        ok = verify_manifest(pathlib.Path(args.root), manifest)
+        return 0 if ok else 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/prov-ledger/docs/example_manifest.json
+++ b/prov-ledger/docs/example_manifest.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    {
+      "path": "example.txt",
+      "sha256": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+      "size": 5
+    }
+  ]
+}

--- a/prov-ledger/tests/test_manifest_cli.py
+++ b/prov-ledger/tests/test_manifest_cli.py
@@ -1,0 +1,31 @@
+import pathlib
+import subprocess
+import sys
+import os
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app.manifest import generate_manifest, save_manifest, load_manifest, verify_manifest
+
+
+def test_manifest_roundtrip(tmp_path):
+    f = tmp_path / "data.txt"
+    f.write_text("hello")
+    manifest = generate_manifest([f])
+    save_manifest(manifest, tmp_path / "manifest.json")
+    loaded = load_manifest(tmp_path / "manifest.json")
+    assert verify_manifest(tmp_path, loaded)
+    f.write_text("tampered")
+    assert not verify_manifest(tmp_path, loaded)
+
+
+def test_manifest_cli(tmp_path):
+    f = tmp_path / "data.txt"
+    f.write_text("hello")
+    m = tmp_path / "manifest.json"
+    env = os.environ | {"PYTHONPATH": str(pathlib.Path(__file__).resolve().parents[1])}
+    subprocess.run([sys.executable, "-m", "app.manifest", "generate", str(m), str(f)], check=True, env=env)
+    result = subprocess.run([sys.executable, "-m", "app.manifest", "verify", str(m), str(tmp_path)], env=env)
+    assert result.returncode == 0
+    f.write_text("corrupt")
+    result2 = subprocess.run([sys.executable, "-m", "app.manifest", "verify", str(m), str(tmp_path)], env=env)
+    assert result2.returncode != 0


### PR DESCRIPTION
## Summary
- add SHA-256 manifest generation and verification utilities with CLI
- provide sample manifest document
- test round-trip and tampering detection

## Testing
- `npm test` *(fails: jest not found)*
- `pytest prov-ledger/tests/test_manifest_cli.py::test_manifest_roundtrip -q`
- `pytest prov-ledger/tests/test_manifest_cli.py::test_manifest_cli -q`
- `pytest prov-ledger/tests/test_signatures_hashing.py::test_hash_and_signature -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac3b9af2c833390a6a46096b4254a