### PR TITLE
feat: scaffold hypothesis workbench

### DIFF
--- a/client/src/features/hypotheses/components/HypothesisWorkbench.tsx
+++ b/client/src/features/hypotheses/components/HypothesisWorkbench.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createHypothesisStore } from '../store';
+
+const store = createHypothesisStore();
+
+export function HypothesisWorkbench() {
+  return (
+    <div>
+      <h2>Hypotheses</h2>
+      <ul>
+        {store.hypotheses.map((h) => (
+          <li key={h.id}>
+            {h.text} – {Math.round(h.posterior * 100)}%
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default HypothesisWorkbench;

--- a/client/src/features/hypotheses/store.test.ts
+++ b/client/src/features/hypotheses/store.test.ts
@@ -1,0 +1,22 @@
+import { createHypothesisStore } from './store';
+
+describe('hypothesis store', () => {
+  it('updates with evidence weight', () => {
+    const store = createHypothesisStore();
+    store.addHypothesis({
+      id: 'h1',
+      text: 'test',
+      prior: 0.5,
+      evidence: [],
+      residualUnknowns: [],
+      dissent: [],
+    });
+    store.addEvidence('h1', {
+      id: 'e1',
+      description: 'supporting',
+      cited: true,
+      weight: 3,
+    });
+    expect(store.hypotheses[0].posterior).toBeCloseTo(0.75, 5);
+  });
+});

--- a/client/src/features/hypotheses/store.ts
+++ b/client/src/features/hypotheses/store.ts
@@ -1,0 +1,45 @@
+export interface Evidence {
+  id: string;
+  description: string;
+  cited: boolean;
+  weight: number;
+}
+
+export interface Hypothesis {
+  id: string;
+  text: string;
+  prior: number;
+  evidence: Evidence[];
+  posterior: number;
+  residualUnknowns: string[];
+  dissent: string[];
+}
+
+export interface HypothesisStore {
+  hypotheses: Hypothesis[];
+  addHypothesis: (h: Omit<Hypothesis, 'posterior'>) => void;
+  addEvidence: (id: string, e: Evidence) => void;
+  addDissent: (id: string, note: string) => void;
+}
+
+export function createHypothesisStore(): HypothesisStore {
+  const store: HypothesisStore = {
+    hypotheses: [],
+    addHypothesis(h) {
+      store.hypotheses.push({ ...h, posterior: h.prior });
+    },
+    addEvidence(id, e) {
+      const h = store.hypotheses.find((x) => x.id === id);
+      if (!h) return;
+      h.evidence.push(e);
+      const odds = h.posterior / (1 - h.posterior);
+      const updated = odds * e.weight;
+      h.posterior = updated / (1 + updated);
+    },
+    addDissent(id, note) {
+      const h = store.hypotheses.find((x) => x.id === id);
+      if (h) h.dissent.push(note);
+    },
+  };
+  return store;
+}

--- a/client/src/features/reports/NarrativeBuilder.test.tsx
+++ b/client/src/features/reports/NarrativeBuilder.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NarrativeBuilder } from './NarrativeBuilder';
+import { Hypothesis } from '../hypotheses/store';
+
+describe('NarrativeBuilder', () => {
+  it('blocks publish when citations missing', () => {
+    const h: Hypothesis = {
+      id: 'h1',
+      text: 'claim',
+      prior: 0.5,
+      posterior: 0.5,
+      evidence: [{ id: 'e1', description: 'uncited', cited: false, weight: 1 }],
+      residualUnknowns: [],
+      dissent: [],
+    };
+    render(<NarrativeBuilder hypotheses={[h]} />);
+    expect(screen.getByText(/Missing citations/)).toBeInTheDocument();
+  });
+});

--- a/client/src/features/reports/NarrativeBuilder.tsx
+++ b/client/src/features/reports/NarrativeBuilder.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Hypothesis } from '../hypotheses/store';
+
+interface Props {
+  hypotheses: Hypothesis[];
+}
+
+export function NarrativeBuilder({ hypotheses }: Props) {
+  const uncited = hypotheses.flatMap((h) =>
+    h.evidence.filter((e) => !e.cited).map((e) => `${h.id}:${e.id}`),
+  );
+  if (uncited.length > 0) {
+    return <div>Missing citations: {uncited.join(', ')}</div>;
+  }
+  return (
+    <div>
+      <h2>Report</h2>
+      {hypotheses.map((h) => (
+        <p key={h.id}>
+          {h.text} ({Math.round(h.posterior * 100)}%)
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export default NarrativeBuilder;

--- a/server/src/hypotheses/index.ts
+++ b/server/src/hypotheses/index.ts
@@ -1,0 +1,41 @@
+export interface Evidence {
+  id: string;
+  description: string;
+  likelihoodGivenHypothesis: number; // P(E|H)
+  likelihoodGivenAlternative: number; // P(E|~H)
+  cited: boolean;
+}
+
+export interface Hypothesis {
+  id: string;
+  statement: string;
+  prior: number; // P(H)
+  evidence: Evidence[];
+  posterior: number; // updated probability
+  residualUnknowns: string[];
+  dissent: string[];
+}
+
+export function bayesianUpdate(prior: number, evidence: Evidence[]): number {
+  let odds = prior / (1 - prior);
+  for (const e of evidence) {
+    const weight = e.likelihoodGivenHypothesis / e.likelihoodGivenAlternative;
+    odds *= weight;
+  }
+  return odds / (1 + odds);
+}
+
+export function applyEvidence(h: Hypothesis, e: Evidence): Hypothesis {
+  const evidence = [...h.evidence, e];
+  const posterior = bayesianUpdate(h.prior, evidence);
+  return { ...h, evidence, posterior };
+}
+
+export function addDissent(h: Hypothesis, note: string): Hypothesis {
+  return { ...h, dissent: [...h.dissent, note] };
+}
+
+export function missingEvidencePrompts(h: Hypothesis): string[] {
+  const uncited = h.evidence.filter((e) => !e.cited);
+  return uncited.map((e) => `Evidence ${e.id} lacks citation`);
+}

--- a/server/tests/hypotheses.test.ts
+++ b/server/tests/hypotheses.test.ts
@@ -1,0 +1,30 @@
+import { bayesianUpdate, applyEvidence, addDissent, Hypothesis, Evidence } from '../src/hypotheses';
+
+describe('hypothesis updates', () => {
+  const base: Hypothesis = {
+    id: 'h1',
+    statement: 'Test hypothesis',
+    prior: 0.2,
+    evidence: [],
+    posterior: 0.2,
+    residualUnknowns: [],
+    dissent: [],
+  };
+
+  it('updates probability with evidence', () => {
+    const e: Evidence = {
+      id: 'e1',
+      description: 'supporting',
+      likelihoodGivenHypothesis: 0.9,
+      likelihoodGivenAlternative: 0.1,
+      cited: true,
+    };
+    const updated = applyEvidence(base, e);
+    expect(updated.posterior).toBeCloseTo(0.6923, 4);
+  });
+
+  it('records dissent', () => {
+    const dissenting = addDissent(base, 'alternative explanation');
+    expect(dissenting.dissent).toContain('alternative explanation');
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold hypothesis module with Bayes updates and dissent tracking
- add client hypothesis store and narrative builder that blocks uncited claims
- basic tests for update math and citation checks

## Testing
- `cd server && npm test tests/hypotheses.test.ts` *(fails: jest: not found)*
- `cd client && npm test src/features/hypotheses/store.test.ts` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: YAML parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68aac310ca30833390b00a43aff1cbfe