### PR TITLE
feat: add chain of custody utilities

### DIFF
--- a/server/src/cases/chain-of-custody.ts
+++ b/server/src/cases/chain-of-custody.ts
@@ -1,0 +1,54 @@
+import { createHash, sign, verify, KeyObject } from 'crypto';
+
+export interface CustodyEvent {
+  caseId: string;
+  attachmentId?: string;
+  actorId: string;
+  action: string;
+  at?: Date;
+  payload?: Record<string, any>;
+}
+
+/**
+ * Append a custody event to the chain with an Ed25519 signature.
+ * Returns the computed event hash which should be used as the next prevHash.
+ */
+export async function writeCoC(
+  db: any,
+  event: CustodyEvent,
+  prevHash: string,
+  privateKey: KeyObject,
+): Promise<string> {
+  const payload = JSON.stringify(event);
+  const eventHash = createHash('sha256')
+    .update(prevHash + payload)
+    .digest('hex');
+  const signature = sign(null, Buffer.from(eventHash), privateKey).toString('base64');
+  await db.custodyEvent.create({ data: { ...event, prevHash, eventHash, signature } });
+  return eventHash;
+}
+
+/**
+ * Verify a chain of custody events. Returns true if the chain is intact and
+ * signatures are valid.
+ */
+export function verifyChain(events: any[], publicKey: KeyObject): boolean {
+  let prevHash = 'GENESIS';
+  for (const e of events) {
+    const { caseId, attachmentId, actorId, action, at, payload } = e;
+    const payloadStr = JSON.stringify({ caseId, attachmentId, actorId, action, at, payload });
+    const hash = createHash('sha256')
+      .update(prevHash + payloadStr)
+      .digest('hex');
+    if (hash !== e.eventHash) return false;
+    const ok = verify(
+      null,
+      Buffer.from(e.eventHash),
+      publicKey,
+      Buffer.from(e.signature, 'base64'),
+    );
+    if (!ok) return false;
+    prevHash = e.eventHash;
+  }
+  return true;
+}

--- a/server/src/cases/legal-hold-guard.ts
+++ b/server/src/cases/legal-hold-guard.ts
@@ -1,0 +1,7 @@
+export const denyWhenHold = async (req: any, reply: any) => {
+  const { id } = req.params as any;
+  const c = await req.db.case.findUnique({ where: { id } });
+  if (c?.legalHold) {
+    return reply.code(423).send({ error: 'Legal hold active: operation locked' });
+  }
+};

--- a/server/tests/chain-of-custody.test.ts
+++ b/server/tests/chain-of-custody.test.ts
@@ -1,0 +1,38 @@
+import { generateKeyPairSync, KeyObject, verify } from 'crypto';
+import { writeCoC, verifyChain } from '../src/cases/chain-of-custody';
+
+describe('chain of custody', () => {
+  it('builds a hash-linked signed chain', async () => {
+    const events: any[] = [];
+    const db = {
+      custodyEvent: {
+        create: ({ data }: any) => {
+          events.push(data);
+        },
+      },
+    };
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+    let prevHash = 'GENESIS';
+    prevHash = await writeCoC(
+      db,
+      { caseId: 'c1', actorId: 'u1', action: 'CREATE', payload: { device: 'a' } },
+      prevHash,
+      privateKey,
+    );
+    prevHash = await writeCoC(
+      db,
+      { caseId: 'c1', actorId: 'u2', action: 'TRANSFER', payload: { reason: 'review' } },
+      prevHash,
+      privateKey,
+    );
+    expect(events[1].prevHash).toBe(events[0].eventHash);
+    const firstValid = verify(
+      null,
+      Buffer.from(events[0].eventHash),
+      publicKey,
+      Buffer.from(events[0].signature, 'base64'),
+    );
+    expect(firstValid).toBe(true);
+    expect(verifyChain(events, publicKey)).toBe(true);
+  });
+});

--- a/server/tests/legal-hold-guard.test.ts
+++ b/server/tests/legal-hold-guard.test.ts
@@ -1,0 +1,34 @@
+import { denyWhenHold } from '../src/cases/legal-hold-guard';
+
+describe('legal hold guard', () => {
+  it('denies when case has legal hold', async () => {
+    const req = {
+      params: { id: 'c1' },
+      db: { case: { findUnique: async () => ({ legalHold: true }) } },
+    } as any;
+    const reply: any = {
+      status: 0,
+      body: null,
+      code(code: number) {
+        this.status = code;
+        return this;
+      },
+      send(payload: any) {
+        this.body = payload;
+      },
+    };
+    await denyWhenHold(req, reply);
+    expect(reply.status).toBe(423);
+    expect(reply.body).toEqual({ error: 'Legal hold active: operation locked' });
+  });
+
+  it('passes through when no hold', async () => {
+    const req = {
+      params: { id: 'c1' },
+      db: { case: { findUnique: async () => ({ legalHold: false }) } },
+    } as any;
+    const reply = { code: jest.fn().mockReturnThis(), send: jest.fn() } as any;
+    await denyWhenHold(req, reply);
+    expect(reply.code).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- implement chain-of-custody writer and verifier using SHA-256 and Ed25519 signatures
- add legal hold guard to block operations when a case is under legal hold
- include jest tests for custody chain and legal hold guard

## Testing
- `npm install` *(fails: Missing pixman-1 and unsupported Node version)*
- `npm test --workspace=server server/tests/chain-of-custody.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac6eda45c83339ddc2918ce74a2ab