### PR TITLE
feat: scaffold brief studio modules

### DIFF
--- a/cli/ig-brief/index.js
+++ b/cli/ig-brief/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('ig-brief CLI placeholder');

--- a/cli/ig-brief/package.json
+++ b/cli/ig-brief/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ig-brief",
+  "version": "0.0.1",
+  "bin": {
+    "ig-brief": "index.js"
+  }
+}

--- a/client/src/features/briefstudio/BriefStudio.tsx
+++ b/client/src/features/briefstudio/BriefStudio.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+/**
+ * BriefStudio is a placeholder component for composing briefs with citations and exhibits.
+ * Future iterations will integrate TipTap editor, citation picker, and export UI.
+ */
+const BriefStudio: React.FC = () => {
+  return <div data-testid="brief-studio">Brief Studio coming soon...</div>;
+};
+
+export default BriefStudio;

--- a/client/src/features/briefstudio/index.ts
+++ b/client/src/features/briefstudio/index.ts
@@ -1,0 +1,1 @@
+export { default as BriefStudio } from './BriefStudio';

--- a/server/src/graphql/resolvers/brief.ts
+++ b/server/src/graphql/resolvers/brief.ts
@@ -1,0 +1,8 @@
+const briefResolvers = {
+  Query: {
+    brief: (_: unknown, { id }: { id: string }) => ({ id, title: 'Draft' }),
+  },
+  Mutation: {},
+};
+
+export default briefResolvers;

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -7,6 +7,7 @@ import relationshipResolvers from './relationship';
 import userResolvers from './user';
 import investigationResolvers from './investigation';
 import { WargameResolver } from '../../resolvers/WargameResolver.js'; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
+import briefResolvers from './brief';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -19,31 +20,34 @@ const resolvers = {
   Query: {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
-    
+
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Query,
     ...userResolvers.Query,
     ...investigationResolvers.Query,
-    
+    ...briefResolvers.Query,
+
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     getCrisisTelemetry: wargameResolver.getCrisisTelemetry.bind(wargameResolver),
     getAdversaryIntentEstimates: wargameResolver.getAdversaryIntentEstimates.bind(wargameResolver),
     getNarrativeHeatmapData: wargameResolver.getNarrativeHeatmapData.bind(wargameResolver),
-    getStrategicResponsePlaybooks: wargameResolver.getStrategicResponsePlaybooks.bind(wargameResolver),
+    getStrategicResponsePlaybooks:
+      wargameResolver.getStrategicResponsePlaybooks.bind(wargameResolver),
     getCrisisScenario: wargameResolver.getCrisisScenario.bind(wargameResolver),
     getAllCrisisScenarios: wargameResolver.getAllCrisisScenarios.bind(wargameResolver),
   },
-  
+
   Mutation: {
     // Production core resolvers
     ...coreResolvers.Mutation,
-    
+
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,
     ...relationshipResolvers.Mutation,
     ...userResolvers.Mutation,
     ...investigationResolvers.Mutation,
-    
+    ...briefResolvers.Mutation,
+
     // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
     runWarGameSimulation: wargameResolver.runWarGameSimulation.bind(wargameResolver),
     updateCrisisScenario: wargameResolver.updateCrisisScenario.bind(wargameResolver),
@@ -57,4 +61,3 @@ const resolvers = {
 };
 
 export default resolvers;
-

--- a/server/src/graphql/typeDefs/brief.gql
+++ b/server/src/graphql/typeDefs/brief.gql
@@ -1,0 +1,8 @@
+type BriefDocument {
+  id: ID!
+  title: String
+}
+
+extend type Query {
+  brief(id: ID!): BriefDocument
+}

--- a/services/brief/README.md
+++ b/services/brief/README.md
@@ -1,0 +1,5 @@
+# Brief Service
+
+This service will handle templating, citation resolution, preflight checks, and rendering of briefs to HTML and PDF formats.
+
+_Currently a placeholder._

--- a/services/brief/src/index.ts
+++ b/services/brief/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Placeholder brief service.
+ * Provides stub rendering for brief documents.
+ */
+export function renderBrief() {
+  return 'TODO: implement rendering pipeline';
+}


### PR DESCRIPTION
## Summary
- scaffold client brief studio component
- add placeholder brief service and CLI
- add basic GraphQL types and resolvers for briefs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: YAML syntax errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5e9ff148333aa24a63dc252f073