### PR TITLE
feat: scaffold federated services

### DIFF
--- a/apps/web/src/features/federated-search/FederatedSearch.tsx
+++ b/apps/web/src/features/federated-search/FederatedSearch.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+import $ from 'jquery';
+
+/**
+ * FederatedSearch renders a placeholder matrix and demonstrates how jQuery
+ * can be combined with React refs for high-frequency interactions.
+ */
+export function FederatedSearch() {
+  const matrixRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = matrixRef.current ? $(matrixRef.current) : null;
+    if (!el) return;
+    const handler = (e: JQuery.MouseMoveEvent) => {
+      el.text(`x:${e.offsetX}, y:${e.offsetY}`);
+    };
+    el.on('mousemove', handler);
+    return () => {
+      el.off('mousemove', handler);
+    };
+  }, []);
+
+  return <div ref={matrixRef}>Federated search placeholder</div>;
+}

--- a/cli/ig-dp/index.js
+++ b/cli/ig-dp/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('ig-dp placeholder CLI');

--- a/cli/ig-federate/index.js
+++ b/cli/ig-federate/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('ig-federate placeholder CLI');

--- a/cli/ig-psi/index.js
+++ b/cli/ig-psi/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('ig-psi placeholder CLI');

--- a/server/federation.plan.test.ts
+++ b/server/federation.plan.test.ts
@@ -1,0 +1,9 @@
+import { planFederatedQuery } from '../services/federation/index.js';
+
+describe('planFederatedQuery', () => {
+  it('creates subqueries for each enclave', () => {
+    const plan = planFederatedQuery('MATCH (n) RETURN n', ['alpha', 'beta']);
+    expect(plan.subqueries.alpha).toBe('MATCH (n) RETURN n');
+    expect(plan.subqueries.beta).toBe('MATCH (n) RETURN n');
+  });
+});

--- a/server/graphql/federation/index.ts
+++ b/server/graphql/federation/index.ts
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag';
+
+export const federationTypeDefs = gql`
+  type FederatedQuery {
+    query: String!
+  }
+
+  type Query {
+    _federationInfo: String!
+  }
+`;
+
+export const federationResolvers = {
+  Query: {
+    _federationInfo: () => 'federation placeholder',
+  },
+};

--- a/services/dp/__init__.py
+++ b/services/dp/__init__.py
@@ -1,0 +1,5 @@
+"""Differential Privacy (DP) service placeholders."""
+
+from .noise import add_laplace_noise
+
+__all__ = ["add_laplace_noise"]

--- a/services/dp/noise.py
+++ b/services/dp/noise.py
@@ -1,0 +1,18 @@
+"""Simple noise calibration utilities for DP aggregates."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Iterable
+from typing import List
+
+
+def add_laplace_noise(values: Iterable[float], epsilon: float) -> List[float]:
+    """Return values perturbed with Laplace-like noise.
+
+    This placeholder uses Gaussian noise scaled by ``epsilon`` and is not a
+    secure DP mechanism. It exists solely to facilitate early integration
+    tests.
+    """
+    scale = 1.0 / max(epsilon, 1e-9)
+    return [v + random.gauss(0, scale) for v in values]

--- a/services/federation/index.ts
+++ b/services/federation/index.ts
@@ -1,0 +1,19 @@
+export interface FederationPlan {
+  enclaves: string[];
+  subqueries: Record<string, string>;
+}
+
+/**
+ * planFederatedQuery creates a simple plan that maps each enclave
+ * to the provided query. This is a placeholder for the future planner
+ * that will push down policies and compile subqueries per enclave.
+ */
+export function planFederatedQuery(query: string, enclaves: string[]): FederationPlan {
+  return {
+    enclaves,
+    subqueries: enclaves.reduce<Record<string, string>>((acc, id) => {
+      acc[id] = query;
+      return acc;
+    }, {}),
+  };
+}

--- a/services/psi/__init__.py
+++ b/services/psi/__init__.py
@@ -1,0 +1,5 @@
+"""Private Set Intersection (PSI) service placeholders."""
+
+from .oprf import create_tokens
+
+__all__ = ["create_tokens"]

--- a/services/psi/oprf.py
+++ b/services/psi/oprf.py
@@ -1,0 +1,13 @@
+"""OPRF tokenization helpers used for PSI joins."""
+
+from collections.abc import Iterable
+from typing import List
+
+
+def create_tokens(ids: Iterable[str]) -> List[str]:
+    """Return deterministic placeholder tokens for identifiers.
+
+    This stub does not implement real cryptography but illustrates the
+    interface expected by the federation gateway.
+    """
+    return [f"token:{value}" for value in ids]


### PR DESCRIPTION
## Summary
- scaffold federation planner to split queries across enclaves
- add PSI token and DP noise stubs for privacy-preserving ops
- expose federation types/resolvers and basic federated search UI

## Testing
- `npm run lint` *(fails: parsing error in existing files)*
- `npm run format` *(fails: prettier syntax error in YAML)*
- `npm test` *(fails: multiple existing tests and configuration issues)*

------
https://chatgpt.com/codex/tasks/task_e_68aac6ffa9b48333adc84eab8a6cc992