### PR TITLE
feat: scaffold bitemporal time services

### DIFF
--- a/docs/bitemporal-time-machine.md
+++ b/docs/bitemporal-time-machine.md
@@ -1,0 +1,65 @@
+# Bitemporal Graph Time Machine
+
+This design introduces bitemporal graph storage with `AS OF` queries, `DIFF` views and a What‑If simulator for forecasting and counterfactual analysis.
+
+## Bitemporal Model
+
+- Nodes, edges and properties carry `valid_from`, `valid_to`, `tx_from` and `tx_to` timestamps.
+- Retroactive and corrective updates append new intervals and close previous ones without losing history.
+- Postgres maintains a `temporal_index` to prune candidates before executing Neo4j predicates.
+
+## AS OF Queries
+
+- `graphAsOf` reconstructs the graph at a given valid or transaction time.
+- A planner combines Postgres temporal filtering with Neo4j `valid_from`/`valid_to` predicates.
+- Results are cached as materialised snapshots keyed by `(case, branch, instant, filter)` with TTL and invalidation on overlapping writes.
+
+## DIFF Views
+
+- `graphDiff` compares two instants or windows and classifies entities as `added`, `removed` or `changed`.
+- Explanations trace which deltas triggered each change.
+
+## Snapshot Cache
+
+- Redis stores projection subgraphs; keys use the pattern `case@branch|filter|instant`.
+- LRU + TTL eviction; a lease protocol prevents thundering herds on cold caches.
+
+## What-If Simulator
+
+- The simulator applies a hypothetical change‑set in isolation and runs propagation models:
+  - reachability BFS
+  - personalised PageRank‑Δ
+  - SIR contagion
+  - shortest‑path Δ
+  - simple risk cascade
+- Deterministic seeds ensure identical inputs yield identical outputs.
+
+## Auditability & Policy
+
+- Each AS OF/DIFF/SIM run records inputs, seeds, policies and code version for replayability.
+- OPA policies filter or redact sensitive entities by time; blocked operations return human‑readable reasons.
+
+## Tech Components
+
+- **Temporal Service (`services/time`)** – temporal indexer, snapshotter, diff engine, compactor.
+- **Simulator Service (`services/sim`)** – scenario runner built on NetworkX.
+- **GraphQL (`server/graphql/time`)** – temporal types, queries, mutations and subscriptions.
+- **Web UI (`apps/web/src/features/time-machine`)** – React + MUI time scrubber, compare mode and scenario builder.
+- **CLI (`cli/ig-time`, `cli/ig-sim`)** – snapshot, diff, simulate and export tools.
+
+## Performance Targets
+
+- AS OF p95 ≤ 1.2s (cached) / ≤ 4.5s (cold) on 50M edges.
+- DIFF p95 ≤ 6s on 10M‑edge windows.
+- Reachability on a 1M‑node subgraph p95 ≤ 8s; PPR‑Δ ≤ 12s for 100k changed edges.
+
+## Testing & Determinism
+
+- Unit: interval arithmetic, predicate builders, diff classification, compaction rules, simulator steps.
+- Property‑based: randomised delta streams with non‑overlap invariants.
+- Integration: AS OF → DIFF → SIM pipeline on 50M‑edge synthetic graph.
+- Determinism: identical seeds and inputs produce identical outputs.
+
+## Next Steps
+
+Implement the temporal data model, snapshot cache and diff engine, flesh out simulator models, expose GraphQL API and UI, and deliver CLI commands.

--- a/services/sim/__init__.py
+++ b/services/sim/__init__.py
@@ -1,0 +1,1 @@
+"""Simulation service package."""

--- a/services/sim/runner.py
+++ b/services/sim/runner.py
@@ -1,0 +1,57 @@
+"""What-If simulator for graph scenarios."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from typing import Dict, Iterable, Tuple
+
+import networkx as nx
+
+
+@dataclass
+class ChangeSet:
+    nodes: Iterable[Tuple[str, Dict]] | None = None
+    edges: Iterable[Tuple[str, str, Dict]] | None = None
+
+
+def apply_changes(base: nx.Graph, changes: ChangeSet) -> nx.Graph:
+    graph = base.copy()
+    for node, attrs in changes.nodes or []:
+        graph.add_node(node, **attrs)
+    for u, v, attrs in changes.edges or []:
+        graph.add_edge(u, v, **attrs)
+    return graph
+
+
+def run_scenario(
+    base: nx.Graph,
+    changes: ChangeSet,
+    model: str,
+    params: Dict | None = None,
+    seed: int | None = None,
+) -> Dict:
+    """Run a deterministic simulation over a changed graph."""
+    random.seed(seed)
+    params = params or {}
+    graph = apply_changes(base, changes)
+
+    if model == "reach":
+        start = params.get("start")
+        if start is None:
+            raise ValueError("reach model requires 'start' node")
+        reachable = nx.descendants(graph, start) | {start}
+        return {"kpi": {"reach": len(reachable)}, "seed": seed}
+
+    if model == "shortest":
+        src = params.get("src")
+        dst = params.get("dst")
+        if src is None or dst is None:
+            raise ValueError("shortest model requires 'src' and 'dst'")
+        try:
+            length = nx.shortest_path_length(graph, src, dst)
+        except nx.NetworkXNoPath:
+            length = None
+        return {"kpi": {"shortest_path": length}, "seed": seed}
+
+    raise ValueError(f"unsupported model: {model}")

--- a/services/time/diff.ts
+++ b/services/time/diff.ts
@@ -1,0 +1,30 @@
+export interface DiffResult<T> {
+  added: T[];
+  removed: T[];
+  changed: { before: T; after: T }[];
+}
+
+export function diffById<T extends { id: string }>(before: T[], after: T[]): DiffResult<T> {
+  const beforeMap = new Map(before.map((e) => [e.id, e]));
+  const afterMap = new Map(after.map((e) => [e.id, e]));
+
+  const added: T[] = [];
+  const removed: T[] = [];
+  const changed: { before: T; after: T }[] = [];
+
+  afterMap.forEach((value, id) => {
+    if (!beforeMap.has(id)) {
+      added.push(value);
+    } else if (JSON.stringify(beforeMap.get(id)) !== JSON.stringify(value)) {
+      changed.push({ before: beforeMap.get(id)!, after: value });
+    }
+  });
+
+  beforeMap.forEach((value, id) => {
+    if (!afterMap.has(id)) {
+      removed.push(value);
+    }
+  });
+
+  return { added, removed, changed };
+}

--- a/services/time/index.ts
+++ b/services/time/index.ts
@@ -1,0 +1,2 @@
+export * from './interval.js';
+export * from './diff.js';

--- a/services/time/interval.test.ts
+++ b/services/time/interval.test.ts
@@ -1,0 +1,17 @@
+import { overlaps, isConsistent, TemporalInterval } from './interval.js';
+
+describe('Temporal interval helpers', () => {
+  const a: TemporalInterval = {
+    validFrom: new Date('2024-01-01'),
+    validTo: new Date('2024-02-01'),
+  };
+  const b: TemporalInterval = {
+    validFrom: new Date('2024-02-01'),
+    validTo: new Date('2024-03-01'),
+  };
+
+  test('non-overlapping intervals', () => {
+    expect(overlaps(a, b)).toBe(false);
+    expect(isConsistent([a], b)).toBe(true);
+  });
+});

--- a/services/time/interval.ts
+++ b/services/time/interval.ts
@@ -1,0 +1,26 @@
+export interface TemporalInterval {
+  validFrom: Date;
+  validTo: Date;
+}
+
+export interface TemporalEntity<T = Record<string, unknown>> {
+  id: string;
+  data: T;
+  validFrom: Date;
+  validTo: Date;
+  txFrom: Date;
+  txTo: Date;
+}
+
+export function overlaps(a: TemporalInterval, b: TemporalInterval): boolean {
+  return a.validFrom < b.validTo && b.validFrom < a.validTo;
+}
+
+export function isConsistent(existing: TemporalInterval[], candidate: TemporalInterval): boolean {
+  return !existing.some((i) => overlaps(i, candidate));
+}
+
+export function buildValidTimePredicate(instant: Date): string {
+  const iso = instant.toISOString();
+  return `valid_from <= datetime(\"${iso}\") AND valid_to > datetime(\"${iso}\")`;
+}


### PR DESCRIPTION
## Summary
- outline bitemporal graph architecture with detailed design doc
- add temporal interval and diff utilities in `services/time`
- stub graph scenario simulator in `services/sim`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: SyntaxError in .github/workflows/cd-deploy.yml)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaca5259e08333a9b41726e247d98b