### PR TITLE
feat: add minimal copilot service skeleton

### DIFF
--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -1,0 +1,10 @@
+# Analyst Copilot Service
+
+This document outlines the minimal Copilot service used for tests.
+
+- **Retrieval:** static snippet pool representing graph and document evidence.
+- **Synthesis:** if evidence exists for the question, the snippet text is returned with its manifest identifier. Otherwise the service answers `"insufficient evidence"`.
+- **Guardrails:** calls require `x-tenant`, `x-user`, `x-legal-basis`, `x-reason` and persisted operation header `x-operation` set to `AskCopilot`.
+- **Faithfulness gate:** responses below coverage `0.9` or faithfulness `0.85` are replaced with `insufficient evidence`.
+
+This implementation is a lightweight reference and omits the production Fastify runtime and external data sources.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -42,6 +42,17 @@ module.exports = {
       testMatch: ['<rootDir>/client/**/*.{test,spec}.{js,jsx,ts,tsx}'],
       testEnvironment: 'jsdom',
       setupFilesAfterEnv: ['<rootDir>/client/src/setupTests.js']
+    },
+    {
+      displayName: 'copilot',
+      testMatch: ['<rootDir>/services/copilot/**/*.test.{js,ts}'],
+      preset: 'ts-jest/presets/default-esm',
+      extensionsToTreatAsEsm: ['.ts'],
+      globals: {
+        'ts-jest': {
+          useESM: true
+        }
+      }
     }
   ]
 };

--- a/services/copilot/src/index.js
+++ b/services/copilot/src/index.js
@@ -1,0 +1,79 @@
+import { performance } from 'node:perf_hooks';
+
+const REQUIRED_HEADERS = [
+  'x-tenant',
+  'x-user',
+  'x-legal-basis',
+  'x-reason',
+  'x-operation'
+];
+
+const SNIPPETS = [
+  {
+    manifestId: 'm1',
+    title: 'IntelGraph Handbook',
+    text: 'IntelGraph uses graph-aware retrieval augmented generation.'
+  }
+];
+
+function policyGate(headers) {
+  for (const key of REQUIRED_HEADERS) {
+    if (!headers[key]) {
+      throw new Error('missing required header');
+    }
+  }
+  if (headers['x-operation'] !== 'AskCopilot') {
+    throw new Error('unknown operation');
+  }
+}
+
+function retrieve(question) {
+  if (question.toLowerCase().includes('intelgraph')) {
+    return SNIPPETS;
+  }
+  return [];
+}
+
+function synthesize(question, snippets) {
+  const start = performance.now();
+  if (snippets.length === 0) {
+    return {
+      answer: 'insufficient evidence',
+      citations: [],
+      coverage: 0,
+      faithfulness: 0,
+      latencyMs: Math.round(performance.now() - start)
+    };
+  }
+
+  const citation = {
+    manifestId: snippets[0].manifestId,
+    title: snippets[0].title,
+    span: snippets[0].text
+  };
+  const response = {
+    answer: snippets[0].text,
+    citations: [citation],
+    coverage: 1,
+    faithfulness: 1,
+    latencyMs: Math.round(performance.now() - start)
+  };
+
+  if (response.coverage < 0.9 || response.faithfulness < 0.85) {
+    return {
+      answer: 'insufficient evidence',
+      citations: [citation],
+      coverage: response.coverage,
+      faithfulness: response.faithfulness,
+      latencyMs: response.latencyMs
+    };
+  }
+
+  return response;
+}
+
+export function ask(headers, question) {
+  policyGate(headers);
+  const snippets = retrieve(question);
+  return synthesize(question, snippets);
+}

--- a/services/copilot/src/index.test.ts
+++ b/services/copilot/src/index.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ask } from './index.js';
+
+const headers = {
+  'x-tenant': 't1',
+  'x-user': 'u1',
+  'x-legal-basis': 'law',
+  'x-reason': 'investigation',
+  'x-operation': 'AskCopilot'
+};
+
+test('throws without required headers', () => {
+  assert.throws(() => ask({}, 'hello'), /missing required header/);
+});
+
+test('returns answer with citation', () => {
+  const res = ask(headers, 'What is IntelGraph?');
+  assert.ok(/IntelGraph/.test(res.answer));
+  assert.equal(res.citations.length, 1);
+  assert.notEqual(res.answer, 'insufficient evidence');
+  assert.equal(res.coverage, 1);
+  assert.equal(res.faithfulness, 1);
+});
+
+test('returns insufficient evidence when no snippets', () => {
+  const res = ask(headers, 'unknown question');
+  assert.equal(res.answer, 'insufficient evidence');
+  assert.equal(res.citations.length, 0);
+});


### PR DESCRIPTION
## Summary
- add minimal copilot service with header policy gate and citation-based answers
- document copilot design and guardrails
- wire copilot tests into repository config

## Testing
- `node --test services/copilot/src/index.test.ts`
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1265fb4c83338eda228f9403e8df