### PR TITLE
feat: add GraphSAGE training utilities

### DIFF
--- a/docs/gnn_methodology.md
+++ b/docs/gnn_methodology.md
@@ -1,0 +1,10 @@
+# GNN Methodology
+
+This document describes the GraphSAGE-based approach used in the demo
+GML service. The encoder computes node embeddings via mean aggregation of
+neighbor features and supports link prediction and node classification
+tasks through simple MLP heads.
+
+Training routines are implemented in `packages/gml/tasks` and demonstrate
+negative sampling for link prediction and cross-entropy optimization for
+node classification.

--- a/packages/gml/__init__.py
+++ b/packages/gml/__init__.py
@@ -1,0 +1,2 @@
+"""GML service package providing basic GraphSAGE models and tasks."""
+__all__ = ["models", "tasks"]

--- a/packages/gml/models/sage.py
+++ b/packages/gml/models/sage.py
@@ -1,0 +1,106 @@
+"""Minimal GraphSAGE implementation using PyTorch.
+
+This module provides a mean-aggregator GraphSAGE encoder that operates on
+an adjacency list representation. It is intentionally lightweight and does
+not depend on external graph learning libraries.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+def _mean_aggregate(x: torch.Tensor, neigh_indices: List[Sequence[int]]) -> torch.Tensor:
+    """Compute mean of neighbors for each node.
+
+    Args:
+        x: Node feature matrix of shape ``(N, F)``.
+        neigh_indices: List where ``neigh_indices[i]`` is a sequence of neighbor
+            indices for node ``i``.
+
+    Returns:
+        Tensor of shape ``(N, F)`` with averaged neighbor features. Nodes with no
+        neighbors receive a zero vector.
+    """
+
+    device = x.device
+    out = torch.zeros_like(x, device=device)
+    for i, neigh in enumerate(neigh_indices):
+        if len(neigh) == 0:
+            continue
+        neigh_feat = x[torch.tensor(list(neigh), device=device)]
+        out[i] = neigh_feat.mean(dim=0)
+    return out
+
+
+class GraphSAGELayer(nn.Module):
+    """Single GraphSAGE layer with mean aggregation."""
+
+    def __init__(self, in_dim: int, out_dim: int) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_dim * 2, out_dim)
+
+    def forward(self, x: torch.Tensor, neigh: List[Sequence[int]]) -> torch.Tensor:
+        neigh_mean = _mean_aggregate(x, neigh)
+        h = torch.cat([x, neigh_mean], dim=1)
+        return F.relu(self.linear(h))
+
+
+@dataclass
+class GraphSAGEConfig:
+    in_dim: int
+    hidden_dim: int = 64
+    num_layers: int = 2
+
+
+class GraphSAGE(nn.Module):
+    """Simple multi-layer GraphSAGE encoder."""
+
+    def __init__(self, cfg: GraphSAGEConfig) -> None:
+        super().__init__()
+        layers = []
+        in_dim = cfg.in_dim
+        for _ in range(cfg.num_layers):
+            layers.append(GraphSAGELayer(in_dim, cfg.hidden_dim))
+            in_dim = cfg.hidden_dim
+        self.layers = nn.ModuleList(layers)
+
+    def forward(self, x: torch.Tensor, neigh: List[Sequence[int]]) -> torch.Tensor:
+        for layer in self.layers:
+            x = layer(x, neigh)
+        return x
+
+
+class LinkPredictor(nn.Module):
+    """MLP link predictor over GraphSAGE embeddings."""
+
+    def __init__(self, emb_dim: int, hidden_dim: int = 64) -> None:
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(emb_dim * 4, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, z: torch.Tensor, edges: Iterable[tuple[int, int]]) -> torch.Tensor:
+        feats = []
+        for u, v in edges:
+            zu, zv = z[u], z[v]
+            feats.append(torch.cat([torch.abs(zu - zv), zu * zv, zu, zv]))
+        x = torch.stack(feats)
+        return self.mlp(x).squeeze(-1)
+
+
+class NodeClassifier(nn.Module):
+    """Softmax classifier over node embeddings."""
+
+    def __init__(self, emb_dim: int, num_classes: int) -> None:
+        super().__init__()
+        self.lin = nn.Linear(emb_dim, num_classes)
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        return self.lin(z)

--- a/packages/gml/tasks/link_pred.py
+++ b/packages/gml/tasks/link_pred.py
@@ -1,0 +1,65 @@
+"""Training routine for link prediction using GraphSAGE."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Iterable
+
+import random
+import torch
+from torch import nn
+
+from ..models.sage import GraphSAGE, GraphSAGEConfig, LinkPredictor
+
+
+def _negative_samples(num_nodes: int, pos: Iterable[tuple[int, int]], k: int) -> List[tuple[int, int]]:
+    pos_set = {tuple(sorted(e)) for e in pos}
+    neg = set()
+    while len(neg) < k:
+        u = random.randrange(num_nodes)
+        v = random.randrange(num_nodes)
+        if u == v:
+            continue
+        e = tuple(sorted((u, v)))
+        if e in pos_set or e in neg:
+            continue
+        neg.add(e)
+    return list(neg)
+
+
+@dataclass
+class LinkPredConfig:
+    sage: GraphSAGEConfig
+    lr: float = 0.01
+    epochs: int = 50
+
+
+def train_link_pred(
+    features: torch.Tensor,
+    neigh: List[Sequence[int]],
+    pos_edges: List[tuple[int, int]],
+    cfg: LinkPredConfig,
+) -> tuple[GraphSAGE, LinkPredictor]:
+    """Train link predictor; returns encoder and predictor models."""
+
+    num_nodes = features.size(0)
+    encoder = GraphSAGE(cfg.sage)
+    predictor = LinkPredictor(cfg.sage.hidden_dim)
+    opt = torch.optim.Adam(list(encoder.parameters()) + list(predictor.parameters()), lr=cfg.lr)
+    criterion = nn.BCEWithLogitsLoss()
+
+    pos_edges = [tuple(map(int, e)) for e in pos_edges]
+
+    for _ in range(cfg.epochs):
+        neg_edges = _negative_samples(num_nodes, pos_edges, len(pos_edges))
+        all_edges = pos_edges + neg_edges
+        labels = torch.tensor([1] * len(pos_edges) + [0] * len(neg_edges), dtype=torch.float32)
+
+        z = encoder(features, neigh)
+        logits = predictor(z, all_edges)
+        loss = criterion(logits, labels)
+
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
+    return encoder, predictor

--- a/packages/gml/tasks/node_cls.py
+++ b/packages/gml/tasks/node_cls.py
@@ -1,0 +1,40 @@
+"""Training routine for node classification using GraphSAGE."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+import torch
+from torch import nn
+
+from ..models.sage import GraphSAGE, GraphSAGEConfig, NodeClassifier
+
+
+@dataclass
+class NodeClsConfig:
+    sage: GraphSAGEConfig
+    lr: float = 0.01
+    epochs: int = 50
+
+
+def train_node_cls(
+    features: torch.Tensor,
+    neigh: List[Sequence[int]],
+    labels: torch.Tensor,
+    cfg: NodeClsConfig,
+) -> tuple[GraphSAGE, NodeClassifier]:
+    num_nodes = features.size(0)
+    encoder = GraphSAGE(cfg.sage)
+    classifier = NodeClassifier(cfg.sage.hidden_dim, int(labels.max().item()) + 1)
+    opt = torch.optim.Adam(list(encoder.parameters()) + list(classifier.parameters()), lr=cfg.lr)
+    criterion = nn.CrossEntropyLoss()
+
+    for _ in range(cfg.epochs):
+        z = encoder(features, neigh)
+        logits = classifier(z)
+        loss = criterion(logits, labels)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
+    return encoder, classifier

--- a/packages/gml/tests/test_sage.py
+++ b/packages/gml/tests/test_sage.py
@@ -1,0 +1,44 @@
+import torch
+
+from gml.models.sage import GraphSAGEConfig, GraphSAGE
+from gml.tasks.link_pred import LinkPredConfig, train_link_pred
+from gml.tasks.node_cls import NodeClsConfig, train_node_cls
+
+
+def build_chain_graph(num_nodes: int = 4):
+    neigh = [[] for _ in range(num_nodes)]
+    edges = []
+    for i in range(num_nodes - 1):
+        neigh[i].append(i + 1)
+        neigh[i + 1].append(i)
+        edges.append((i, i + 1))
+    features = torch.eye(num_nodes, dtype=torch.float32)
+    return features, neigh, edges
+
+
+def test_graphsage_forward():
+    features, neigh, _ = build_chain_graph()
+    model = GraphSAGE(GraphSAGEConfig(in_dim=4, hidden_dim=8, num_layers=2))
+    out = model(features, neigh)
+    assert out.shape == (4, 8)
+
+
+def test_link_prediction_training():
+    features, neigh, edges = build_chain_graph()
+    cfg = LinkPredConfig(GraphSAGEConfig(in_dim=4, hidden_dim=8, num_layers=1), epochs=100)
+    encoder, predictor = train_link_pred(features, neigh, edges, cfg)
+    z = encoder(features, neigh)
+    pos_score = predictor(z, [edges[0]])[0].item()
+    neg_score = predictor(z, [(0, 3)])[0].item()
+    assert pos_score > neg_score
+
+
+def test_node_classification_training():
+    features, neigh, _ = build_chain_graph()
+    labels = torch.tensor([0, 0, 1, 1], dtype=torch.long)
+    cfg = NodeClsConfig(GraphSAGEConfig(in_dim=4, hidden_dim=8, num_layers=1), epochs=100)
+    encoder, classifier = train_node_cls(features, neigh, labels, cfg)
+    z = encoder(features, neigh)
+    preds = classifier(z).argmax(dim=1)
+    accuracy = (preds == labels).float().mean().item()
+    assert accuracy >= 0.5


### PR DESCRIPTION
## Summary
- implement minimal GraphSAGE encoder, link predictor, and node classifier
- add training routines for link prediction and node classification
- document approach in new gnn methodology guide

## Testing
- `PYTHONPATH=packages pytest packages/gml/tests/test_sage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab349862188333acb83976fe6d4f0f