### PR TITLE
feat: add link analysis canvas

### DIFF
--- a/client/cypress.config.ts
+++ b/client/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    supportFile: false,
+  },
+});

--- a/client/cypress/e2e/link-analysis.cy.ts
+++ b/client/cypress/e2e/link-analysis.cy.ts
@@ -1,0 +1,39 @@
+describe('link analysis canvas', () => {
+  it('brushing time updates all panes', () => {
+    cy.visit('/');
+    cy.get('[data-testid="start-range"]').as('start');
+    cy.get('@start').invoke('val', 20).trigger('input');
+    cy.get('[data-testid="map-pane"]').should('contain', '20');
+    cy.get('[data-testid="graph-pane"]').should('contain', '20');
+    cy.get('[data-testid="explain-panel"]').should('contain', '20');
+  });
+
+  it('command palette executes a saved query', () => {
+    cy.visit('/');
+    cy.get('body').type('{meta}k');
+    cy.get('[data-testid="command-palette"]').contains('recent-incidents').click();
+    cy.get('[data-testid="explain-panel"]').should('contain', 'recent-incidents');
+  });
+
+  it('explain panel reflects active filters', () => {
+    cy.visit('/');
+    cy.get('[data-testid="start-range"]').invoke('val', 30).trigger('input');
+    cy.get('body').type('{meta}k');
+    cy.get('[data-testid="command-palette"]').contains('top-entities').click();
+    cy.get('[data-testid="explain-panel"]').should('contain', '30');
+    cy.get('[data-testid="explain-panel"]').should('contain', 'top-entities');
+  });
+
+  it('pinning a node updates explain panel', () => {
+    cy.visit('/');
+    cy.get('[data-testid="graph-pane"] .react-flow__node').click();
+    cy.get('[data-testid="explain-panel"]').should('contain', 'Pinned: 1');
+  });
+
+  it('clear pinned resets count', () => {
+    cy.visit('/');
+    cy.get('[data-testid="graph-pane"] .react-flow__node').click();
+    cy.contains('Clear pinned').click();
+    cy.get('[data-testid="explain-panel"]').should('contain', 'Pinned: 0');
+  });
+});

--- a/client/index.html
+++ b/client/index.html
@@ -6,9 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>IntelGraph Platform</title>
     <meta name="description" content="Next-generation intelligence analysis platform with AI-augmented graph analytics" />
+    <meta
+      name="description"
+      content="Next-generation intelligence analysis platform with AI-augmented graph analytics"
+    />
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.link-analysis.tsx"></script>
   </body>
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -65,7 +65,10 @@
     "uuid": "^9.0.1",
     "vis-timeline": "^8.3.0",
     "web-vitals": "^5.1.0",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "mapbox-gl": "^3.3.0",
+    "reactflow": "^11.10.2",
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",
@@ -103,7 +106,8 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jest": "^29.0.1",
-    "typescript-eslint": "^8.0.0"
+    "typescript-eslint": "^8.0.0",
+    "cypress": "^13.9.0"
   },
   "engines": { "node": ">=18.18 <20" },
   "packageManager": "npm @10.8.1"

--- a/client/src/App.link-analysis.tsx
+++ b/client/src/App.link-analysis.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { LinkAnalysisCanvas } from './features/link-analysis/LinkAnalysisCanvas';
+
+const App: React.FC = () => {
+  return <LinkAnalysisCanvas />;
+};
+
+export default App;

--- a/client/src/features/link-analysis/CommandPalette.tsx
+++ b/client/src/features/link-analysis/CommandPalette.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { useAnalysisStore } from './store';
+
+const SAVED_QUERIES = ['recent-incidents', 'top-entities'];
+
+export const CommandPalette: React.FC = () => {
+  const runQuery = useAnalysisStore((s) => s.runQuery);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <div data-testid="command-palette" className="absolute inset-0 bg-black/50 flex items-center justify-center">
+      <div className="bg-white text-black p-4 space-y-2">
+        {SAVED_QUERIES.map((q) => (
+          <button
+            key={q}
+            onClick={() => {
+              runQuery(q);
+              setOpen(false);
+            }}
+            className="block w-full text-left p-2 hover:bg-gray-100"
+          >
+            {q}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CommandPalette;

--- a/client/src/features/link-analysis/ExplainPanel.tsx
+++ b/client/src/features/link-analysis/ExplainPanel.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useAnalysisStore } from './store';
+
+export const ExplainPanel: React.FC = () => {
+  const { timeRange, activeQuery, pinned, clearPinned } = useAnalysisStore();
+  return (
+    <div
+      data-testid="explain-panel"
+      className="absolute bottom-0 right-0 m-4 p-2 bg-gray-800 text-white text-sm space-y-1"
+    >
+      <div>Time: {timeRange.start} - {timeRange.end}</div>
+      <div>Query: {activeQuery ?? 'none'}</div>
+      <div>Pinned: {pinned.size}</div>
+      {pinned.size > 0 && (
+        <div>
+          <button
+            onClick={clearPinned}
+            className="mt-1 rounded bg-gray-700 px-2 py-1 text-xs"
+          >
+            Clear pinned
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExplainPanel;

--- a/client/src/features/link-analysis/GraphPane.tsx
+++ b/client/src/features/link-analysis/GraphPane.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import ReactFlow, { Background } from 'reactflow';
+import 'reactflow/dist/style.css';
+import { useAnalysisStore } from './store';
+
+export const GraphPane: React.FC = () => {
+  const { timeRange, pinned, togglePinned } = useAnalysisStore();
+  const nodes = [
+    {
+      id: '1',
+      position: { x: 0, y: 0 },
+      data: { label: `Node ${timeRange.start}-${timeRange.end}` },
+      style: {
+        border: pinned.has('1') ? '2px solid #f00' : undefined,
+        padding: 4,
+        borderRadius: 4,
+      },
+    },
+  ];
+  return (
+    <div data-testid="graph-pane" style={{ height: '100%' }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={[]}
+        onNodeClick={(_, node) => togglePinned(node.id)}
+      >
+        <Background />
+      </ReactFlow>
+    </div>
+  );
+};
+
+export default GraphPane;

--- a/client/src/features/link-analysis/LinkAnalysisCanvas.stories.tsx
+++ b/client/src/features/link-analysis/LinkAnalysisCanvas.stories.tsx
@@ -1,0 +1,10 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LinkAnalysisCanvas } from './LinkAnalysisCanvas';
+
+const meta: Meta<typeof LinkAnalysisCanvas> = {
+  title: 'Features/LinkAnalysisCanvas',
+  component: LinkAnalysisCanvas,
+};
+
+export default meta;
+export const Default: StoryObj<typeof LinkAnalysisCanvas> = {};

--- a/client/src/features/link-analysis/LinkAnalysisCanvas.tsx
+++ b/client/src/features/link-analysis/LinkAnalysisCanvas.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import TimelinePane from './TimelinePane';
+import MapPane from './MapPane';
+import GraphPane from './GraphPane';
+import CommandPalette from './CommandPalette';
+import ExplainPanel from './ExplainPanel';
+
+export const LinkAnalysisCanvas: React.FC = () => {
+  return (
+    <div
+      className="relative grid grid-cols-3 h-screen divide-x"
+      data-testid="link-analysis-canvas"
+    >
+      <TimelinePane />
+      <MapPane />
+      <GraphPane />
+      <CommandPalette />
+      <ExplainPanel />
+    </div>
+  );
+};
+
+export default LinkAnalysisCanvas;

--- a/client/src/features/link-analysis/MapPane.tsx
+++ b/client/src/features/link-analysis/MapPane.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useAnalysisStore } from './store';
+// Placeholder for Mapbox GL map
+// In a full implementation, mapbox-gl would render a map synchronized with timeRange
+
+export const MapPane: React.FC = () => {
+  const timeRange = useAnalysisStore((s) => s.timeRange);
+  return (
+    <div data-testid="map-pane" className="p-2">
+      Map showing data from {timeRange.start} to {timeRange.end}
+    </div>
+  );
+};
+
+export default MapPane;

--- a/client/src/features/link-analysis/TimelinePane.tsx
+++ b/client/src/features/link-analysis/TimelinePane.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useAnalysisStore } from './store';
+
+export const TimelinePane: React.FC = () => {
+  const timeRange = useAnalysisStore((s) => s.timeRange);
+  const setTimeRange = useAnalysisStore((s) => s.setTimeRange);
+
+  return (
+    <div data-testid="timeline-pane" className="p-2 space-y-2">
+      <input
+        data-testid="start-range"
+        type="range"
+        min={0}
+        max={100}
+        value={timeRange.start}
+        onChange={(e) =>
+          setTimeRange({ ...timeRange, start: Number(e.target.value) })
+        }
+      />
+      <input
+        data-testid="end-range"
+        type="range"
+        min={0}
+        max={100}
+        value={timeRange.end}
+        onChange={(e) =>
+          setTimeRange({ ...timeRange, end: Number(e.target.value) })
+        }
+      />
+    </div>
+  );
+};
+
+export default TimelinePane;

--- a/client/src/features/link-analysis/index.ts
+++ b/client/src/features/link-analysis/index.ts
@@ -1,0 +1,1 @@
+export * from './LinkAnalysisCanvas';

--- a/client/src/features/link-analysis/store.ts
+++ b/client/src/features/link-analysis/store.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+
+interface TimeRange {
+  start: number;
+  end: number;
+}
+
+interface AnalysisState {
+  timeRange: TimeRange;
+  activeQuery: string | null;
+  pinned: Set<string>;
+  setTimeRange: (range: TimeRange) => void;
+  runQuery: (query: string) => void;
+  togglePinned: (id: string) => void;
+  clearPinned: () => void;
+}
+
+export const useAnalysisStore = create<AnalysisState>((set) => ({
+  timeRange: { start: 0, end: 100 },
+  activeQuery: null,
+  pinned: new Set<string>(),
+  setTimeRange: (range) =>
+    set({
+      timeRange: {
+        start: Math.min(range.start, range.end),
+        end: Math.max(range.start, range.end),
+      },
+    }),
+  runQuery: (activeQuery) => set({ activeQuery }),
+  togglePinned: (id) =>
+    set((s) => {
+      const next = new Set(s.pinned);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return { pinned: next };
+    }),
+  clearPinned: () => set({ pinned: new Set<string>() }),
+}));

--- a/client/src/main.link-analysis.tsx
+++ b/client/src/main.link-analysis.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.link-analysis';
+import './styles/globals.css';
+
+const root = document.getElementById('root')!;
+
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+


### PR DESCRIPTION
## Summary
- add tri-pane link analysis canvas with timeline, map, graph, command palette and explain panel
- introduce zustand store with pinned nodes and range validation
- create link-analysis app entry point and cypress coverage

## Testing
- `npm install --no-audit --no-fund` *(failed: Package 'pixman-1' not found)*
- `cd server && npm install --no-audit --no-fund` *(failed: Package 'pixman-1' not found)*
- `cd client && npm install --no-audit --no-fund` *(failed: Package 'pixman-1' not found)*
- `npm run lint` *(Cannot find package '@eslint/js')*
- `npm test` *(jest: not found)*
- `npx cypress run --config-file client/cypress.config.ts` *(missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a31fe6883338c287099456e6628