### PR TITLE
feat: add minimal osint service

### DIFF
--- a/docs/ga-osint/architecture.md
+++ b/docs/ga-osint/architecture.md
@@ -1,0 +1,8 @@
+# GA-OSINT Architecture
+
+```
+[fixtures] -> [ingestors] -> [osint service] -> [gateway] -> [web ui]
+           \-> [capture service] -/
+```
+
+This document provides a high-level overview of the GA-OSINT vertical slice. Fixtures are ingested and normalized by the ingestors. The OSINT service performs text extraction and analysis while the capture service archives content. The gateway exposes a GraphQL API consumed by the web UI.

--- a/packages/osint/requirements.txt
+++ b/packages/osint/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+pydantic
+beautifulsoup4
+uvicorn

--- a/packages/osint/src/main.py
+++ b/packages/osint/src/main.py
@@ -1,0 +1,35 @@
+"""Minimal OSINT service providing HTML-to-text extraction."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from bs4 import BeautifulSoup
+
+app = FastAPI(title="OSINT Service")
+
+
+class ExtractRequest(BaseModel):
+    """Request body for the text extraction endpoint."""
+
+    html: str
+
+
+class ExtractResponse(BaseModel):
+    """Response model containing the extracted plain text."""
+
+    text: str
+
+
+@app.post("/extract/text", response_model=ExtractResponse)
+def extract_text(request: ExtractRequest) -> ExtractResponse:
+    """Extract readable text from supplied HTML."""
+
+    soup = BeautifulSoup(request.html, "html.parser")
+    text = soup.get_text(separator=" ", strip=True)
+    return ExtractResponse(text=text)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+
+    return {"status": "ok"}

--- a/packages/osint/tests/test_extract.py
+++ b/packages/osint/tests/test_extract.py
@@ -1,0 +1,24 @@
+"""Tests for the minimal OSINT service."""
+
+from fastapi.testclient import TestClient
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+from main import app  # type: ignore
+
+
+client = TestClient(app)
+
+
+def test_extract_text() -> None:
+    html = "<p>Hello <b>world</b></p>"
+    response = client.post("/extract/text", json={"html": html})
+    assert response.status_code == 200
+    assert response.json()["text"] == "Hello world"
+
+
+def test_health() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add GA-OSINT architecture doc
- add minimal FastAPI OSINT service with HTML extraction endpoint
- test extraction and health endpoints

## Testing
- `pytest packages/osint/tests/test_extract.py`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3e8746bc8333a6bca5cad1c43675