### PR TITLE
feat(common-types): add shared entity schemas

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -42,6 +42,17 @@ module.exports = {
       testMatch: ['<rootDir>/client/**/*.{test,spec}.{js,jsx,ts,tsx}'],
       testEnvironment: 'jsdom',
       setupFilesAfterEnv: ['<rootDir>/client/src/setupTests.js']
+    },
+    {
+      displayName: 'common-types',
+      testMatch: ['<rootDir>/packages/common-types/**/*.{test,spec}.ts'],
+      preset: 'ts-jest/presets/default-esm',
+      extensionsToTreatAsEsm: ['.ts'],
+      globals: {
+        'ts-jest': {
+          useESM: true
+        }
+      }
     }
   ]
 };

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@intelgraph/common-types",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "license": "MIT"
+}

--- a/packages/common-types/src/index.test.ts
+++ b/packages/common-types/src/index.test.ts
@@ -1,0 +1,44 @@
+import { Host, Indicator, Rule, schemas } from './index';
+
+describe('entity schemas', () => {
+  it('creates a valid Host', () => {
+    const host: Host = {
+      id: 'h1',
+      hostname: 'web1',
+      ip: '10.0.0.5',
+      os: 'linux',
+      assetCriticality: 'medium',
+      policyLabels: [],
+    };
+    expect(host.hostname).toBe('web1');
+  });
+
+  it('contains enum values in schema', () => {
+    const indicator: Indicator = {
+      id: 'i1',
+      type: 'ip',
+      value: '8.8.8.8',
+      labels: [],
+      sources: [],
+      firstSeen: new Date().toISOString(),
+      lastSeen: new Date().toISOString(),
+      policyLabels: [],
+    };
+    const rule: Rule = {
+      id: 'r1',
+      kind: 'SIGMA',
+      name: 'test',
+      version: '1',
+      source: 'local',
+      enabled: true,
+      severity: 'low',
+      tags: [],
+      content: 'rule',
+      policyLabels: [],
+    };
+    expect(indicator.type).toBe('ip');
+    expect(rule.kind).toBe('SIGMA');
+    expect(schemas.Indicator.properties.type.enum).toContain('ip');
+    expect(schemas.Rule.properties.kind.enum).toContain('SIGMA');
+  });
+});

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -1,0 +1,118 @@
+export interface Host {
+  id: string;
+  hostname: string;
+  ip: string;
+  os: string;
+  assetCriticality: 'low' | 'medium' | 'high';
+  policyLabels: string[];
+}
+
+export const HostSchema = {
+  $id: 'Host',
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    hostname: { type: 'string' },
+    ip: { type: 'string', format: 'ipv4' },
+    os: { type: 'string' },
+    assetCriticality: {
+      type: 'string',
+      enum: ['low', 'medium', 'high'],
+    },
+    policyLabels: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+  },
+  required: ['id', 'hostname', 'ip', 'os', 'assetCriticality', 'policyLabels'],
+  additionalProperties: false,
+} as const;
+
+export interface Indicator {
+  id: string;
+  type: 'ip' | 'domain' | 'url' | 'hash' | 'email' | 'yara';
+  value: string;
+  labels: string[];
+  sources: string[];
+  firstSeen: string;
+  lastSeen: string;
+  policyLabels: string[];
+}
+
+export const IndicatorSchema = {
+  $id: 'Indicator',
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    type: {
+      type: 'string',
+      enum: ['ip', 'domain', 'url', 'hash', 'email', 'yara'],
+    },
+    value: { type: 'string' },
+    labels: { type: 'array', items: { type: 'string' } },
+    sources: { type: 'array', items: { type: 'string' } },
+    firstSeen: { type: 'string', format: 'date-time' },
+    lastSeen: { type: 'string', format: 'date-time' },
+    policyLabels: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['id', 'type', 'value', 'labels', 'sources', 'firstSeen', 'lastSeen', 'policyLabels'],
+  additionalProperties: false,
+} as const;
+
+export interface Rule {
+  id: string;
+  kind: 'SIGMA' | 'YARA';
+  name: string;
+  version: string;
+  source: string;
+  enabled: boolean;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  tags: string[];
+  content: string;
+  policyLabels: string[];
+}
+
+export const RuleSchema = {
+  $id: 'Rule',
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    kind: { type: 'string', enum: ['SIGMA', 'YARA'] },
+    name: { type: 'string' },
+    version: { type: 'string' },
+    source: { type: 'string' },
+    enabled: { type: 'boolean' },
+    severity: {
+      type: 'string',
+      enum: ['low', 'medium', 'high', 'critical'],
+    },
+    tags: { type: 'array', items: { type: 'string' } },
+    content: { type: 'string' },
+    policyLabels: { type: 'array', items: { type: 'string' } },
+  },
+  required: [
+    'id',
+    'kind',
+    'name',
+    'version',
+    'source',
+    'enabled',
+    'severity',
+    'tags',
+    'content',
+    'policyLabels',
+  ],
+  additionalProperties: false,
+} as const;
+
+export type EntitySchemas = {
+  Host: typeof HostSchema;
+  Indicator: typeof IndicatorSchema;
+  Rule: typeof RuleSchema;
+};
+
+export const schemas: EntitySchemas = {
+  Host: HostSchema,
+  Indicator: IndicatorSchema,
+  Rule: RuleSchema,
+};

--- a/packages/common-types/tsconfig.json
+++ b/packages/common-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add `@intelgraph/common-types` package with Host, Indicator, and Rule schemas
- wire package into Jest projects for isolated testing

## Testing
- `npm test` *(fails: see logs for multiple failing suites)*
- `npx eslint packages/common-types/src/index.ts --no-eslintrc` *(failed: JavaScript heap out of memory)*


------
https://chatgpt.com/codex/tasks/task_e_68ab3c5d147c8333bab91c5cde9cc4b8