### PR TITLE
feat: add entity resolution scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,3 +901,17 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ---
 
 **IntelGraph Platform** - Next-Generation Intelligence Analysis
+
+## Entity Resolution (GA-EntityRes)
+
+```
+[Blocking] -> [Pairwise] -> [Clustering] -> [Canonical]
+```
+
+Run locally:
+
+```bash
+npm install
+npm test packages/common-types packages/gateway packages/web
+pytest packages/er
+```

--- a/docs/api.graphql.md
+++ b/docs/api.graphql.md
@@ -1,0 +1,3 @@
+# GraphQL API
+
+The gateway exposes GraphQL operations for entity resolution.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,7 @@
+# Architecture
+
+```
+[Blocking] -> [Pairwise] -> [Clustering] -> [Canonical]
+```
+
+Components communicate via GraphQL and REST APIs.

--- a/docs/blocking.md
+++ b/docs/blocking.md
@@ -1,0 +1,3 @@
+# Blocking
+
+Candidate generation using simple scopes.

--- a/docs/canonicalization.md
+++ b/docs/canonicalization.md
@@ -1,0 +1,3 @@
+# Canonicalization
+
+Field synthesis choosing best source.

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1,0 +1,3 @@
+# Clustering
+
+Transitive closure on scored pairs.

--- a/docs/human_review.md
+++ b/docs/human_review.md
@@ -1,0 +1,3 @@
+# Human Review
+
+Analysts decide on uncertain pairs.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,3 @@
+# Operations
+
+Run `docker-compose` for local development.

--- a/docs/pairwise_features.md
+++ b/docs/pairwise_features.md
@@ -1,0 +1,3 @@
+# Pairwise Features
+
+Basic string comparison features.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,3 @@
+# Security
+
+JWT, RBAC, and ABAC ensure data access rules.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: example
+    ports: ['5432:5432']
+  gateway:
+    build: ../packages/gateway
+    command: npm start
+    ports: ['4000:4000']
+    depends_on: [postgres]
+  er:
+    build: ../packages/er
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    ports: ['8000:8000']
+    depends_on: [postgres]

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@intelgraph/common-types",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -1,0 +1,33 @@
+export interface RawEntity {
+  id: string;
+  tenantId: string;
+  type: 'PERSON' | 'ORG' | 'LOCATION' | 'DOCUMENT';
+  names: string[];
+  emails_hash: string[];
+  phones_hash: string[];
+}
+
+export interface CanonicalEntity {
+  id: string;
+  tenantId: string;
+  type: RawEntity['type'];
+  primaryName: string;
+  names: string[];
+  emails_hash: string[];
+  phones_hash: string[];
+}
+
+export interface MatchPair {
+  id: string;
+  a_id: string;
+  b_id: string;
+  score: number;
+  decision: 'AUTO_LINK' | 'AUTO_NO' | 'REVIEW';
+}
+
+export interface Cluster {
+  id: string;
+  canonicalId: string;
+  memberIds: string[];
+  frozen: boolean;
+}

--- a/packages/common-types/test/index.test.ts
+++ b/packages/common-types/test/index.test.ts
@@ -1,0 +1,15 @@
+import { RawEntity } from '../src';
+
+describe('types', () => {
+  it('allows constructing RawEntity', () => {
+    const r: RawEntity = {
+      id: '1',
+      tenantId: 't1',
+      type: 'PERSON',
+      names: ['Alice'],
+      emails_hash: [],
+      phones_hash: []
+    };
+    expect(r.names[0]).toBe('Alice');
+  });
+});

--- a/packages/common-types/tsconfig.json
+++ b/packages/common-types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/er/pyproject.toml
+++ b/packages/er/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "intelgraph-er"
+version = "0.1.0"
+dependencies = [
+  "fastapi",
+  "uvicorn",
+  "pydantic",
+  "scikit-learn",
+  "numpy",
+  "pandas"
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/packages/er/src/main.py
+++ b/packages/er/src/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class BlockRequest(BaseModel):
+    scope: str
+
+@app.post('/block')
+async def block(req: BlockRequest):
+    # placeholder blocking
+    return {"candidatesCount": 0, "samplePairs": []}
+
+class Pair(BaseModel):
+    a_id: str
+    b_id: str
+
+@app.post('/match/pairs')
+async def match_pairs(pairs: list[Pair]):
+    scored = [{"a_id": p.a_id, "b_id": p.b_id, "score": 0.5, "calibrated": 0.5} for p in pairs]
+    return {"scoredPairs": scored}
+
+@app.get('/health')
+async def health():
+    return {"status": "ok"}

--- a/packages/er/tests/test_main.py
+++ b/packages/er/tests/test_main.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+import importlib.util, sys, pathlib
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / 'src'
+sys.path.append(str(MODULE_PATH))
+from main import app
+
+def test_health():
+    client = TestClient(app)
+    resp = client.get('/health')
+    assert resp.json()['status'] == 'ok'

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@intelgraph/gateway",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "apollo-server-express": "^3.12.1",
+    "graphql": "^16.8.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.14",
+    "ts-jest": "^29.2.6",
+    "supertest": "^7.1.1"
+  }
+}

--- a/packages/gateway/src/graphql/resolvers.ts
+++ b/packages/gateway/src/graphql/resolvers.ts
@@ -1,0 +1,8 @@
+export const resolvers = {
+  Query: {
+    rawEntities: () => [
+      { id: '1', names: ['Alice'] },
+      { id: '2', names: ['Bob'] }
+    ]
+  }
+};

--- a/packages/gateway/src/graphql/schema.ts
+++ b/packages/gateway/src/graphql/schema.ts
@@ -1,0 +1,12 @@
+import { gql } from 'apollo-server-express';
+
+export const typeDefs = gql`
+  type RawEntity {
+    id: ID!
+    names: [String!]!
+  }
+
+  type Query {
+    rawEntities: [RawEntity!]!
+  }
+`;

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { ApolloServer } from 'apollo-server-express';
+import { typeDefs } from './graphql/schema';
+import { resolvers } from './graphql/resolvers';
+
+export async function createServer() {
+  const app = express();
+  const apollo = new ApolloServer({ typeDefs, resolvers });
+  await apollo.start();
+  apollo.applyMiddleware({ app, path: '/graphql' });
+  return app;
+}
+
+if (require.main === module) {
+  createServer().then(app => {
+    const port = process.env.PORT || 4000;
+    app.listen(port, () => {
+      console.log(`Gateway running at http://localhost:${port}/graphql`);
+    });
+  });
+}

--- a/packages/gateway/test/schema.test.ts
+++ b/packages/gateway/test/schema.test.ts
@@ -1,0 +1,12 @@
+import request from 'supertest';
+import { createServer } from '../src';
+
+describe('gateway schema', () => {
+  it('returns raw entities', async () => {
+    const app = await createServer();
+    const res = await request(app)
+      .post('/graphql')
+      .send({ query: '{ rawEntities { id names } }' });
+    expect(res.body.data.rawEntities.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@intelgraph/web",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "jquery": "^3.7.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.3",
+    "@types/jquery": "^3.5.29",
+    "ts-jest": "^29.2.6",
+    "@types/jest": "^29.5.14",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/jest-dom": "^6.4.2"
+  }
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+import $ from 'jquery';
+
+export const App: React.FC = () => {
+  useEffect(() => {
+    $(document).on('demo:event', (_e, detail) => {
+      console.log('event', detail);
+    });
+  }, []);
+  return <div role="main">Resolution Console</div>;
+};

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,0 +1,1 @@
+export { App } from './App';

--- a/packages/web/test/app.test.tsx
+++ b/packages/web/test/app.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { App } from '../src';
+
+describe('App', () => {
+  it('renders heading', () => {
+    const { getByRole } = render(<App />);
+    expect(getByRole('main').textContent).toBe('Resolution Console');
+  });
+});

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/scripts/dev-seed.ts
+++ b/scripts/dev-seed.ts
@@ -1,0 +1,8 @@
+import { RawEntity } from '../packages/common-types/src';
+
+// simple seed of raw entities
+const seeds: RawEntity[] = [
+  { id: '1', tenantId: 't1', type: 'PERSON', names: ['Alice'], emails_hash: [], phones_hash: [] },
+  { id: '2', tenantId: 't1', type: 'PERSON', names: ['Alicia'], emails_hash: [], phones_hash: [] }
+];
+console.log('Seeded', seeds.length, 'entities');


### PR DESCRIPTION
## Summary
- scaffold docs and packages for GA-EntityRes
- add gateway, ER service, web console stubs
- docker-compose for local services and seed script

## Testing
- `pip install fastapi uvicorn pydantic`
- `pytest packages/er/tests/test_main.py`
- `npm install` *(fails: Package 'pixman-1' not found for canvas build)*
- `npx jest packages/common-types/test/index.test.ts` *(prompted for missing jest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab40ac207c833387f4583f56f0551b