### PR TITLE
feat: add basic PII detection utility

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level services package."""

--- a/services/ediscovery/__init__.py
+++ b/services/ediscovery/__init__.py
@@ -1,0 +1,1 @@
+"""eDiscovery service package."""

--- a/services/ediscovery/src/__init__.py
+++ b/services/ediscovery/src/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the eDiscovery service."""

--- a/services/ediscovery/src/rules.py
+++ b/services/ediscovery/src/rules.py
@@ -1,0 +1,47 @@
+"""Basic PII detection utilities.
+
+This module provides simple regular expression based detectors for
+common personally identifiable information (PII) artifacts found in
+eDiscovery content such as email bodies or attachments.
+"""
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?(?:\d{3}[-.\s]?){2}\d{4}\b")
+
+
+def detect_pii(text: str) -> Dict[str, List[str]]:
+    """Detect basic PII elements in *text*.
+
+    Parameters
+    ----------
+    text:
+        Arbitrary text that may contain email addresses, phone numbers or
+        U.S. Social Security Numbers (SSNs).
+
+    Returns
+    -------
+    dict
+        A mapping with keys ``emails``, ``phones`` and ``ssns`` containing
+        sorted lists of the unique matches found. Keys with no matches are
+        omitted from the result.
+    """
+    emails = sorted(set(EMAIL_RE.findall(text)))
+    phones = sorted(set(PHONE_RE.findall(text)))
+    ssns = sorted(set(SSN_RE.findall(text)))
+
+    result: Dict[str, List[str]] = {}
+    if emails:
+        result["emails"] = emails
+    if phones:
+        result["phones"] = phones
+    if ssns:
+        result["ssns"] = ssns
+    return result
+
+
+__all__ = ["detect_pii"]

--- a/services/ediscovery/tests/test_rules.py
+++ b/services/ediscovery/tests/test_rules.py
@@ -1,0 +1,12 @@
+from services.ediscovery.src.rules import detect_pii
+
+
+def test_detect_pii_basic() -> None:
+    text = (
+        "Contact john.doe@example.com or jane@corp.co. "
+        "Call 123-456-7890. SSN 111-22-3333."
+    )
+    result = detect_pii(text)
+    assert result["emails"] == ["jane@corp.co", "john.doe@example.com"]
+    assert result["phones"] == ["123-456-7890"]
+    assert result["ssns"] == ["111-22-3333"]


### PR DESCRIPTION
## Summary
- add PII detection helper for emails, phones, and SSNs
- test detection logic

## Testing
- `PYTHONPATH=. pytest services/ediscovery/tests/test_rules.py --no-cov`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4f3c08b483338417602c8f415648