### PR TITLE
feat: add finintel service skeleton

### DIFF
--- a/packages/finintel/README.md
+++ b/packages/finintel/README.md
@@ -1,0 +1,3 @@
+# FinIntel Service
+
+Minimal FastAPI service exposing a health endpoint.

--- a/packages/finintel/finintel/__init__.py
+++ b/packages/finintel/finintel/__init__.py
@@ -1,0 +1,5 @@
+"""FinIntel service package."""
+
+__all__ = ["create_app"]
+
+from .main import create_app

--- a/packages/finintel/finintel/main.py
+++ b/packages/finintel/finintel/main.py
@@ -1,0 +1,18 @@
+"""FastAPI application for the FinIntel service."""
+
+from fastapi import FastAPI
+
+
+def create_app() -> FastAPI:
+  """Create and configure the FastAPI application."""
+  app = FastAPI(title="FinIntel Service")
+
+  @app.get("/health", tags=["health"])
+  def health() -> dict[str, str]:
+    """Simple healthcheck endpoint."""
+    return {"status": "ok"}
+
+  return app
+
+
+app = create_app()

--- a/packages/finintel/pyproject.toml
+++ b/packages/finintel/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "finintel"
+version = "0.1.0"
+description = "FinIntel service"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi",
+  "uvicorn[standard]",
+  "pytest",
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/packages/finintel/tests/test_health.py
+++ b/packages/finintel/tests/test_health.py
@@ -1,0 +1,17 @@
+"""Tests for the FinIntel FastAPI health endpoint."""
+
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from finintel.main import create_app
+
+
+def test_health_endpoint() -> None:
+  app = create_app()
+  client = TestClient(app)
+  response = client.get("/health")
+  assert response.status_code == 200
+  assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- scaffold FinIntel FastAPI service with health endpoint
- add basic pytest ensuring health endpoint works

## Testing
- `pytest packages/finintel/tests/test_health.py -q`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4abe8bd48333abe79fcbef1a620e