### PR TITLE
docs: add GA-Ontology documentation

### DIFF
--- a/docs/ga-ontology/api.graphql.md
+++ b/docs/ga-ontology/api.graphql.md
@@ -1,0 +1,11 @@
+# GraphQL API Overview
+
+The gateway exposes types for ontologies, versions, classes, properties, proposals, mappings, validations, and releases.
+
+Example query:
+
+```
+query GetClasses($versionId: ID!) {
+  classes(versionId: $versionId) { key label }
+}
+```

--- a/docs/ga-ontology/architecture.md
+++ b/docs/ga-ontology/architecture.md
@@ -1,0 +1,16 @@
+# GA-Ontology Architecture
+
+The GA-Ontology stack is a set of services that run locally via `docker-compose`.
+
+```
++-----------+      +-----------------+      +-------+
+|  Web UI   | <--> |  Gateway (GraphQL) | <--> | Redis |
++-----------+      +-----------------+      +-------+
+        |                    |                    |
+        v                    v                    v
++-----------------+  +--------------+  +----------------+
+| Ontology Service|  | PostgreSQL   |  |   Neo4j        |
++-----------------+  +--------------+  +----------------+
+```
+
+The gateway exposes a GraphQL API and relays real-time events via Socket.IO. The ontology service materializes RDF, validates data, and builds the search index.

--- a/docs/ga-ontology/governance_workflow.md
+++ b/docs/ga-ontology/governance_workflow.md
@@ -1,0 +1,9 @@
+# Governance Workflow
+
+Contributors propose ontology changes which curators review and merge.
+
+```
+propose -> review -> approve -> merge -> release
+```
+
+Approved proposals generate signed provenance manifests and trigger semantic versioning.

--- a/docs/ga-ontology/mapping_dsl.md
+++ b/docs/ga-ontology/mapping_dsl.md
@@ -1,0 +1,16 @@
+# Mapping DSL
+
+Mappings connect external schemas to ontology classes and properties.
+
+```
+source:
+  system: "people.csv"
+  entity: "row"
+target:
+  class: "Person"
+rules:
+  - set:
+      property: "Person.name"
+      from: "row.full_name"
+      transforms: [trim, title]
+```

--- a/docs/ga-ontology/ontology_model.md
+++ b/docs/ga-ontology/ontology_model.md
@@ -1,0 +1,13 @@
+# Ontology Model
+
+Base ontology defines core classes and properties:
+
+- **Person** — name, email, employedBy -> Org
+- **Org** — name, industry
+- **Event** — label, occursAt -> Location
+- **Location** — name, geo
+- **Document** — title, author -> Person
+- **Account** — identifier, owner -> Person
+- **Transaction** — amount, currency, from -> Account, to -> Account
+
+Each version is immutable; changes are proposed via governance and released with semantic versioning.

--- a/docs/ga-ontology/operations.md
+++ b/docs/ga-ontology/operations.md
@@ -1,0 +1,5 @@
+# Operations
+
+- `docker-compose up` launches Postgres, Neo4j, Redis, MinIO, gateway, ontology service, and web app.
+- Metrics exposed on `/metrics`; health at `/health`.
+- Logs use structured formats: pino for Node and Python logging for FastAPI.

--- a/docs/ga-ontology/releases_migrations.md
+++ b/docs/ga-ontology/releases_migrations.md
@@ -1,0 +1,7 @@
+# Releases & Migrations
+
+Publishing a release freezes a version and produces a signed manifest. Migration plans compare parent and child versions to suggest semver bumps and data fixes.
+
+```
+POST /release/publish {"ontologyId":1, "versionId":2, "notes":"v1.0.0"}
+```

--- a/docs/ga-ontology/security.md
+++ b/docs/ga-ontology/security.md
@@ -1,0 +1,6 @@
+# Security
+
+- JWT authentication with RS256.
+- RBAC roles: OWNER, ADMIN, CURATOR, CONTRIBUTOR, VIEWER.
+- ABAC policies enforce tenant isolation.
+- Strict CSP and CSRF protection in the web app.

--- a/docs/ga-ontology/semantic_search.md
+++ b/docs/ga-ontology/semantic_search.md
@@ -1,0 +1,9 @@
+# Semantic Search
+
+Search index stores labels, synonyms, and SKOS relations. Queries expand terms to improve recall.
+
+```
+POST /search {"versionId":1, "q":"company", "expand":true}
+```
+
+Results include score and reasons such as matching synonym or broader term.

--- a/docs/ga-ontology/shacl_validation.md
+++ b/docs/ga-ontology/shacl_validation.md
@@ -1,0 +1,11 @@
+# SHACL Validation
+
+Data is validated against SHACL shapes using `pySHACL`.
+
+Example:
+
+```
+POST /validate/shacl {"versionId":1,"target":"postgres","scope":{"table":"people"}}
+```
+
+Results include node and shape violations persisted for audit.

--- a/docs/ga-ontology/skos_vocab_synonyms.md
+++ b/docs/ga-ontology/skos_vocab_synonyms.md
@@ -1,0 +1,12 @@
+# SKOS Vocabularies & Synonyms
+
+SKOS TTL files import controlled vocabularies. Synonyms are extracted into the search index.
+
+Example TTL snippet:
+
+```
+:org a skos:Concept ;
+  skos:prefLabel "Org" ;
+  skos:altLabel "Company", "Corporation" ;
+  skos:broader :entity .
+```


### PR DESCRIPTION
## Summary
- add GA-Ontology documentation skeleton covering architecture, model, governance, validation, mapping, search, releases, API, security, and operations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4fec5b588333a1fc7575873c4fdc