### PR TITLE
feat: add minimal caseops service

### DIFF
--- a/packages/caseops/pyproject.toml
+++ b/packages/caseops/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "caseops"
+version = "0.1.0"
+description = "Minimal CaseOps service"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/caseops/src/caseops/main.py
+++ b/packages/caseops/src/caseops/main.py
@@ -1,0 +1,32 @@
+from uuid import uuid4
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="CaseOps")
+
+
+class Case(BaseModel):
+    id: str
+    title: str
+    description: str | None = None
+
+
+class CreateCaseRequest(BaseModel):
+    title: str
+    description: str | None = None
+
+
+_cases: list[Case] = []
+
+
+@app.post("/case/create", response_model=Case)
+def create_case(req: CreateCaseRequest) -> Case:
+    case = Case(id=str(uuid4()), **req.dict())
+    _cases.append(case)
+    return case
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/packages/caseops/tests/test_caseops.py
+++ b/packages/caseops/tests/test_caseops.py
@@ -1,0 +1,18 @@
+from caseops.main import app
+from fastapi.testclient import TestClient
+
+
+def test_health():
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_create_case():
+    client = TestClient(app)
+    resp = client.post("/case/create", json={"title": "Test Case", "description": "example"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "Test Case"
+    assert "id" in data


### PR DESCRIPTION
## Summary
- scaffold minimal FastAPI CaseOps service with create case and health endpoints
- add tests for service

## Testing
- `ruff check packages/caseops/src packages/caseops/tests`
- `black packages/caseops/src packages/caseops/tests`
- `pytest packages/caseops/tests/test_caseops.py -q`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab54f136ec83339dc299956e508e71