### PR TITLE
feat: add common types package

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -42,6 +42,17 @@ module.exports = {
       testMatch: ['<rootDir>/client/**/*.{test,spec}.{js,jsx,ts,tsx}'],
       testEnvironment: 'jsdom',
       setupFilesAfterEnv: ['<rootDir>/client/src/setupTests.js']
+    },
+    {
+      displayName: 'common-types',
+      testMatch: ['<rootDir>/packages/common-types/**/*.{test,spec}.{js,ts}'],
+      preset: 'ts-jest/presets/default-esm',
+      extensionsToTreatAsEsm: ['.ts'],
+      globals: {
+        'ts-jest': {
+          useESM: true
+        }
+      }
     }
   ]
 };

--- a/packages/common-types/__tests__/subscriber.test.ts
+++ b/packages/common-types/__tests__/subscriber.test.ts
@@ -1,0 +1,7 @@
+import { subscriberSchema } from '../src/index';
+
+describe('subscriberSchema', () => {
+  it('includes required fields', () => {
+    expect(subscriberSchema.required).toEqual(['id', 'msisdn']);
+  });
+});

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@intelgraph/common-types",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "license": "MIT"
+}

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -1,0 +1,20 @@
+export interface Subscriber {
+  id: string;
+  msisdn: string;
+  label?: string;
+  risk?: string;
+}
+
+export const subscriberSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Subscriber',
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    msisdn: { type: 'string' },
+    label: { type: 'string' },
+    risk: { type: 'string' }
+  },
+  required: ['id', 'msisdn'],
+  additionalProperties: false
+} as const;

--- a/packages/common-types/tsconfig.json
+++ b/packages/common-types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true
+  },
+  "include": ["src/**/*", "__tests__/**/*"]
+}


### PR DESCRIPTION
## Summary
- add reusable `@intelgraph/common-types` package with subscriber schema
- configure Jest to run common-types tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: canvas prebuilt binaries missing pixman)*
- `npm test` *(fails: jest not found due to install failure)*
- `npm run format` *(fails: Prettier syntax errors in existing workflows)*

------
https://chatgpt.com/codex/tasks/task_e_68ab574638fc8333bba590584577f0b8