### PR TITLE
feat: add url resolver service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ __pycache__/
 
 .aider*
 .env
+
+# Coverage reports
+.coverage
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ No code merges that break the golden path workflow:
 
 ## Quickstart (Local)
 
+```
+feeds -> normalize -> snapshot -> extract -> analyze -> detect -> export
+```
+
 **Prereqs:** Docker Desktop (6–8 GB memory), Node 18 (optional for host dev), Python 3.10+
 
 ```bash

--- a/docs/url_expand_resolve.md
+++ b/docs/url_expand_resolve.md
@@ -1,0 +1,6 @@
+# URL Expansion & Resolution
+
+This service expands short URLs to their final destination without performing
+external network requests. A small in-memory table defines known shortlink
+redirects. Each call to `POST /resolve/url` traverses the redirect chain and
+returns the expanded URL along with the intermediate hops.

--- a/packages/osint/src/main.py
+++ b/packages/osint/src/main.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="OSINT Service")
+
+# Simple in-memory shortlink map used for offline URL expansion tests.
+SHORTLINKS = {
+    "http://short.local/a": "http://example.com/article",
+    "http://short.local/b": "http://example.com/about",
+}
+
+
+class URLRequest(BaseModel):
+    """Incoming request payload for URL resolution."""
+
+    raw: str
+
+
+class URLResponse(BaseModel):
+    """Response payload containing the expanded URL and redirect chain."""
+
+    expanded: str
+    redirects: list[str]
+
+
+@app.post("/resolve/url", response_model=URLResponse)
+async def resolve_url(req: URLRequest) -> URLResponse:
+    """Expand a raw URL using the in-memory shortlink table."""
+
+    current = req.raw
+    redirects: list[str] = []
+    while current in SHORTLINKS:
+        current = SHORTLINKS[current]
+        redirects.append(current)
+    return URLResponse(expanded=current, redirects=redirects)

--- a/packages/osint/tests/test_resolve.py
+++ b/packages/osint/tests/test_resolve.py
@@ -1,0 +1,17 @@
+import pathlib
+import sys
+
+from fastapi.testclient import TestClient
+
+# Ensure the service src path is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+from main import app  # type: ignore  # noqa: E402
+
+
+def test_resolve_url():
+    client = TestClient(app)
+    resp = client.post('/resolve/url', json={'raw': 'http://short.local/a'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['expanded'] == 'http://example.com/article'
+    assert data['redirects'] == ['http://example.com/article']


### PR DESCRIPTION
## Summary
- add FastAPI URL resolver with in-memory shortlink table
- document URL expansion
- include pipeline diagram in README

## Testing
- `pytest packages/osint/tests/test_resolve.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ef8c6208333b6608c47b2cae608