### PR TITLE
docs: add Sprint 14 task CSV and sourcing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ make up        # Core services only (minimal hardware)
 make smoke
 ```
 
-* Client: [http://localhost:3000](http://localhost:3000)
-* GraphQL: [http://localhost:4000/graphql](http://localhost:4000/graphql)
-* Neo4j Browser: [http://localhost:7474](http://localhost:7474) (neo4j / devpassword)
+- Client: [http://localhost:3000](http://localhost:3000)
+- GraphQL: [http://localhost:4000/graphql](http://localhost:4000/graphql)
+- Neo4j Browser: [http://localhost:7474](http://localhost:7474) (neo4j / devpassword)
 
 ### Optional AI/Kafka Services
 
@@ -94,7 +94,7 @@ cd intelgraph
 - [Security](#-security)
 - [Contributing](#-contributing)
 - [Support](#-support)
-- [Project Management](docs/project_management/README.md)
+- [Project Management](#project-management)
 
 ## ✨ Features
 
@@ -449,7 +449,7 @@ make bootstrap && make up
 # With AI capabilities
 make up-ai
 
-# With Kafka streaming  
+# With Kafka streaming
 make up-kafka
 
 # Full deployment (AI + Kafka)
@@ -884,6 +884,10 @@ Use the [Feature Request template](https://github.com/BrianCLong/intelgraph/issu
 - Use case and business value
 - Proposed implementation approach
 - Alternative solutions considered
+
+## Project Management
+
+Sprint planning artifacts and issue import CSVs live in the `project_management/` directory. For Sprint 14, import `project_management/sprint14_issues.csv` into Jira or Linear to seed the board. See [docs/project_management/README.md](docs/project_management/README.md) for detailed workflow.
 
 ---
 

--- a/project_management/sprint14_issues.csv
+++ b/project_management/sprint14_issues.csv
@@ -1,0 +1,30 @@
+Issue Type,Summary,Description,Priority,Labels,Story Points,Components,Epic Name,Epic Link,Sprint,Due Date
+Epic,IG Sprint 14 Vertical,"Prov-ledger beta, ABAC/OPA, tri-pane skeleton, NL→Cypher sandbox, SLO+Cost Guard",Highest,"sprint-14,vertical",,"Graph;Web;Security;Prov-Ledger;SRE;QA",IG Sprint 14 Vertical,,,2025-09-12
+Story,S1: Register Evidence & Export Verifiable Bundle,"Export bundle with manifest (hash tree) + signature; external Verifier CLI validates.",High,"sprint-14,prov-ledger,export",13,"Prov-Ledger;Web;QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-05
+Task,S1-T1: Evidence Register API,"POST /evidence/register → checksum, license, transforms; Postgres schema+migration.",Medium,"prov-ledger,api",5,"Prov-Ledger",,IG Sprint 14 Vertical,Sprint 14,2025-09-01
+Task,S1-T2: Manifest Builder & Signer,"Build Merkle tree manifest; sign with KMS; attach to bundle.",Medium,"prov-ledger,crypto",5,"Prov-Ledger",,IG Sprint 14 Vertical,Sprint 14,2025-09-03
+Task,S1-T3: Bundle Packager + S3 Client,"Stream ZIP; content-addressed paths; upload to S3-compatible store.",Medium,"prov-ledger,storage",3,"Prov-Ledger",,IG Sprint 14 Vertical,Sprint 14,2025-09-04
+Task,S1-T4: Verifier CLI,"Python tool `verifier verify bundle.zip` with SHA-256 checks.",Medium,"cli,qa",3,"QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-05
+Story,S2: Claim Graph & Contradictions,"Claim nodes; supports/contradicts edges; UI pane.",Medium,"graph,claims,ui",8,"Graph;Web;QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-06
+Task,S2-T1: Schema + Migrations,"Create Claim node, edges, indexes.",Medium,"graph,cypher",3,"Graph",,IG Sprint 14 Vertical,Sprint 14,2025-09-02
+Task,S2-T2: Ingest Mapper,"Derive claims from evidence fields; link sources.",Medium,"ingest,graph",3,"Graph",,IG Sprint 14 Vertical,Sprint 14,2025-09-04
+Task,S2-T3: UI Claim Pane,"List claims, provenance badges, conflict chips.",Medium,"web,ui",2,"Web",,IG Sprint 14 Vertical,Sprint 14,2025-09-06
+Story,S3: ABAC/OPA Field-Level Authz,"OPA sidecar; persisted queries; field elision; audit.",High,"security,opa,authz",8,"Security;Gateway;QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-09
+Task,S3-T1: OPA Sidecar + Bundles,"Wire Rego policies; GitOps policy bundles.",Medium,"security,opa",3,"Security",,IG Sprint 14 Vertical,Sprint 14,2025-09-03
+Task,S3-T2: Field-Level Elision,"Gateway evaluates policy→ hides restricted fields.",Medium,"gateway,security",3,"Security;Gateway",,IG Sprint 14 Vertical,Sprint 14,2025-09-06
+Task,S3-T3: Audit Events,"Immutable append-only audit stream.",Medium,"audit,security",2,"Security",,IG Sprint 14 Vertical,Sprint 14,2025-09-09
+Story,S4: Reason-for-Access Prompt,"User justification modal; persist to audit.",Medium,"security,ux",5,"Web;Security;QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-08
+Task,S4-T1: Modal + Flow,"Prompt on sensitive queries; cancel/continue.",Medium,"web,ux",2,"Web",,IG Sprint 14 Vertical,Sprint 14,2025-09-07
+Task,S4-T2: Audit Write,"Attach reason to audit log entries.",Medium,"security,audit",2,"Security",,IG Sprint 14 Vertical,Sprint 14,2025-09-08
+Story,S5: NL→Cypher Sandbox,"LLM-generated Cypher preview; run in sandbox DB; cost/row estimate.",High,"nlp,cypher,sandbox",13,"Graph;Web;Gateway;QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-11
+Task,S5-T1: UI Prompt→Preview,"Text input → generated Cypher + cost.",Medium,"web,nlp",3,"Web",,IG Sprint 14 Vertical,Sprint 14,2025-09-08
+Task,S5-T2: Sandbox Executor,"Ephemeral Neo4j per run; TTL; results labeled ephemeral.",Medium,"graph,sandbox",5,"Graph",,IG Sprint 14 Vertical,Sprint 14,2025-09-10
+Task,S5-T3: Cost Estimator,"Explain plan parse; budget preview.",Medium,"gateway,perf",3,"Gateway",,IG Sprint 14 Vertical,Sprint 14,2025-09-10
+Story,S6: Tri‑Pane Skeleton & Provenance Tooltip,"Graph/Map/Timeline sync; provenance hover tooltip; brushing.",Medium,"web,graph,ux",8,"Web;Graph;QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-10
+Task,S6-T1: Shell + Layout,"3-pane layout; resizable; hotkeys.",Medium,"web,layout",3,"Web",,IG Sprint 14 Vertical,Sprint 14,2025-09-02
+Task,S6-T2: Brushing Sync,"Timeline brush filters map/graph.",Medium,"web,events",3,"Web;Graph",,IG Sprint 14 Vertical,Sprint 14,2025-09-06
+Task,S6-T3: Provenance Tooltip,"Source, license, confidence, last transform.",Medium,"web,ui",2,"Web",,IG Sprint 14 Vertical,Sprint 14,2025-09-09
+Story,S7: SLO Dashboard & Cost Guard,"Prometheus/OTEL p95/p99; slow-query killer; alerts.",High,"sre,observability,cost",8,"SRE;Gateway;QA",,IG Sprint 14 Vertical,Sprint 14,2025-09-12
+Task,S7-T1: OTEL + Prom Dash,"Traces + panels; latency heatmap.",Medium,"observability",3,"SRE",,IG Sprint 14 Vertical,Sprint 14,2025-09-09
+Task,S7-T2: Query Killer,"Budget-based cancel + user hint.",Medium,"gateway,perf",3,"Gateway",,IG Sprint 14 Vertical,Sprint 14,2025-09-11
+Task,S7-T3: Alerts,"SLO burn → Slack; denials spike.",Medium,"alerts,sre",2,"SRE",,IG Sprint 14 Vertical,Sprint 14,2025-09-12


### PR DESCRIPTION
## Summary
- add Sprint 14 issue/task CSV for import into Jira/Linear
- document where to source sprint tasks in project management section of README

## Testing
- `npx prettier -w README.md`
- `npm test` *(fails: jest not found)*
- `npx eslint README.md` *(fails: Cannot find module 'ajv/lib/refs/json-schema-draft-04.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b0d4905b748333aa7eb6d74f54fa39