### PR TITLE
Absorb orphan: codex/implement-v1-graphql-typedefs-and-resolvers

### DIFF
--- a/apps/web/src/generated/graphql-types.ts
+++ b/apps/web/src/generated/graphql-types.ts
@@ -1,0 +1,31 @@
+/* This file is auto-generated via GraphQL codegen */
+export type Entity = {
+  id: string;
+  type: string;
+  value: string;
+  confidence?: number | null;
+  source?: string | null;
+  firstSeen?: string | null;
+  lastSeen?: string | null;
+  properties?: any | null;
+  metadata?: any | null;
+};
+
+export type Relationship = {
+  id: string;
+  source: string;
+  target: string;
+  type: string;
+  label?: string | null;
+  confidence?: number | null;
+  properties?: any | null;
+};
+
+export type Query = {
+  entities: Entity[];
+  relationships: Relationship[];
+};
+
+export type Mutation = {
+  upsertEntity: Entity;
+};

--- a/server/codegen.yml
+++ b/server/codegen.yml
@@ -1,13 +1,13 @@
 overwrite: true
-schema: "./src/graphql/schema-unified.ts"
+schema: './src/graphql/schema-unified.ts'
 generates:
   src/generated/graphql-types.ts:
     plugins:
-      - "typescript"
-      - "typescript-resolvers"
+      - 'typescript'
+      - 'typescript-resolvers'
     config:
       useIndexSignature: true
-      contextType: "../types/context#GraphQLContext"
+      contextType: '../types/context#GraphQLContext'
       scalars:
         DateTime: Date
         JSON: any
@@ -15,7 +15,11 @@ generates:
 
   src/generated/introspection.json:
     plugins:
-      - "introspection"
+      - 'introspection'
+
+  ../apps/web/src/generated/graphql-types.ts:
+    plugins:
+      - 'typescript'
 
 hooks:
   afterAllFileWrite:

--- a/server/src/graphql/modules/core/resolvers.ts
+++ b/server/src/graphql/modules/core/resolvers.ts
@@ -1,0 +1,19 @@
+import type { GraphStore, AIService } from '../services-types';
+import { createGraphStore } from './services/graph-store';
+import { createAIService } from './services/ai';
+
+const store: GraphStore = createGraphStore();
+const ai: AIService = createAIService();
+
+export const Query = {
+  entities: (_: unknown, { filters }: { filters: any }) => store.getEntities(filters || {}),
+  relationships: (_: unknown, { entityId }: { entityId: string }) =>
+    store.getRelationships(entityId),
+};
+
+export const Mutation = {
+  upsertEntity: async (_: unknown, { input }: { input: any }) => {
+    const enriched = await ai.enrichEntity(input);
+    return store.upsertEntity(enriched);
+  },
+};

--- a/server/src/graphql/modules/core/services/ai.ts
+++ b/server/src/graphql/modules/core/services/ai.ts
@@ -1,0 +1,9 @@
+import type { AIService } from '../../services-types';
+
+export function createAIService(): AIService {
+  return {
+    async enrichEntity(input) {
+      return { ...input };
+    },
+  };
+}

--- a/server/src/graphql/modules/core/services/graph-store.ts
+++ b/server/src/graphql/modules/core/services/graph-store.ts
@@ -1,0 +1,27 @@
+import type { GraphStore } from '../../services-types';
+
+export function createGraphStore(): GraphStore {
+  const entities: any[] = [];
+  const relationships: any[] = [];
+
+  return {
+    async getEntities(filters) {
+      const { limit } = filters || {};
+      return typeof limit === 'number' ? entities.slice(0, limit) : entities;
+    },
+    async getRelationships(entityId: string) {
+      return relationships.filter((r) => r.source === entityId || r.target === entityId);
+    },
+    async upsertEntity(input) {
+      const index = entities.findIndex((e) => e.id === input.id);
+      if (index >= 0) {
+        entities[index] = { ...entities[index], ...input };
+        return entities[index];
+      }
+      const id = input.id || String(entities.length + 1);
+      const entity = { id, ...input };
+      entities.push(entity);
+      return entity;
+    },
+  };
+}

--- a/server/src/graphql/modules/core/typeDefs.ts
+++ b/server/src/graphql/modules/core/typeDefs.ts
@@ -1,0 +1,50 @@
+import { gql } from 'graphql-tag';
+
+export default gql`
+  scalar JSON
+
+  type Entity {
+    id: ID!
+    type: String!
+    value: String!
+    confidence: Float
+    source: String
+    firstSeen: String
+    lastSeen: String
+    properties: JSON
+    metadata: JSON
+  }
+
+  type Relationship {
+    id: ID!
+    source: ID!
+    target: ID!
+    type: String!
+    label: String
+    confidence: Float
+    properties: JSON
+  }
+
+  input EntityFilters {
+    type: String
+    q: String
+    limit: Int
+  }
+
+  type Query {
+    entities(filters: EntityFilters): [Entity!]!
+    relationships(entityId: ID!): [Relationship!]!
+  }
+
+  input UpsertEntityInput {
+    id: ID
+    type: String!
+    value: String!
+    confidence: Float
+    properties: JSON
+  }
+
+  type Mutation {
+    upsertEntity(input: UpsertEntityInput!): Entity!
+  }
+`;

--- a/server/src/graphql/modules/security/directives.ts
+++ b/server/src/graphql/modules/security/directives.ts
@@ -1,0 +1,20 @@
+import { defaultFieldResolver, GraphQLSchema } from 'graphql';
+import { getDirective, mapSchema, MapperKind } from '@graphql-tools/utils';
+
+export const authDirectiveTypeDefs = `directive @authz on FIELD_DEFINITION`;
+
+export function authDirectiveTransformer(schema: GraphQLSchema): GraphQLSchema {
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
+      const authz = getDirective(schema, fieldConfig, 'authz');
+      if (authz) {
+        const { resolve = defaultFieldResolver } = fieldConfig;
+        fieldConfig.resolve = async function (source, args, context, info) {
+          // Authorization logic handled by Team 6
+          return resolve.call(this, source, args, context, info);
+        };
+        return fieldConfig;
+      }
+    },
+  });
+}

--- a/server/src/graphql/modules/services-types.ts
+++ b/server/src/graphql/modules/services-types.ts
@@ -1,0 +1,9 @@
+export interface GraphStore {
+  getEntities(filters: Record<string, any>): Promise<any[]>;
+  getRelationships(entityId: string): Promise<any[]>;
+  upsertEntity(input: Record<string, any>): Promise<any>;
+}
+
+export interface AIService {
+  enrichEntity(input: Record<string, any>): Promise<Record<string, any>>;
+}


### PR DESCRIPTION
Automated absorption PR to merge all functionality from 
codex/implement-v1-graphql-typedefs-and-resolvers
 into 
main.

Commits ahead of main: 1