### PR TITLE
feat: add OSINT threat actor profiling agent

### DIFF
--- a/python/osint_threat_actor_agent.py
+++ b/python/osint_threat_actor_agent.py
@@ -1,0 +1,124 @@
+import asyncio
+import logging
+import os
+from typing import Any, Dict
+
+import aiohttp
+from dotenv import load_dotenv
+
+from enrichment_service.enrichment_service import Neo4jGraph
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
+class OSINTDataFetcher:
+    """Collects OSINT information from various external services."""
+
+    async def fetch_shodan(self, ip: str) -> Dict[str, Any]:
+        api_key = os.getenv("SHODAN_API_KEY")
+        if not api_key:
+            return {}
+        url = f"https://api.shodan.io/shodan/host/{ip}?key={api_key}"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                if response.status == 200:
+                    return await response.json()
+                return {}
+
+    async def fetch_virustotal(self, ip: str) -> Dict[str, Any]:
+        api_key = os.getenv("VT_API_KEY")
+        if not api_key:
+            return {}
+        headers = {"x-apikey": api_key}
+        url = f"https://www.virustotal.com/api/v3/ip_addresses/{ip}"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                if response.status == 200:
+                    return await response.json()
+                return {}
+
+    async def fetch_abuseipdb(self, ip: str) -> Dict[str, Any]:
+        api_key = os.getenv("ABUSEIPDB_API_KEY")
+        if not api_key:
+            return {}
+        headers = {"Key": api_key, "Accept": "application/json"}
+        url = f"https://api.abuseipdb.com/api/v2/check?ipAddress={ip}&maxAgeInDays=90"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers) as response:
+                if response.status == 200:
+                    return await response.json()
+                return {}
+
+    async def gather(self, ip: str) -> Dict[str, Any]:
+        """Fetches OSINT data from all sources for a given IP."""
+        results = await asyncio.gather(
+            self.fetch_shodan(ip),
+            self.fetch_virustotal(ip),
+            self.fetch_abuseipdb(ip),
+            return_exceptions=True,
+        )
+        combined: Dict[str, Any] = {}
+        sources = ["shodan", "virustotal", "abuseipdb"]
+        for source, result in zip(sources, results):
+            if isinstance(result, dict) and result:
+                combined[source] = result
+        return combined
+
+
+class ThreatActorProfilingAgent:
+    """Enriches the graph with OSINT data about threat actors."""
+
+    def __init__(self, graph: Neo4jGraph, fetcher: OSINTDataFetcher | None = None) -> None:
+        self.graph = graph
+        self.fetcher = fetcher or OSINTDataFetcher()
+
+    async def enrich_ip(self, ip: str, actor_name: str) -> None:
+        data = await self.fetcher.gather(ip)
+        if not data:
+            logging.info("No OSINT data retrieved for %s", ip)
+            return
+        if not self.graph.driver:
+            logging.error("Neo4j driver is not connected.")
+            return
+        query = (
+            "MERGE (i:IP {address: $ip}) "
+            "MERGE (a:ThreatActor {name: $actor_name}) "
+            "MERGE (a)-[:USES]->(i) "
+            "SET i.last_seen = datetime(), i.osint = $data"
+        )
+        with self.graph.driver.session() as session:
+            session.run(query, ip=ip, actor_name=actor_name, data=data)
+            logging.info("Enriched IP %s for actor %s", ip, actor_name)
+
+
+async def periodic_enrich(
+    agent: ThreatActorProfilingAgent,
+    ip: str,
+    actor: str,
+    interval_seconds: int = 3600,
+) -> None:
+    """Periodically enriches an IP with OSINT data."""
+    while True:
+        await agent.enrich_ip(ip, actor)
+        await asyncio.sleep(interval_seconds)
+
+
+async def main() -> None:
+    load_dotenv()
+    uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = os.getenv("NEO4J_USER", "neo4j")
+    password = os.getenv("NEO4J_PASSWORD", "password")
+
+    graph = Neo4jGraph(uri, user, password)
+    graph.connect()
+
+    try:
+        agent = ThreatActorProfilingAgent(graph)
+        await periodic_enrich(agent, "8.8.8.8", "ExampleActor")
+    finally:
+        graph.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/python/tests/test_osint_profiling_agent.py
+++ b/python/tests/test_osint_profiling_agent.py
@@ -1,0 +1,26 @@
+import pytest
+
+from osint_threat_actor_agent import OSINTDataFetcher
+
+
+@pytest.mark.asyncio
+async def test_gather_combines_sources(monkeypatch):
+    fetcher = OSINTDataFetcher()
+
+    async def fake_shodan(ip: str):
+        return {"shodan": True}
+
+    async def fake_vt(ip: str):
+        return {"vt": True}
+
+    async def fake_abuse(ip: str):
+        return {}
+
+    monkeypatch.setattr(fetcher, "fetch_shodan", fake_shodan)
+    monkeypatch.setattr(fetcher, "fetch_virustotal", fake_vt)
+    monkeypatch.setattr(fetcher, "fetch_abuseipdb", fake_abuse)
+
+    data = await fetcher.gather("1.2.3.4")
+    assert "shodan" in data
+    assert "virustotal" in data
+    assert "abuseipdb" not in data


### PR DESCRIPTION
## Summary
- add OSINT data fetcher and threat actor profiling agent to enrich Neo4j with Shodan, VirusTotal, and AbuseIPDB intelligence
- schedule periodic enrichment for threat actor IP associations
- cover data aggregation with unit test

## Testing
- `npm run lint` *(fails: sh: 1: eslint: not found)*
- `npm run format` *(fails: sh: 1: prettier: not found)*
- `cd python && pytest tests/test_osint_profiling_agent.py` *(fails: /workspace/intelgraph/python/pyproject.toml: 'minversion' requires pytest-8.0, actual pytest-7.4.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b1235591d883338c31b2d14df004ba