### PR TITLE
docs: deepen adversarial threat simulation sandbox

### DIFF
--- a/docs/ADVERSARIAL_LLM_THREAT_SIMULATION_SANDBOX.md
+++ b/docs/ADVERSARIAL_LLM_THREAT_SIMULATION_SANDBOX.md
@@ -1,0 +1,122 @@
+# Adversarial LLM Threat Simulation Sandbox
+
+## Objective
+
+Provide a controlled environment where security teams can safely explore how adversaries might leverage large language models. The sandbox lets defenders rehearse detection, response, and governance workflows without risking real systems.
+
+## Capabilities
+
+### Phishing & Social Engineering
+
+- Generate multilingual phishing templates with realistic branding and voice cloning for attachments.
+- Model victim personas and adapt tone, urgency, and cultural references to increase believability.
+- Inject context from synthetic or anonymized data to craft highly targeted spear‑phishing campaigns.
+- Schedule iterative campaigns to test awareness training and mail‑gateway resilience.
+
+### Exploit Development & Obfuscation
+
+- Produce proof‑of‑concept exploit scaffolding and payload droppers with configurable obfuscation layers.
+- Experiment with code mutation, virtualization, and polymorphic packing to stress static and dynamic analysis tools.
+- Simulate vulnerability discovery workflows, including patch diffing and exploit prototype generation.
+- Track defensive signatures to evaluate coverage against evolving attack tooling.
+
+### Influence & Disinformation Operations
+
+- Coordinate multi‑agent chat narratives across social platforms and forums.
+- Pivot messaging strategies in real time to counter fact‑checking or moderation interventions.
+- Analyze amplification patterns, bot‑net behavior, and narrative propagation through synthetic social graphs.
+- Inject counter‑narratives to train detection of subtle framing or emotional manipulation.
+
+### Supply Chain & Lateral Movement Scenarios
+
+- Model compromise of third‑party libraries, update channels, or CI/CD pipelines leading to downstream infections.
+- Rehearse multi‑stage kill chains spanning initial access, privilege escalation, persistence, and exfiltration.
+- Include cloud and on‑prem components with role‑based access simulation and secret rotation checks.
+
+### Data Poisoning & Model Evasion
+
+- Generate adversarial training data or prompt‑injection patterns to test model hardening techniques.
+- Create evasive queries targeting content filters, jailbreak detectors, or policy classifiers.
+- Simulate slow‑roll poisoning campaigns and measure model drift over time.
+
+### Defensive Countermeasures
+
+- Run blue‑team response drills using auto‑generated playbooks and kill‑switch triggers.
+- Feed telemetry into SIEM/SOAR pipelines for automated triage and containment.
+- Benchmark detection efficacy, time‑to‑response, and analyst workload.
+
+## Architecture
+
+- **Red‑Team LLMs with Safety Governors** – Configurable guardrails, rate limits, and prompt auditing.
+- **Scenario Orchestrator** – Builds multi‑stage campaigns, tracks state, and replays scenarios deterministically.
+- **Sandboxed Execution Pods** – Isolated containers capturing system calls, network traffic, and model outputs.
+- **Telemetry & Analytics Pipeline** – Normalizes events, computes metrics, and exposes dashboards.
+- **Integration Connectors** – Hooks into email gateways, ticketing systems, chat platforms, and endpoint agents.
+
+## Operational Safeguards
+
+- Synthetic or anonymized datasets only; no production credentials or live endpoints.
+- Role‑based access control with mandatory logging and periodic review.
+- Automatic kill‑switch for outputs breaching policy thresholds.
+- Clear labeling of all content as simulated to prevent weaponization.
+
+## Metrics & Reporting
+
+- Coverage of the MITRE ATT&CK kill chain stages.
+- Detection precision/recall for each simulated scenario.
+- Time‑to‑detect and time‑to‑respond benchmarks.
+- Executive summary reports with scenario severity and remediation notes.
+
+## Integration & Extensibility
+
+- REST and message‑queue APIs for custom scenario ingestion or telemetry export.
+- Plugin architecture enabling additional LLMs, data sources, or defensive tools.
+- Scripting hooks for CI pipelines to run regression scenarios on model or rule changes.
+
+## User Roles & Workflow
+
+- **Red‑Team Operators** – design and launch adversarial scenarios, tune model parameters, and submit threat hypotheses.
+- **Blue‑Team Analysts** – monitor telemetry, validate alerts, and feed findings back into detection logic.
+- **Scenario Review Board** – approves high‑risk simulations and oversees after‑action reporting.
+- **System Administrators** – maintain infrastructure, enforce policy controls, and manage model updates.
+
+### Scenario Lifecycle
+
+1. **Design** – operators compose or import templates defining entry points, goals, and guardrails.
+2. **Approval** – review board vets scenarios for legality, ethics, and resource impact.
+3. **Execution** – orchestrator schedules campaigns in isolated pods while streaming telemetry.
+4. **Analysis** – dashboards visualize outcomes and annotate detection gaps.
+5. **Remediation** – teams update rules, signatures, or playbooks before archiving the run.
+
+## Model Management & Auditability
+
+- Central registry tracks model versions, training data lineage, and risk scores.
+- Prompt/response pairs are hashed and stored for reproducible experiments.
+- Differential tests compare outputs across models to surface drift or regression.
+- Opt‑in human feedback loops refine safety governors over time.
+
+## Deployment & Scalability
+
+- Helm charts and Terraform modules provision sandbox clusters across cloud or on‑prem environments.
+- Pod‑level resource quotas prevent runaway compute usage.
+- Horizontal autoscaling reacts to queued scenarios or peak exercises.
+- Cost dashboards estimate per‑scenario expenditure for budgeting.
+
+## Roadmap & Future Enhancements
+
+- Multi‑tenant support to allow cross‑team exercises with strict data partitions.
+- Integration with threat‑intelligence feeds to auto‑generate emerging attack scenarios.
+- Federated learning hooks to share defensive improvements without exposing raw data.
+- Gamified training modules that pit human analysts against adaptive LLM adversaries.
+
+## Governance & Continuous Improvement
+
+- Documented policies for approved use, audit trails, and data retention.
+- Regular update cycles informed by threat‑intelligence feeds and post‑exercise reviews.
+- Training modules for analysts and developers to stay current on adversarial ML trends.
+
+## Value Proposition
+
+- **Proactive Defense** – Identify gaps before real adversaries exploit them.
+- **Training & Awareness** – Strengthen staff preparedness against AI‑enabled attacks.
+- **Governance Insight** – Clarify the policy and technical controls needed for safe LLM deployment.

--- a/docs/project_management/epics/Real-Time_Threat_Simulation_&_'What-If'_Analysis.md
+++ b/docs/project_management/epics/Real-Time_Threat_Simulation_&_'What-If'_Analysis.md
@@ -2,6 +2,17 @@
 
 Milestone: MVP1-Simulation
 
+Introduces the Adversarial LLM Threat Simulation Sandbox, enabling controlled exploration of AI-enabled attack chains. The sandbox orchestrates phishing, exploit development, influence operations, and supply-chain scenarios while enforcing safety governors and exhaustive logging. See [Adversarial LLM Threat Simulation Sandbox](../../ADVERSARIAL_LLM_THREAT_SIMULATION_SANDBOX.md) for the full capabilities and architecture.
+
 ## Child Issues
+
 - [ ] Simulation Scenario Builder
 - [ ] Simulation Engine Backend
+- [ ] Telemetry and Metrics Pipeline
+- [ ] Safety Governor and Policy Framework
+- [ ] Integration Connectors (email, SIEM, chat)
+- [ ] User Role & Access Control Service
+- [ ] Model Registry and Audit Trail
+- [ ] Scenario Scheduler & Versioning
+- [ ] Analyst Dashboard & Reporting
+- [ ] Post-exercise Review and Knowledge Base


### PR DESCRIPTION
## Summary
- add user roles, model auditing, deployment guidance, and roadmap details to the adversarial LLM threat simulation sandbox guide
- expand Real-Time Threat Simulation epic with governance, scheduling, and reporting child issues

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx prettier -w docs/ADVERSARIAL_LLM_THREAT_SIMULATION_SANDBOX.md docs/project_management/epics/Real-Time_Threat_Simulation_&_'What-If'_Analysis.md`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b128e0c0a88333915c6882380611b2