### PR TITLE
feat: add red-blue simulation skeleton

### DIFF
--- a/active-measures-module/src/ai/red-blue-simulation.ts
+++ b/active-measures-module/src/ai/red-blue-simulation.ts
@@ -1,0 +1,67 @@
+/**
+ * Red-Blue Adversarial Simulation Engine
+ *
+ * Provides a simple framework for modelling attacker (Red Team) actions
+ * and defensive (Blue Team) controls.  Each simulation run calculates basic
+ * effectiveness metrics that can be used by higher level orchestration or
+ * visualization layers.
+ */
+
+export interface RedAction {
+  id: string;
+  tactic: string; // MITRE ATT&CK tactic identifier
+  timestamp: number; // epoch milliseconds
+  success: boolean;
+}
+
+export interface BlueControl {
+  id: string;
+  name: string;
+  detects: string[]; // array of tactic identifiers this control can detect
+  effectiveness: number; // 0-1 scale probability of detection
+}
+
+export interface SimulationScorecard {
+  timeToDetect: number; // milliseconds from first action to detection, -1 if undetected
+  lateralSpread: number; // count of successful actions before detection
+  containmentTime: number; // naive metric: detection time + 1 for now
+}
+
+/**
+ * Execute a simple red/blue simulation.
+ *
+ * @param actions list of red team actions ordered by timestamp
+ * @param controls list of defensive controls
+ */
+export function runRedBlueSimulation(
+  actions: RedAction[],
+  controls: BlueControl[],
+): SimulationScorecard {
+  if (actions.length === 0) {
+    return { timeToDetect: -1, lateralSpread: 0, containmentTime: -1 };
+  }
+
+  const start = actions[0].timestamp;
+  let detectedAt = -1;
+  let spread = 0;
+
+  for (const action of actions) {
+    if (!action.success) continue;
+    if (detectedAt === -1) {
+      spread += 1;
+      const triggered = controls.some((c) => {
+        if (!c.detects.includes(action.tactic)) return false;
+        return Math.random() < c.effectiveness;
+      });
+      if (triggered) {
+        detectedAt = action.timestamp;
+      }
+    }
+  }
+
+  return {
+    timeToDetect: detectedAt === -1 ? -1 : detectedAt - start,
+    lateralSpread: detectedAt === -1 ? spread : spread - 1,
+    containmentTime: detectedAt === -1 ? -1 : detectedAt - start + 1,
+  };
+}

--- a/active-measures-module/tests/red-blue-simulation.test.ts
+++ b/active-measures-module/tests/red-blue-simulation.test.ts
@@ -1,0 +1,18 @@
+import { runRedBlueSimulation, RedAction, BlueControl } from '../src/ai/red-blue-simulation';
+
+describe('runRedBlueSimulation', () => {
+  test('detects attack when control covers tactic', () => {
+    const actions: RedAction[] = [
+      { id: 'a1', tactic: 'initial-access', timestamp: 0, success: true },
+      { id: 'a2', tactic: 'execution', timestamp: 10, success: true },
+    ];
+    const controls: BlueControl[] = [
+      { id: 'c1', name: 'edr', detects: ['execution'], effectiveness: 1 },
+    ];
+
+    const result = runRedBlueSimulation(actions, controls);
+    expect(result.timeToDetect).toBe(10);
+    expect(result.lateralSpread).toBe(1);
+    expect(result.containmentTime).toBe(11);
+  });
+});

--- a/docs/red-blue-simulation-mode.md
+++ b/docs/red-blue-simulation-mode.md
@@ -1,0 +1,26 @@
+# Red-Blue Adversarial Simulation Mode
+
+The Red-Blue Adversarial Simulation Mode allows analysts to model attacker behaviour and defensive controls within the IntelGraph ecosystem. It transforms static intelligence into an interactive cyber wargaming environment.
+
+## Capabilities
+
+- **Red Team Agents**
+  - Represent adversary actions mapped to MITRE ATT&CK tactics.
+  - Configurable sequences for initial access, lateral movement, and escalation.
+  - Actions are recorded with timestamps for replay and analysis.
+- **Blue Team Controls**
+  - Nodes for SIEM, EDR, honeypots, and other detection mechanisms.
+  - Coverage metadata defines which tactics each control can detect.
+  - Effectiveness can be toggled to simulate blind spots or failures.
+- **Scorecard Metrics**
+  - _Time to Detect_ – elapsed time between attack start and first detection.
+  - _Lateral Spread_ – number of successful attacker actions prior to detection.
+  - _Containment_ – simple estimate of response time once detection occurs.
+- **Interactive Canvas**
+  - Visualization layer can step through simulations or play them in real time.
+  - Analysts can adjust both attacker tactics and defensive posture on the fly.
+
+## Implementation Notes
+
+This repository now includes a lightweight simulation engine in
+`active-measures-module/src/ai/red-blue-simulation.ts` which calculates basic scorecard metrics. The implementation is framework agnostic and can be extended with richer agent behaviours or integrated with frontend visualizations in subsequent iterations.


### PR DESCRIPTION
## Summary
- establish basic red/blue adversarial simulation engine
- document red-blue simulation mode and metrics
- add unit test covering detection and scorecard logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Prettier YAML syntax error in .github/workflows/cd-deploy.yml)*
- `npm test` *(fails: jest not found)*
- `cd active-measures-module && npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1239c8c5483338359fee14c5b12f2